### PR TITLE
fix: reading memory of stack allocated object past its scope

### DIFF
--- a/common/common.cpp
+++ b/common/common.cpp
@@ -370,7 +370,7 @@ std::string basename(const std::string& path) {
     return path;
 }
 
-const char* get_image_params(SDParams params, int seed) {
+std::string get_image_params(SDParams params, int seed) {
     std::string parameter_string = params.prompt + "\n";
     if (params.negative_prompt.size() != 0) {
         parameter_string += "Negative prompt: " + params.negative_prompt + "\n";
@@ -387,5 +387,5 @@ const char* get_image_params(SDParams params, int seed) {
     }
     parameter_string += ", ";
     parameter_string += "Version: stable-diffusion.cpp";
-    return parameter_string.c_str();
+    return parameter_string;
 }

--- a/common/common.h
+++ b/common/common.h
@@ -40,4 +40,4 @@ void print_usage(int argc, const char* argv[]);
 
 void parse_args(int argc, const char** argv, SDParams& params);
 
-const char* get_image_params(SDParams params, int seed);
+std::string get_image_params(SDParams params, int seed);

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -87,7 +87,7 @@ int main(int argc, const char* argv[]) {
     std::string dummy_name = last != std::string::npos ? params.output_path.substr(0, last) : params.output_path;
     for (int i = 0; i < params.batch_count; i++) {
         std::string final_image_path = i > 0 ? dummy_name + "_" + std::to_string(i + 1) + ".png" : dummy_name + ".png";
-        stbi_write_png(final_image_path.c_str(), params.width, params.height, 3, results[i], 0, get_image_params(params, params.seed + i));
+        stbi_write_png(final_image_path.c_str(), params.width, params.height, 3, results[i], 0, get_image_params(params, params.seed + i).c_str());
         printf("save result image to '%s'\n", final_image_path.c_str());
     }
 


### PR DESCRIPTION
I was having random crashes and corrupted png files over in #88 .
This pr fixes those