### PR TITLE
fix: never use a log message as a format string

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -460,13 +460,13 @@ void sd_log_cb(enum sd_log_level_t level, const char* log, void* data) {
         return;
     }
     if (level <= SD_LOG_INFO) {
-        fprintf(stdout, log);
+        fputs(log, stdout);
         fflush(stdout);
     } else {
-        fprintf(stderr, log);
+        fputs(log, stderr);
         fflush(stderr);
     }
-};
+}
 
 int main(int argc, const char* argv[]) {
     SDParams params;


### PR DESCRIPTION
Users could inject formatters and crash the application.
Also does not compile with my setup:
```
/examples/cli/main.cpp:463:16: error: format not a string literal and no format arguments [-Werror=format-security]
  463 |         fprintf(stdout, log);
```