### PR TITLE
Docs: specify `models` directory for location of model weights downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ git submodule update
     - Stable Diffusion 3 2B from https://huggingface.co/stabilityai/stable-diffusion-3-medium
 
     ```shell
+    mkdir models
+    cd models
     curl -L -O https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt
     # curl -L -O https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors
     # curl -L -O https://huggingface.co/stabilityai/stable-diffusion-2-1/resolve/main/v2-1_768-nonema-pruned.safetensors


### PR DESCRIPTION
I mostly got things working by just copying+pasting Bash commands shown in the `README`.

Only issue was:
- After building, the first example command(`./bin/sd -m ../models/sd-v1-4.ckpt -p "a lovely cat"`) failed because I didn't have the `models` dir nor anything in it.

Fix was:
- `mkdir ../models`
- `mv ../sd-v1-4.ckpt ../models/`

This just makes that explicit in the weight downloading setup.