### PR TITLE
Upscale progress bar fix

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -454,7 +454,7 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
     ggml_tensor* input_tile  = ggml_new_tensor_4d(tiles_ctx, GGML_TYPE_F32, tile_size, tile_size, input->ne[2], 1);
     ggml_tensor* output_tile = ggml_new_tensor_4d(tiles_ctx, GGML_TYPE_F32, tile_size * scale, tile_size * scale, output->ne[2], 1);
     on_processing(input_tile, NULL, true);
-    int num_tiles = (input_width * input_height) / (non_tile_overlap * non_tile_overlap);
+    int num_tiles = ceil((float)input_width / non_tile_overlap) * ceil((float)input_height / non_tile_overlap);
     LOG_INFO("processing %i tiles", num_tiles);
     pretty_progress(1, num_tiles, 0.0f);
     int tile_count = 1;


### PR DESCRIPTION
Small fix of a number of tiles processed in upscaling, so progress bar works correctly.
Logs before fix:
```
upscaler.cpp:45   - upscaling from (544 x 960) to (2176 x 3840)
...
ggml_extend.hpp:461  - processing 56 tiles
  |==================================================| 56/56 - 12.35it/s
  |==================================================| 60/56 - 12.35it/supscaler.cpp:75   - input_image_tensor upscaled, taking 5.15s
```
Logs after fix:

```
ggml_extend.hpp:458  - processing 60 tiles
  |==================================================| 60/60 - 12.05it/s
upscaler.cpp:75   - input_image_tensor upscaled, taking 5.13s
```

