### PR TITLE
Add build script for Microsoft Visual Studio

### DIFF
--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -1,0 +1,32 @@
+@echo OFF
+
+REM Determine if this batch file was launched by double-clicking it from Explorer.
+REM If it was, we will pause before exiting so the user can read the output.
+set explorer_launched=0
+for %%x in (%cmdcmdline%) do if /i "%%~x"=="/c" set explorer_launched=1
+
+REM Make sure the Visual Studio compiler is present
+where cl.exe > nul 2> nul
+if %errorlevel% neq 0 (
+    echo Unable to find `cl.exe`, the Visual Studio compiler.
+    echo Please make sure Visual Studio is installed and in your PATH environment variable.
+    echo if Visual Studio is installed, you may have to launch "x64 Native Tools Command Prompt for VS".
+    if "%explorer_launched%" == "1" pause
+    exit /b 1
+)
+
+REM  Make sure that the x64 compiler is selected by looking for "for x86" in cl.exe's statement of its version.
+for /f "delims=" %%a in ('cl.exe 2^>^&1') do (
+    setlocal enabledelayedexpansion
+    set "line=%%a"
+    if "!line!" neq "!line:for x86=!" (
+        echo The 32-bit Visual Studio tools are active, but Stable Diffusion cannot allocate enough memory in 32-bit mode.
+        echo Please make sure the Visual Studio tools targeting x64 are active.
+        echo You may have to launch "x64 Native Tools Command Prompt for VS".
+        if "%explorer_launched%" == "1" pause
+        exit /b 1
+    )
+    endlocal
+)
+
+cl.exe /fp:fast /Ox /EHsc /I. /I ggml\include\ggml /I ggml\include main.cpp stable-diffusion.cpp ggml\src\ggml.c /link /out:sd.exe

--- a/build_msvc.bat
+++ b/build_msvc.bat
@@ -29,4 +29,4 @@ for /f "delims=" %%a in ('cl.exe 2^>^&1') do (
     endlocal
 )
 
-cl.exe /fp:fast /Ox /EHsc /I. /I ggml\include\ggml /I ggml\include main.cpp stable-diffusion.cpp ggml\src\ggml.c /link /out:sd.exe
+cl.exe /fp:fast /Ox /EHsc /arch:AVX2 /GL /I. /I ggml\include\ggml /I ggml\include main.cpp stable-diffusion.cpp ggml\src\ggml.c /link /out:sd.exe


### PR DESCRIPTION
For Windows users, this batch file builds sd.exe using Visual Studio's `cl.exe`. Most of the file is dedicated to checking the environment and reporting errors nicely. Specifically, it will explain what to do if `cl.exe` is missing or for the wrong architecture.