### PR TITLE
add inplace conversion support for f8_e4m3

### DIFF
--- a/model.h
+++ b/model.h
@@ -32,6 +32,7 @@ struct TensorStorage {
     std::string name;
     ggml_type type          = GGML_TYPE_F32;
     bool is_bf16            = false;
+    bool is_f8_e4m3         = false;
     int64_t ne[SD_MAX_DIMS] = {1, 1, 1, 1, 1};
     int n_dims              = 0;
 
@@ -61,7 +62,7 @@ struct TensorStorage {
     }
 
     int64_t nbytes_to_read() const {
-        if (is_bf16) {
+        if (is_bf16 || is_f8_e4m3) {
             return nbytes() / 2;
         } else {
             return nbytes();
@@ -109,6 +110,8 @@ struct TensorStorage {
         const char* type_name = ggml_type_name(type);
         if (is_bf16) {
             type_name = "bf16";
+        } else if (is_f8_e4m3) {
+            type_name = "f8_e4m3";
         }
         ss << name << " | " << type_name << " | ";
         ss << n_dims << " [";
@@ -160,4 +163,6 @@ public:
     static std::string load_merges();
     static std::string load_t5_tokenizer_json();
 };
+
 #endif  // __MODEL_H__
+


### PR DESCRIPTION
In the same way it is done for bf16.
Like how bf16 converts losslessly to fp32, f8_e4m3 converts losslessly to fp16.

(merge base right now is `flux`, @leejet tell me if I should retarget onto master)