### PR TITLE
flushes after printf

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -26,12 +26,16 @@ static SDLogLevel log_level = SDLogLevel::INFO;
         }                                                                                             \
         if (level == SDLogLevel::DEBUG) {                                                             \
             printf("[DEBUG] %s:%-4d - " format "\n", __FILENAME__, __LINE__, ##__VA_ARGS__);          \
+            fflush(stdout);                                                                           \
         } else if (level == SDLogLevel::INFO) {                                                       \
             printf("[INFO]  %s:%-4d - " format "\n", __FILENAME__, __LINE__, ##__VA_ARGS__);          \
+            fflush(stdout);                                                                           \
         } else if (level == SDLogLevel::WARN) {                                                       \
             fprintf(stderr, "[WARN]  %s:%-4d - " format "\n", __FILENAME__, __LINE__, ##__VA_ARGS__); \
+            fflush(stdout);                                                                           \
         } else if (level == SDLogLevel::ERROR) {                                                      \
             fprintf(stderr, "[ERROR] %s:%-4d - " format "\n", __FILENAME__, __LINE__, ##__VA_ARGS__); \
+            fflush(stdout);                                                                           \
         }                                                                                             \
     } while (0)
 
@@ -135,6 +139,7 @@ float ggml_tensor_get_f32(const ggml_tensor* tensor, int l, int k = 0, int j = 0
 
 void print_ggml_tensor(struct ggml_tensor* tensor, bool shape_only = false) {
     printf("shape(%zu, %zu, %zu, %zu)\n", tensor->ne[0], tensor->ne[1], tensor->ne[2], tensor->ne[3]);
+    fflush(stdout);
     if (shape_only) {
         return;
     }
@@ -156,6 +161,7 @@ void print_ggml_tensor(struct ggml_tensor* tensor, bool shape_only = false) {
                         continue;
                     }
                     printf("  [%d, %d, %d, %d] = %f\n", i, j, k, l, ggml_tensor_get_f32(tensor, l, k, j, i));
+                    fflush(stdout);
                 }
             }
         }


### PR DESCRIPTION
add flushes after `printf` statements, so that stdout will throw events and log in real time. 

if not flushed, stuck in buffer for other processes until this finishes. 

this fixes for example using `sd | tee output.txt`

fixes building UI tools without need for ABI/RPC (formatted logging probably ideal next)

<img width="975" alt="Screenshot 2023-08-29 at 10 25 28 PM" src="https://github.com/leejet/stable-diffusion.cpp/assets/328000/943774d3-8ea4-461f-b872-8f63fac1d7aa">