### PR TITLE
Add in capability to repeatedly run the upscaler in a row

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ git submodule update
 #### Build from scratch
 
 ```shell
-git submodule init
-git submodule update
 mkdir build
 cd build
 cmake ..

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ git submodule update
 #### Build from scratch
 
 ```shell
+git submodule init
+git submodule update
 mkdir build
 cd build
 cmake ..
@@ -148,7 +150,7 @@ cmake --build . --config Release
 ### Run
 
 ```
-usage: ./bin/sd [arguments]
+usage: ./build/bin/sd [arguments]
 
 arguments:
   -h, --help                         show this help message and exit
@@ -161,6 +163,7 @@ arguments:
   --control-net [CONTROL_PATH]       path to control net model
   --embd-dir [EMBEDDING_PATH]        path to embeddings.
   --upscale-model [ESRGAN_PATH]      path to esrgan model. Upscale images after generate, just RealESRGAN_x4plus_anime_6B supported by now.
+  --upscale-repeats                  Run the ESRGAN upscaler this many times (default 1)
   --type [TYPE]                      weight type (f32, f16, q4_0, q4_1, q5_0, q5_1, q8_0)
                                      If not specified, the default is the type of the weight file.
   --lora-model-dir [DIR]             lora model directory
@@ -186,6 +189,7 @@ arguments:
                                      <= 0 represents unspecified, will be 1 for SD1.x, 2 for SD2.x
   --vae-tiling                       process vae in tiles to reduce memory usage
   --control-net-cpu                  keep controlnet in cpu (for low vram)
+  --canny                            apply canny preprocessor (edge detection)
   -v, --verbose                      print extra info
 ```
 

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -96,7 +96,7 @@ struct SDParams {
     bool vae_tiling               = false;
     bool control_net_cpu          = false;
     bool canny_preprocess         = false;
-    int upscale_repeats        = 1;
+    int upscale_repeats           = 1;
 };
 
 void print_params(SDParams params) {
@@ -174,7 +174,7 @@ void print_usage(int argc, const char* argv[]) {
     printf("  --vae-tiling                       process vae in tiles to reduce memory usage\n");
     printf("  --control-net-cpu                  keep controlnet in cpu (for low vram)\n");
     printf("  --canny                            apply canny preprocessor (edge detection)\n");
-    printf("  -v, --verbose                      print extra info\n"); 
+    printf("  -v, --verbose                      print extra info\n");
 }
 
 void parse_args(int argc, const char** argv, SDParams& params) {
@@ -714,34 +714,31 @@ int main(int argc, const char* argv[]) {
 
     int upscale_factor = 4;  // unused for RealESRGAN_x4plus_anime_6B.pth
     if (params.esrgan_path.size() > 0 && params.upscale_repeats > 0) {
-    upscaler_ctx_t* upscaler_ctx = new_upscaler_ctx(params.esrgan_path.c_str(),
-                                                    params.n_threads,
-                                                    params.wtype);
+        upscaler_ctx_t* upscaler_ctx = new_upscaler_ctx(params.esrgan_path.c_str(),
+                                                        params.n_threads,
+                                                        params.wtype);
 
-    if (upscaler_ctx == NULL) {
-        printf("new_upscaler_ctx failed\n");
-    } else {
-        for (int i = 0; i < params.batch_count; i++) {
-            if (results[i].data == NULL) {
-                continue;
-            }
-            sd_image_t current_image = results[i];
-            for (int u = 0; u < params.upscale_repeats; ++u) {
-                sd_image_t upscaled_image = upscale(upscaler_ctx, current_image, upscale_factor);
-                if (u > 0) { // Free the previous iteration's image data if not the first upscale
+        if (upscaler_ctx == NULL) {
+            printf("new_upscaler_ctx failed\n");
+        } else {
+            for (int i = 0; i < params.batch_count; i++) {
+                if (results[i].data == NULL) {
+                    continue;
+                }
+                sd_image_t current_image = results[i];
+                for (int u = 0; u < params.upscale_repeats; ++u) {
+                    sd_image_t upscaled_image = upscale(upscaler_ctx, current_image, upscale_factor);
+                    if (upscaled_image.data == NULL) {
+                        printf("upscale failed\n");
+                        break;
+                    }
                     free(current_image.data);
+                    current_image = upscaled_image;
                 }
-                if (upscaled_image.data == NULL) {
-                    printf("upscale failed\n");
-                    break;
-                }
-                current_image = upscaled_image;
+                results[i] = current_image;  // Set the final upscaled image as the result
             }
-            results[i] = current_image; // Set the final upscaled image as the result
         }
     }
-}
-
 
     size_t last            = params.output_path.find_last_of(".");
     std::string dummy_name = last != std::string::npos ? params.output_path.substr(0, last) : params.output_path;

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -173,10 +173,11 @@ public:
         if (version == VERSION_XL) {
             scale_factor = 0.13025f;
             if (vae_path.size() == 0 && taesd_path.size() == 0) {
-                LOG_WARN("!!!It looks like you are using SDXL model. "
-                         "If you find that the generated images are completely black, "
-                         "try specifying SDXL VAE FP16 Fix with the --vae parameter. "
-                         "You can find it here: https://huggingface.co/madebyollin/sdxl-vae-fp16-fix/blob/main/sdxl_vae.safetensors");
+                LOG_WARN(
+                    "!!!It looks like you are using SDXL model. "
+                    "If you find that the generated images are completely black, "
+                    "try specifying SDXL VAE FP16 Fix with the --vae parameter. "
+                    "You can find it here: https://huggingface.co/madebyollin/sdxl-vae-fp16-fix/blob/main/sdxl_vae.safetensors");
             }
         }
 


### PR DESCRIPTION
While the ESRGAN upscaler models compatible with stable-diffusion.cpp at this time are fixed in their upscaling rate, they do not discriminate on input image data. This means that, hypothetically, we could continuously run that upscaling model on the outputs of the previous upscaling run until we run out of memory.

I've tested this locally on my M1 MBP, and have successfully done txt2img and img2img generation resulting in image resolutions of 8192x8192. Bigger than that and I get an out-of-memory error, but hypothetically a large enough machine should be able to do this. 

This does *not* affect the image upscale multiplier inherent to the model, it simply runs the same fixed-multiplier model repeatedly (so for example, an `x4` model would take a 512x512 image upscaled to 2048x2048 on one pass, and then from 2048x2048 to 8192x8192 on a second pass, then 32k x 32k, then 128...)

The changes were designed to have minimal impact on any other code, so anything which currently leverages legacy versions should continue to function fine. If you want to use the new upscale repeating function, add

`--upscale-repeats <int >= 1>` 

to your command. Otherwise, by default, it will default to run the upscaler once.