### PR TITLE
Allow Loras with negative weight, too.

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -276,9 +276,6 @@ std::pair<std::unordered_map<std::string, float>, std::string> extract_and_remov
     while (std::regex_search(text, matches, re)) {
         std::string filename = matches[1].str();
         float multiplier     = std::stof(matches[2].str());
-        if (multiplier < 0.f) {
-            continue;
-        }
         if (filename2multiplier.find(filename) == filename2multiplier.end()) {
             filename2multiplier[filename] = multiplier;
         } else {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -276,6 +276,11 @@ std::pair<std::unordered_map<std::string, float>, std::string> extract_and_remov
     while (std::regex_search(text, matches, re)) {
         std::string filename = matches[1].str();
         float multiplier     = std::stof(matches[2].str());
+
+        if (multiplier == 0.f) {
+            continue;
+        }
+
         if (filename2multiplier.find(filename) == filename2multiplier.end()) {
             filename2multiplier[filename] = multiplier;
         } else {


### PR DESCRIPTION
There are a couple of loras which serve to adjust certain concepts in both positive and negative directions (like exposure, detail level etc).

The current code rejects them if loaded with a negative weight, but I suggest that this check can simply be dropped.