### PR TITLE
Make crc32 100x faster on x86-64

### DIFF
--- a/thirdparty/.clang-format
+++ b/thirdparty/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: Never


### PR DESCRIPTION
This change makes checkpoints load significantly faster by optimizing pkzip's cyclic redundancy check. This code was developed by Intel and Google and Mozilla. See Chromium's zlib codebase for further details.