### PR TITLE
Fix Regex for macOS/Clang support

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -397,7 +397,7 @@ std::vector<std::pair<std::string, float>> parse_prompt_attention(const std::str
     float round_bracket_multiplier = 1.1f;
     float square_bracket_multiplier = 1 / 1.1f;
 
-    std::regex re_attention(R"(\\\(|\\\)|\\\[|\\]|\\\\|\\|\(|\[|:([+-]?[.\d]+)\)|\)|]|[^\\()\[\]:]+|:)");
+    std::regex re_attention(R"(\\\(|\\\)|\\\[|\\\]|\\\\|\\|\(|\[|:([-+]?[.\d]+)|\)|\]|[^\\()\[\]:]+|:)");
     std::regex re_break(R"(\s*\bBREAK\b\s*)");
 
     auto multiply_range = [&](int start_position, float multiplier) {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -397,7 +397,7 @@ std::vector<std::pair<std::string, float>> parse_prompt_attention(const std::str
     float round_bracket_multiplier = 1.1f;
     float square_bracket_multiplier = 1 / 1.1f;
 
-    std::regex re_attention(R"(\\\(|\\\)|\\\[|\\\]|\\\\|\\|\(|\[|:([-+]?[.\d]+)|\)|\]|[^\\()\[\]:]+|:)");
+    std::regex re_attention(R"(\\\(|\\\)|\\\[|\\\]|\\\\|\\|\(|\[|:([+-]?[.\d]+)\)|\)|\]|[^\\()\[\]:]+|:)");
     std::regex re_break(R"(\s*\bBREAK\b\s*)");
 
     auto multiply_range = [&](int start_position, float multiplier) {


### PR DESCRIPTION
When running on macOS, I was hitting an exception with std:regex

```
[INFO]  stable-diffusion.cpp:2687 - loading model from '../models/sd-v1-4-ggml-model-f16.bin'
[INFO]  stable-diffusion.cpp:2712 - ftype: f16
[INFO]  stable-diffusion.cpp:2941 - total params size = 1969.97MB (clip 235.01MB, unet 1640.45MB, vae 94.51MB)
[INFO]  stable-diffusion.cpp:2943 - loading model from '../models/sd-v1-4-ggml-model-f16.bin' completed, taking 0.79s
libc++abi: terminating due to uncaught exception of type std::__1::regex_error: The parser did not consume the entire regular expression.
```

I found the root in `parse_prompt_attention`. When compiled on my Mac with Clang, it would always throw. With GCC on Linux, it didn't and would work. I think this is an encoding issue. I updated the line so it should work with everything, but knowing Regex I may have still screwed something up. Such is life.