### PR TITLE
libstable-diffusion.so relative path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ add_subdirectory(ggml)
 set(SD_LIB stable-diffusion)
 
 add_library(${SD_LIB} stable-diffusion.h stable-diffusion.cpp)
+set_target_properties(${SD_LIB} PROPERTIES
+        BUILD_WITH_INSTALL_RPATH FALSE
+        LINK_FLAGS "-Wl,-rpath,$ORIGIN/")
 target_link_libraries(${SD_LIB} PUBLIC ggml)
 target_include_directories(${SD_LIB} PUBLIC .)
 target_compile_features(${SD_LIB} PUBLIC cxx_std_11)

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -4609,7 +4609,7 @@ public:
 
 /*================================================= StableDiffusion ==================================================*/
 
-StableDiffusion::StableDiffusion(int n_threads,
+void StableDiffusion::setup(int n_threads,
                                  bool vae_decode_only,
                                  bool free_params_immediately,
                                  std::string lora_model_dir,

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -4609,7 +4609,7 @@ public:
 
 /*================================================= StableDiffusion ==================================================*/
 
-void StableDiffusion::setup(int n_threads,
+StableDiffusion::StableDiffusion(int n_threads,
                                  bool vae_decode_only,
                                  bool free_params_immediately,
                                  std::string lora_model_dir,

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -42,7 +42,7 @@ private:
     std::shared_ptr<StableDiffusionGGML> sd;
 
 public:
-    void setup(int n_threads                = -1,
+    StableDiffusion(int n_threads                = -1,
                     bool vae_decode_only         = false,
                     bool free_params_immediately = false,
                     std::string lora_model_dir   = "",

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -42,7 +42,7 @@ private:
     std::shared_ptr<StableDiffusionGGML> sd;
 
 public:
-    StableDiffusion(int n_threads                = -1,
+    void setup(int n_threads                = -1,
                     bool vae_decode_only         = false,
                     bool free_params_immediately = false,
                     std::string lora_model_dir   = "",


### PR DESCRIPTION
Currently `libstable-diffusion.so` points to the path where libggml.so was created.
Its possible to change that to the relative path with this PR.