### PR TITLE
do not free sd_ctx in load_from_file

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1516,9 +1516,6 @@ sd_ctx_t* new_sd_ctx(const char* model_path_c_str,
                                     keep_clip_on_cpu,
                                     keep_control_net_cpu,
                                     keep_vae_on_cpu)) {
-        delete sd_ctx->sd;
-        sd_ctx->sd = NULL;
-        free(sd_ctx);
         return NULL;
     }
     return sd_ctx;


### PR DESCRIPTION
With this change I can load another model, when the sd_ctx is freed in load_from_model it crashes while loading a new model (I free the sd_ctx with `free_sd_ctx` first and create a new one for loading a new model).