### PR TITLE
Safetensors load fix

### DIFF
--- a/model.cpp
+++ b/model.cpp
@@ -888,6 +888,11 @@ bool ModelLoader::init_from_safetensors_file(const std::string& file_path, const
             }
         }
 
+        // ggml/src/ggml.c:2745
+        if (n_dims < 1 || n_dims > GGML_MAX_DIMS) {
+            continue;
+        }
+
         TensorStorage tensor_storage(prefix + name, type, ne, n_dims, file_index, ST_HEADER_SIZE_LEN + header_size_ + begin);
         tensor_storage.reverse_ne();
 


### PR DESCRIPTION
In GGML we have check for n_dims on tensor creation:
ggml/src/ggml.c:2745
```
assert(n_dims >= 1 && n_dims <= GGML_MAX_DIMS);
```
So, we cant use `tensor_storage` with n_dims not in range, so I added a skip for this.
Tested with lora Expressive_H.
Logs before fix:
```
model.cpp:1378 - loading tensors from [...]/Expressive_H.safetensors
[...]/ggml/src/ggml.c:2745: ggml_new_tensor_impl: Assertion `n_dims >= 1 && n_dims <= GGML_MAX_DIMS' failed.
```
Logs after fix:

```
model.cpp:1378 - loading tensors from [...]/Expressive_H.safetensors
lora.hpp:67   - finished loaded lora
lora.hpp:174  - (1972 / 1972) LoRA tensors applied successfully
```
