### PR TITLE
Fix Metal build issue

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -124,7 +124,7 @@ public:
 #endif
 #ifdef SD_USE_METAL
         LOG_DEBUG("Using Metal backend");
-        ggml_metal_log_set_callback(ggml_log_callback_default, nullptr);
+        ggml_backend_metal_log_set_callback(ggml_log_callback_default, nullptr);
         backend = ggml_backend_metal_init();
 #endif
 

--- a/upscaler.cpp
+++ b/upscaler.cpp
@@ -21,7 +21,7 @@ struct UpscalerGGML {
 #endif
 #ifdef SD_USE_METAL
         LOG_DEBUG("Using Metal backend");
-        ggml_metal_log_set_callback(ggml_log_callback_default, nullptr);
+        ggml_backend_metal_log_set_callback(ggml_log_callback_default, nullptr);
         backend = ggml_backend_metal_init();
 #endif
 


### PR DESCRIPTION
Fixes failure to build with SD_METAL=ON 

```
error: use of undeclared identifier 'ggml_metal_log_set_callback'; did you mean 'ggml_backend_metal_log_set_callback'?
        ggml_metal_log_set_callback(ggml_log_callback_default, nullptr);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~
        ggml_backend_metal_log_set_callback
```