### PR TITLE
fix: remove dangling pointer to work_output in CLIPTextModel

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1124,6 +1124,7 @@ struct CLIPTextModel {
         ggml_backend_buffer_free(compute_buffer);
         compute_alloc              = NULL;
         compute_memory_buffer_size = -1;
+        work_output                = NULL;
     }
 };
 


### PR DESCRIPTION
`CLIPTextModel::begin()` creates a `work_output` tensor using the provided `work_ctx` but `CLIPTextModel::end()` does not set this value back to `NULL`, causing the next call to `CLIPTextModel::begin()` to not allocate a new tensor and use the value from the previous iteration instead, which is now a dangling pointer and thus invalid. This means that attempts to make multiple generation calls (`StableDiffusion::txt2img()`/`StableDiffusion::img2img()`) using a single `StableDiffusion` instance will cause memory corruption and results in a segmentation fault.

This doesn't affect the example "sd" binary as it creates the instance and only performs a single generation call before exiting, and this bug only occurs if a single instance is used for generation twice.