### PR TITLE
Fix Flux: clip_l support (SD3/3.5 improvements included)

### DIFF
--- a/clip.hpp
+++ b/clip.hpp
@@ -712,7 +712,7 @@ public:
             auto text_projection = params["text_projection"];
             ggml_tensor* pooled  = ggml_view_1d(ctx, x, hidden_size, x->nb[1] * max_token_idx);
             if (text_projection != NULL) {
-                pooled           = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_transpose(ctx, text_projection)), pooled);
+                pooled           = ggml_nn_linear(ctx, pooled, text_projection, NULL);
             } else {
                 LOG_DEBUG("Missing text_projection matrix, assuming identity...");
             }

--- a/clip.hpp
+++ b/clip.hpp
@@ -711,7 +711,11 @@ public:
         if (return_pooled) {
             auto text_projection = params["text_projection"];
             ggml_tensor* pooled  = ggml_view_1d(ctx, x, hidden_size, x->nb[1] * max_token_idx);
-            pooled               = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_transpose(ctx, text_projection)), pooled);
+            if(text_projection != NULL){
+                pooled           = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_transpose(ctx, text_projection)), pooled);
+            }else{
+                LOG_DEBUG("Missing text_projection matrix, assuming identity...");
+            }
             return pooled;
         }
 

--- a/clip.hpp
+++ b/clip.hpp
@@ -711,12 +711,12 @@ public:
         if (return_pooled) {
             auto text_projection = params["text_projection"];
             ggml_tensor* pooled  = ggml_view_1d(ctx, x, hidden_size, x->nb[1] * max_token_idx);
-            if(text_projection != NULL){
+            if (text_projection != NULL) {
                 pooled           = ggml_mul_mat(ctx, ggml_cont(ctx, ggml_transpose(ctx, text_projection)), pooled);
-            }else{
+            } else {
                 LOG_DEBUG("Missing text_projection matrix, assuming identity...");
             }
-            return pooled;
+            return pooled;  // [hidden_size, 1, 1]
         }
 
         return x;  // [N, n_token, hidden_size]

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -1073,7 +1073,7 @@ struct FluxCLIPEmbedder : public Conditioner {
         return {{clip_l_tokens, clip_l_weights}, {t5_tokens, t5_weights}};
     }
 
-    SDCondition get_learned_condition_common(ggml_context* work_ctx,
+      SDCondition get_learned_condition_common(ggml_context* work_ctx,
                                              int n_threads,
                                              std::vector<std::pair<std::vector<int>, std::vector<float>>> token_and_weights,
                                              int clip_skip,
@@ -1084,100 +1084,62 @@ struct FluxCLIPEmbedder : public Conditioner {
         auto& t5_tokens      = token_and_weights[1].first;
         auto& t5_weights     = token_and_weights[1].second;
 
-        int64_t t0                                 = ggml_time_ms();
-        struct ggml_tensor* hidden_states          = NULL;  // [N, n_token, 4096]
-        struct ggml_tensor* chunk_hidden_states    = NULL;  // [n_token*2, 4096]
-        struct ggml_tensor* pooled                 = NULL;  // [768,]
+        int64_t t0                              = ggml_time_ms();
+        struct ggml_tensor* hidden_states       = NULL;  // [N, n_token, 4096]
+        struct ggml_tensor* chunk_hidden_states = NULL;  // [n_token, 4096]
+        struct ggml_tensor* pooled              = NULL;  // [768,]
         std::vector<float> hidden_states_vec;
 
-        size_t chunk_len_l   = 77;
-        size_t chunk_count_l = clip_l_tokens.size() / chunk_len_l;
-
-        size_t chunk_len_t5   = 256;
-        size_t chunk_count_t5 = t5_tokens.size() / chunk_len_t5;
-
-        // TODO: I believe chunk_count_l is actually bigger than chunk_count_t5 
-        // So this ignores some tokens for clip
-        size_t chunk_count = chunk_count_t5; 
-
+        size_t chunk_len   = 256;
+        size_t chunk_count = t5_tokens.size() / chunk_len;
         for (int chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
-            struct ggml_tensor* chunk_hidden_states_l  = NULL;  // [n_token, hidden_size_l]
-            struct ggml_tensor* chunk_hidden_states_t5 = NULL;  // [n_token, hidden_size_t5]
             // clip_l
-            if(chunk_idx < chunk_count_l) {
-                std::vector<int> chunk_tokens(clip_l_tokens.begin() + chunk_idx * chunk_len_l,
-                                              clip_l_tokens.begin() + (chunk_idx + 1) * chunk_len_l);
-                std::vector<float> chunk_weights(clip_l_weights.begin() + chunk_idx * chunk_len_l,
-                                                 clip_l_weights.begin() + (chunk_idx + 1) * chunk_len_l);
+            if (chunk_idx == 0) {
+                size_t chunk_len_l = 77;
+                std::vector<int> chunk_tokens(clip_l_tokens.begin(),
+                                              clip_l_tokens.begin() + chunk_len_l);
+                std::vector<float> chunk_weights(clip_l_weights.begin(),
+                                                 clip_l_weights.begin() + chunk_len_l);
 
                 auto input_ids       = vector_to_ggml_tensor_i32(work_ctx, chunk_tokens);
                 size_t max_token_idx = 0;
 
+                auto it = std::find(chunk_tokens.begin(), chunk_tokens.end(), clip_l_tokenizer.EOS_TOKEN_ID);
+                max_token_idx = std::min<size_t>(std::distance(chunk_tokens.begin(), it), chunk_tokens.size() - 1);
+                LOG_INFO("max_token_idx = %d",max_token_idx);
+                
                 clip_l->compute(n_threads,
                                 input_ids,
                                 0,
                                 NULL,
                                 max_token_idx,
-                                false,
-                                &chunk_hidden_states_l,
+                                true,
+                                &pooled,
                                 work_ctx);
-                {
-                    auto tensor         = chunk_hidden_states_l;
-                    float original_mean = ggml_tensor_mean(tensor);
-                    for (int i2 = 0; i2 < tensor->ne[2]; i2++) {
-                        for (int i1 = 0; i1 < tensor->ne[1]; i1++) {
-                            for (int i0 = 0; i0 < tensor->ne[0]; i0++) {
-                                float value = ggml_tensor_get_f32(tensor, i0, i1, i2);
-                                value *= chunk_weights[i1];
-                                ggml_tensor_set_f32(tensor, value, i0, i1, i2);
-                            }
-                        }
-                    }
-                    float new_mean = ggml_tensor_mean(tensor);
-                    ggml_tensor_scale(tensor, (original_mean / new_mean));
-                }
-                if (chunk_idx == 0) {
-                    std::vector<int> chunk_tokens(clip_l_tokens.begin(),
-                                                clip_l_tokens.begin() + chunk_len_l);
-                    std::vector<float> chunk_weights(clip_l_weights.begin(),
-                                                    clip_l_weights.begin() + chunk_len_l);
 
-                    auto input_ids       = vector_to_ggml_tensor_i32(work_ctx, chunk_tokens);
-                    size_t max_token_idx = 0;
+                LOG_INFO("pooled->ne = [%d, %d, %d, %d] ",pooled->ne[0], pooled->ne[1], pooled->ne[2], pooled->ne[3]);
 
-                    // auto it = std::find(chunk_tokens.begin(), chunk_tokens.end(), clip_l_tokenizer.EOS_TOKEN_ID);
-                    // max_token_idx = std::min<size_t>(std::distance(chunk_tokens.begin(), it), chunk_tokens.size() - 1);
-                    // clip_l->compute(n_threads,
-                    //                 input_ids,
-                    //                 0,
-                    //                 NULL,
-                    //                 max_token_idx,
-                    //                 true,
-                    //                 &pooled,
-                    //                 work_ctx);
-
-                    // clip_l.transformer.text_model.text_projection no in file, ignore
-                    // TODO: use torch.eye(embed_dim) as default clip_l.transformer.text_model.text_projection
-                    pooled = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 768);
-                    ggml_set_f32(pooled, 0.f);
-                }
+                // clip_l.transformer.text_model.text_projection no in file, ignore
+                // TODO: use torch.eye(embed_dim) as default clip_l.transformer.text_model.text_projection
+                // pooled = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 768);
+                // ggml_set_f32(pooled, 0.f);
             }
 
             // t5
-            if(chunk_idx < chunk_count_t5) {
-                std::vector<int> chunk_tokens(t5_tokens.begin() + chunk_idx * chunk_len_t5,
-                                              t5_tokens.begin() + (chunk_idx + 1) * chunk_len_t5);
-                std::vector<float> chunk_weights(t5_weights.begin() + chunk_idx * chunk_len_t5,
-                                                 t5_weights.begin() + (chunk_idx + 1) * chunk_len_t5);
+            {
+                std::vector<int> chunk_tokens(t5_tokens.begin() + chunk_idx * chunk_len,
+                                              t5_tokens.begin() + (chunk_idx + 1) * chunk_len);
+                std::vector<float> chunk_weights(t5_weights.begin() + chunk_idx * chunk_len,
+                                                 t5_weights.begin() + (chunk_idx + 1) * chunk_len);
 
                 auto input_ids = vector_to_ggml_tensor_i32(work_ctx, chunk_tokens);
 
                 t5->compute(n_threads,
                             input_ids,
-                            &chunk_hidden_states_t5,
+                            &chunk_hidden_states,
                             work_ctx);
                 {
-                    auto tensor         = chunk_hidden_states_t5;
+                    auto tensor         = chunk_hidden_states;
                     float original_mean = ggml_tensor_mean(tensor);
                     for (int i2 = 0; i2 < tensor->ne[2]; i2++) {
                         for (int i1 = 0; i1 < tensor->ne[1]; i1++) {
@@ -1193,33 +1155,6 @@ struct FluxCLIPEmbedder : public Conditioner {
                 }
             }
 
-
-            // TODO: Maybe there's a better way to do the padding?
-            auto chunk_hidden_states_l_pad = ggml_new_tensor_3d(work_ctx,
-                                                                 chunk_hidden_states_l->type,
-                                                                 4096,
-                                                                 chunk_hidden_states_l->ne[1],
-                                                                 chunk_hidden_states_l->ne[2]);  // [n_token, 4096]
-
-            for (int i2 = 0; i2 < chunk_hidden_states_l_pad->ne[2]; i2++) {
-                for (int i1 = 0; i1 < chunk_hidden_states_l_pad->ne[1]; i1++) {
-                    for (int i0 = 0; i0 < chunk_hidden_states_l_pad->ne[0]; i0++) {
-                        float value = 0.f;
-                        if (i0 < chunk_hidden_states_l->ne[0]) {
-                            value = ggml_tensor_get_f32(chunk_hidden_states_l, i0, i1, i2);
-                        }
-                        ggml_tensor_set_f32(chunk_hidden_states_l_pad, value, i0, i1, i2);
-                    }
-                }
-            }
-            
-            if(chunk_hidden_states_t5 == NULL){
-                chunk_hidden_states = chunk_hidden_states_l_pad;
-            } else {
-                chunk_hidden_states = ggml_tensor_concat(work_ctx, chunk_hidden_states_l_pad, chunk_hidden_states_t5, 1);  // [n_token*2, 4096]
-            }
-
-            
             int64_t t1 = ggml_time_ms();
             LOG_DEBUG("computing condition graph completed, taking %" PRId64 " ms", t1 - t0);
             if (force_zero_embeddings) {

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -809,10 +809,6 @@ struct SD3CLIPEmbedder : public Conditioner {
                                     &pooled_l,
                                     work_ctx);
 
-                    // clip_l.transformer.text_model.text_projection no in file, ignore
-                    // TODO: use torch.eye(embed_dim) as default clip_l.transformer.text_model.text_projection
-                    // pooled_l = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 768);
-                    // ggml_set_f32(pooled_l, 0.f);
                 }
             }
 
@@ -862,11 +858,7 @@ struct SD3CLIPEmbedder : public Conditioner {
                                     true,
                                     &pooled_g,
                                     work_ctx);
-                    // clip_l.transformer.text_model.text_projection no in file, ignore pooled_g too
 
-                    // TODO: fix pooled_g
-                    // pooled_g = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 1280);
-                    // ggml_set_f32(pooled_g, 0.f);
                 }
             }
 
@@ -1116,10 +1108,6 @@ struct FluxCLIPEmbedder : public Conditioner {
                                 &pooled,
                                 work_ctx);
 
-                // clip_l.transformer.text_model.text_projection no in file, ignore
-                // TODO: use torch.eye(embed_dim) as default clip_l.transformer.text_model.text_projection
-                // pooled = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 768);
-                // ggml_set_f32(pooled, 0.f);
             }
 
             // t5

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -1065,7 +1065,7 @@ struct FluxCLIPEmbedder : public Conditioner {
         return {{clip_l_tokens, clip_l_weights}, {t5_tokens, t5_weights}};
     }
 
-      SDCondition get_learned_condition_common(ggml_context* work_ctx,
+    SDCondition get_learned_condition_common(ggml_context* work_ctx,
                                              int n_threads,
                                              std::vector<std::pair<std::vector<int>, std::vector<float>>> token_and_weights,
                                              int clip_skip,

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -1096,9 +1096,7 @@ struct FluxCLIPEmbedder : public Conditioner {
         size_t chunk_len_t5   = 256;
         size_t chunk_count_t5 = t5_tokens.size() / chunk_len_t5;
 
-        // TODO: I believe chunk_count_l is actually bigger than chunk_count_t5 
-        // So this ignores some tokens for clip
-        size_t chunk_count = chunk_count_t5; 
+        size_t chunk_count = std::max(chunk_count_t5, chunk_count_l); 
 
         for (int chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
             struct ggml_tensor* chunk_hidden_states_l  = NULL;  // [n_token, hidden_size_l]

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -798,21 +798,21 @@ struct SD3CLIPEmbedder : public Conditioner {
                 }
 
                 if (chunk_idx == 0) {
-                    // auto it = std::find(chunk_tokens.begin(), chunk_tokens.end(), clip_l_tokenizer.EOS_TOKEN_ID);
-                    // max_token_idx = std::min<size_t>(std::distance(chunk_tokens.begin(), it), chunk_tokens.size() - 1);
-                    // clip_l->compute(n_threads,
-                    //                 input_ids,
-                    //                 0,
-                    //                 NULL,
-                    //                 max_token_idx,
-                    //                 true,
-                    //                 &pooled_l,
-                    //                 work_ctx);
+                    auto it = std::find(chunk_tokens.begin(), chunk_tokens.end(), clip_l_tokenizer.EOS_TOKEN_ID);
+                    max_token_idx = std::min<size_t>(std::distance(chunk_tokens.begin(), it), chunk_tokens.size() - 1);
+                    clip_l->compute(n_threads,
+                                    input_ids,
+                                    0,
+                                    NULL,
+                                    max_token_idx,
+                                    true,
+                                    &pooled_l,
+                                    work_ctx);
 
                     // clip_l.transformer.text_model.text_projection no in file, ignore
                     // TODO: use torch.eye(embed_dim) as default clip_l.transformer.text_model.text_projection
-                    pooled_l = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 768);
-                    ggml_set_f32(pooled_l, 0.f);
+                    // pooled_l = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 768);
+                    // ggml_set_f32(pooled_l, 0.f);
                 }
             }
 
@@ -852,21 +852,21 @@ struct SD3CLIPEmbedder : public Conditioner {
                 }
 
                 if (chunk_idx == 0) {
-                    // auto it = std::find(chunk_tokens.begin(), chunk_tokens.end(), clip_g_tokenizer.EOS_TOKEN_ID);
-                    // max_token_idx = std::min<size_t>(std::distance(chunk_tokens.begin(), it), chunk_tokens.size() - 1);
-                    // clip_g->compute(n_threads,
-                    //                 input_ids,
-                    //                 0,
-                    //                 NULL,
-                    //                 max_token_idx,
-                    //                 true,
-                    //                 &pooled_g,
-                    //                 work_ctx);
+                    auto it = std::find(chunk_tokens.begin(), chunk_tokens.end(), clip_g_tokenizer.EOS_TOKEN_ID);
+                    max_token_idx = std::min<size_t>(std::distance(chunk_tokens.begin(), it), chunk_tokens.size() - 1);
+                    clip_g->compute(n_threads,
+                                    input_ids,
+                                    0,
+                                    NULL,
+                                    max_token_idx,
+                                    true,
+                                    &pooled_g,
+                                    work_ctx);
                     // clip_l.transformer.text_model.text_projection no in file, ignore pooled_g too
 
                     // TODO: fix pooled_g
-                    pooled_g = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 1280);
-                    ggml_set_f32(pooled_g, 0.f);
+                    // pooled_g = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 1280);
+                    // ggml_set_f32(pooled_g, 0.f);
                 }
             }
 

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -1096,7 +1096,9 @@ struct FluxCLIPEmbedder : public Conditioner {
         size_t chunk_len_t5   = 256;
         size_t chunk_count_t5 = t5_tokens.size() / chunk_len_t5;
 
-        size_t chunk_count = std::max(chunk_count_t5, chunk_count_l); 
+        // TODO: I believe chunk_count_l is actually bigger than chunk_count_t5 
+        // So this ignores some tokens for clip
+        size_t chunk_count = chunk_count_t5; 
 
         for (int chunk_idx = 0; chunk_idx < chunk_count; chunk_idx++) {
             struct ggml_tensor* chunk_hidden_states_l  = NULL;  // [n_token, hidden_size_l]

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -1206,7 +1206,7 @@ struct FluxCLIPEmbedder : public Conditioner {
                 }
             }
 
-            chunk_hidden_states = ggml_tensor_concat(work_ctx, chunk_hidden_states_l, chunk_hidden_states_t5, 1);  // [n_token*2, 4096]
+            chunk_hidden_states = ggml_tensor_concat(work_ctx, chunk_hidden_states_l_pad, chunk_hidden_states_t5, 1);  // [n_token*2, 4096]
 
             
             int64_t t1 = ggml_time_ms();

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -1106,7 +1106,6 @@ struct FluxCLIPEmbedder : public Conditioner {
 
                 auto it = std::find(chunk_tokens.begin(), chunk_tokens.end(), clip_l_tokenizer.EOS_TOKEN_ID);
                 max_token_idx = std::min<size_t>(std::distance(chunk_tokens.begin(), it), chunk_tokens.size() - 1);
-                LOG_INFO("max_token_idx = %d",max_token_idx);
                 
                 clip_l->compute(n_threads,
                                 input_ids,
@@ -1116,8 +1115,6 @@ struct FluxCLIPEmbedder : public Conditioner {
                                 true,
                                 &pooled,
                                 work_ctx);
-
-                LOG_INFO("pooled->ne = [%d, %d, %d, %d] ",pooled->ne[0], pooled->ne[1], pooled->ne[2], pooled->ne[3]);
 
                 // clip_l.transformer.text_model.text_projection no in file, ignore
                 // TODO: use torch.eye(embed_dim) as default clip_l.transformer.text_model.text_projection


### PR DESCRIPTION
Fixes #396 

I made the clip backend skip the last text projection if the `text_projection` tensor doesn't exist This is mathematically equaivalent to replacing the `text_projection` with the identity matrix (aka `torch.eye()`).
Also replaced the matrix multiplication with a biasless linear layer when `text_projection` exists (somehow this changes the outcome).

### Flux.1 Schnell (q3_k): 
|  | clip-L |  ViT-L-14 |
| - | - | - |
| master | ![test-schnell-clip](https://github.com/user-attachments/assets/fdfab0f1-4160-4174-93bf-e4aedecfbef2) | ![test-schnell-vit](https://github.com/user-attachments/assets/77f9bb03-26c5-4f0a-a1d5-c0685e5193bf) |
| PR | ![test-schnell-clip](https://github.com/user-attachments/assets/1349f00e-b6ed-4780-aaeb-bf0144b0f3fd) | ![test-schnell-vit](https://github.com/user-attachments/assets/fc566964-04ad-4cb1-8438-28f1a5d8d9f9) |


### SD3 2B (q8_0):
| Master | PR |
| - | - |
| ![sd3-master](https://github.com/user-attachments/assets/3efbf7c3-bf4b-4b0f-a0ba-9f05083506e2) | ![output](https://github.com/user-attachments/assets/5a3c7013-0f87-4489-84a2-01e205080b21) |

### SD3.5 Large Turbo (q4_1)

| Master | PR |
| - | - |
| ![output](https://github.com/user-attachments/assets/a0978348-ad7a-4669-a5fa-1333efde3ce7) | ![output](https://github.com/user-attachments/assets/89e2aa31-2c3b-4a05-9e8a-321f1ed2b09d) |
