### PR TITLE
Add support for autodetecting tensor_storage.type from the size of the stream

### DIFF
--- a/model.cpp
+++ b/model.cpp
@@ -1037,6 +1037,7 @@ struct PickleTensorReader {
     ReadPhase phase   = READ_NAME;
     size_t entry_size = 0;
     int32_t nelements = 0;
+    bool read_explict_type = false;
 
     TensorStorage tensor_storage;
 
@@ -1047,6 +1048,11 @@ struct PickleTensorReader {
         if (phase == CHECK_SIZE) {
             if (entry_size == value * ggml_type_size(tensor_storage.type)) {
                 nelements = value;
+                phase     = READ_DIMENS;
+                return true;
+            } else if (!read_explict_type && entry_size == value * ggml_type_size(GGML_TYPE_F16)) {
+                nelements = value;
+                tensor_storage.type = GGML_TYPE_F16;
                 phase     = READ_DIMENS;
                 return true;
             } else {
@@ -1072,12 +1078,14 @@ struct PickleTensorReader {
                 read_global_type = false;
             }
             tensor_storage.type = GGML_TYPE_F32;
+            read_explict_type  = true;
         } else if (str == "HalfStorage") {
             if (read_global_type) {
                 global_type      = GGML_TYPE_F16;
                 read_global_type = false;
             }
             tensor_storage.type = GGML_TYPE_F16;
+            read_explict_type   = true;
         }
     }
 


### PR DESCRIPTION
I'm honestly not sure if this is even valid as per the official format, but I have some existing .ckpt files which were written using the automatic1111 DreamBooth extension and they contain some f16 tensors without ` GLOBAL     'torch HalfStorage'` opcodes in the pkl stream. 

These load fine on the Python implementation, but fail here since `PickleTensorReader` skips those tensors due a mismatched size. It seems the other loader is guessing the f16 format based on the size of the tensor data file, whereas this code always assumes f32 if the pickle header doesn't contain a specifier.

With this change my checkpoints load and work fine with stable-diffuision.cpp so I figured I would make a PR incase there are other .ckpts out there that need this same fixup to load and maybe it helps somebody else.