### PR TITLE
fix and improve: VAE tiling

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -349,10 +349,6 @@ __STATIC_INLINE__ void ggml_split_tensor_2d(struct ggml_tensor* input,
     }
 }
 
-__STATIC_INLINE__ float ggml_lerp_f32(const float a, const float b, const float x) {
-    return (1 - x) * a + x * b;
-}
-
 // unclamped -> expects x in the range [0-1]
 __STATIC_INLINE__ float ggml_smootherstep_f32(const float x) {
     GGML_ASSERT(x >= 0.f && x <= 1.f);


### PR DESCRIPTION
- properly handle the upper left corner interpolating both x and y
- use smootherstep to preserve more detail and spend less area blending

Completely fixes tiling seams!
Thanks to @stduhpf 

fixes #353.

<details><summary>Old Details</summary>


Here is a test image, which replaces each tile with a single uniform shade of gray. The lines are the midway points of the overlap.
### Before:
![image](https://github.com/user-attachments/assets/64ae9ec0-80b0-4eeb-a615-add28b9a1db1)
### After:
![image](https://github.com/user-attachments/assets/d9cd81c1-fc92-461e-bc67-da20c2e360d8)

And now with a proper test image.
### Before:
![image](https://github.com/user-attachments/assets/de49dd33-c02e-4c50-b765-a36194125279)
### After:
![image](https://github.com/user-attachments/assets/ea0d5e26-b57e-4660-a9c0-4031692f2f9a)
### Without tiling:
![image](https://github.com/user-attachments/assets/4cf9fbf2-cab9-42f3-b7a6-4a15aeb94d93)


IMO a significant improvement. There are however still vertical seams. I am a bit out of ideas now, so I wanted to contribute what I already have.


Some more details can be found in #353 .

</details> 

This is ready to merge.

### Before:
![image](https://github.com/user-attachments/assets/de49dd33-c02e-4c50-b765-a36194125279)
### After:
![artius_output](https://github.com/user-attachments/assets/40d82ea6-88ed-41ac-9ae3-7ada65d84ab1)
