### PR TITLE
resolve naming conflict while llama.cpp and stable-diffusion.cpp both build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,10 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 add_definitions(-DGGML_MAX_NAME=128)
 
 # deps
-add_subdirectory(ggml)
+# Only add ggml if it hasn't been added yet
+if (NOT TARGET ggml)
+    add_subdirectory(ggml)
+endif()
 
 add_subdirectory(thirdparty)
 


### PR DESCRIPTION
when llama.cpp and stable-diffusion.cpp are both dependencies, ggml will conflict

`CMake Error at dependency/stable-diffusion.cpp/ggml/src/CMakeLists.txt:1280 (add_library):
  add_library cannot create target "ggml" because another target with the
  same name already exists.  The existing target is a shared library created
  in source directory
  "/tmp/build-via-sdist-8bixgjbo/nexaai-0.0.0.dev0/dependency/llama.cpp/ggml/src".
  See documentation for policy CMP0002 for more details`