### PR TITLE
apply pmid lora only once for multiple txt2img calls

### DIFF
--- a/lora.hpp
+++ b/lora.hpp
@@ -11,6 +11,7 @@ struct LoraModel : public GGMLModule {
     std::string file_path;
     ModelLoader model_loader;
     bool load_failed = false;
+    bool applied = false;
 
     LoraModel(ggml_backend_t backend,
               ggml_type wtype,

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1607,10 +1607,11 @@ sd_image_t* txt2img(sd_ctx_t* sd_ctx,
     int64_t t1 = ggml_time_ms();
     LOG_INFO("apply_loras completed, taking %.2fs", (t1 - t0) * 1.0f / 1000);
 
-    if (sd_ctx->sd->stacked_id) {
+    if (sd_ctx->sd->stacked_id && !sd_ctx->sd->pmid_lora->applied) {
         t0 = ggml_time_ms();
         sd_ctx->sd->pmid_lora->apply(sd_ctx->sd->tensors, sd_ctx->sd->n_threads);
         t1 = ggml_time_ms();
+        sd_ctx->sd->pmid_lora->applied = true;
         LOG_INFO("pmid_lora apply completed, taking %.2fs", (t1 - t0) * 1.0f / 1000);
         if (sd_ctx->sd->free_params_immediately) {
             sd_ctx->sd->pmid_lora->free_params_buffer();


### PR DESCRIPTION
This PR fixed an [issue](https://github.com/leejet/stable-diffusion.cpp/issues/207) found by a user. The use case is to call txt2img multiple times and Photomaker lora's should **ONLY** be applied **once**.  

