### PR TITLE
Add DPM2 and DPM++(2s) a samplers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Inference of [Stable Diffusion](https://github.com/CompVis/stable-diffusion) in 
     - `Euler A`
     - `Euler`
     - `Heun`
+    - `DPM2`
     - `DPM++ 2M`
     - [`DPM++ 2M v2`](https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/8457)
+    - `DPM++ 2S a`
 - Cross-platform reproducibility (`--rng cuda`, consistent with the `stable-diffusion-webui GPU RNG`)
 - Supported platforms
     - Linux

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -78,6 +78,7 @@ const char* sample_method_str[] = {
     "euler",
     "heun",
     "dpm2",
+    "dpm++2s_a",
     "dpm++2m",
     "dpm++2mv2"};
 
@@ -145,7 +146,7 @@ void print_usage(int argc, const char* argv[]) {
     printf("                                     1.0 corresponds to full destruction of information in init image\n");
     printf("  -H, --height H                     image height, in pixel space (default: 512)\n");
     printf("  -W, --width W                      image width, in pixel space (default: 512)\n");
-    printf("  --sampling-method {euler, euler_a, heun, dpm2, dpm++2m, dpm++2mv2}\n");
+    printf("  --sampling-method {euler, euler_a, heun, dpm2, dpm++2s_a, dpm++2m, dpm++2mv2}\n");
     printf("                                     sampling method (default: \"euler_a\")\n");
     printf("  --steps  STEPS                     number of sample steps (default: 20)\n");
     printf("  --rng {std_default, cuda}          RNG (default: cuda)\n");

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -77,6 +77,7 @@ const char* sample_method_str[] = {
     "euler_a",
     "euler",
     "heun",
+    "dpm2",
     "dpm++2m",
     "dpm++2mv2"};
 
@@ -144,7 +145,7 @@ void print_usage(int argc, const char* argv[]) {
     printf("                                     1.0 corresponds to full destruction of information in init image\n");
     printf("  -H, --height H                     image height, in pixel space (default: 512)\n");
     printf("  -W, --width W                      image width, in pixel space (default: 512)\n");
-    printf("  --sampling-method {euler, euler_a, heun, dpm++2m, dpm++2mv2}\n");
+    printf("  --sampling-method {euler, euler_a, heun, dpm2, dpm++2m, dpm++2mv2}\n");
     printf("                                     sampling method (default: \"euler_a\")\n");
     printf("  --steps  STEPS                     number of sample steps (default: 20)\n");
     printf("  --rng {std_default, cuda}          RNG (default: cuda)\n");

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -3706,8 +3706,7 @@ class StableDiffusionGGML {
                     }
                 }
             } break;
-            case DPM2:
-            {
+            case DPM2: {
                 LOG_INFO("sampling using DPM2 method");
                 ggml_set_dynamic(ctx, false);
                 struct ggml_tensor* d = ggml_dup_tensor(ctx, x);
@@ -3741,9 +3740,9 @@ class StableDiffusionGGML {
                         }
                     } else {
                         // DPM-Solver-2
-                        float sigma_mid = exp(0.5 * (log(sigmas[i]) + log(sigmas[i+1])));
+                        float sigma_mid = exp(0.5 * (log(sigmas[i]) + log(sigmas[i + 1])));
                         float dt_1 = sigma_mid - sigmas[i];
-                        float dt_2 = sigmas[i+1] - sigmas[i];
+                        float dt_2 = sigmas[i + 1] - sigmas[i];
 
                         float* vec_d = (float*)d->data;
                         float* vec_x = (float*)x->data;
@@ -3762,8 +3761,7 @@ class StableDiffusionGGML {
                 }
 
             } break;
-            case DPMPP2S_A:
-            {
+            case DPMPP2S_A: {
                 LOG_INFO("sampling using DPM++ (2s) a method");
                 ggml_set_dynamic(ctx, false);
                 struct ggml_tensor* noise = ggml_dup_tensor(ctx, x);
@@ -3777,12 +3775,12 @@ class StableDiffusionGGML {
 
                     // get_ancestral_step
                     float sigma_up = std::min(sigmas[i + 1],
-                            std::sqrt(sigmas[i + 1] * sigmas[i + 1] * (sigmas[i] * sigmas[i] - sigmas[i + 1] * sigmas[i + 1]) / (sigmas[i] * sigmas[i])));
+                                              std::sqrt(sigmas[i + 1] * sigmas[i + 1] * (sigmas[i] * sigmas[i] - sigmas[i + 1] * sigmas[i + 1]) / (sigmas[i] * sigmas[i])));
                     float sigma_down = std::sqrt(sigmas[i + 1] * sigmas[i + 1] - sigma_up * sigma_up);
                     auto t_fn = [](float sigma) -> float { return -log(sigma); };
-                    auto sigma_fn = [](float t) -> float {return exp(-t); };
+                    auto sigma_fn = [](float t) -> float { return exp(-t); };
 
-                    if(sigma_down == 0) {
+                    if (sigma_down == 0) {
                         // Euler step
                         float* vec_d = (float*)d->data;
                         float* vec_x = (float*)x->data;
@@ -3814,16 +3812,14 @@ class StableDiffusionGGML {
 
                         // First half-step
                         for (int j = 0; j < ggml_nelements(x); j++) {
-                            vec_x2[j] = (sigma_fn(s) / sigma_fn(t)) * vec_x[j]
-                                - (exp(-h * 0.5)-1) * vec_denoised[j];
+                            vec_x2[j] = (sigma_fn(s) / sigma_fn(t)) * vec_x[j] - (exp(-h * 0.5) - 1) * vec_denoised[j];
                         }
 
                         denoise(x2, sigmas[i + 1], i + 1);
 
                         // Second half-step
                         for (int j = 0; j < ggml_nelements(x); j++) {
-                            vec_x[j] = (sigma_fn(t_next) / sigma_fn(t)) * vec_x[j]
-                                - (exp(-h)-1) * vec_denoised[j];
+                            vec_x[j] = (sigma_fn(t_next) / sigma_fn(t)) * vec_x[j] - (exp(-h) - 1) * vec_denoised[j];
                         }
                     }
 

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -21,6 +21,7 @@ enum SampleMethod {
     EULER,
     HEUN,
     DPM2,
+    DPMPP2S_A,
     DPMPP2M,
     DPMPP2Mv2,
     N_SAMPLE_METHODS

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -20,6 +20,7 @@ enum SampleMethod {
     EULER_A,
     EULER,
     HEUN,
+    DPM2,
     DPMPP2M,
     DPMPP2Mv2,
     N_SAMPLE_METHODS


### PR DESCRIPTION
This adds two more samplers, built by reimplementing the python code from [k_diffusion](https://github.com/crowsonkb/k-diffusion/blob/master/k_diffusion/sampling.py) in C++.

I'm actually not sure why DPM++(2s) a works at all, as [I think it does a negative timestep if the sigma goes to zero](https://github.com/leejet/stable-diffusion.cpp/commit/8f53bb4ee9b685ba4599c7696da7348587a15e79#diff-a8e875e8f7684a2f9e35212d88ee9574001952eb2c049385e73d5e24fd6e2a83R3795-R3797), but [as k_diffusion does the same](https://github.com/crowsonkb/k-diffusion/blob/master/k_diffusion/sampling.py#L525), I just left it as-is.