### PR TITLE
Model: Warn users if diffusion-model tensors names are already prefixed 

### DIFF
--- a/model.cpp
+++ b/model.cpp
@@ -921,9 +921,9 @@ bool ModelLoader::init_from_gguf_file(const std::string& file_path, const std::s
         struct ggml_tensor* dummy = ggml_get_tensor(ctx_meta_, name.c_str());
         size_t offset             = data_offset + gguf_get_tensor_offset(ctx_gguf_, i);
 
-        if(i==0 && starts_with(name,prefix)){
-            LOG_WARN("Tensors have built-in %s prefix.\n", prefix.c_str());
-            if(prefix == "model.diffusion_model."){
+        if (!prefix.empty() && i == 0 && starts_with(name, prefix)) {
+            LOG_WARN("Tensors have built-in \"%s\" prefix.\n", prefix.c_str());
+            if (prefix == "model.diffusion_model.") {
                 // the user probably used `--diffusion-model` instead of `-m`
                 LOG_WARN("Try using `-m`or `--model` instead of `--diffusion-model`\n");
             }
@@ -1009,7 +1009,7 @@ bool ModelLoader::init_from_safetensors_file(const std::string& file_path, const
 
     nlohmann::json header_ = nlohmann::json::parse(header_buf.data());
 
-    int i =0;
+    int i = 0;
     for (auto& item : header_.items()) {
         std::string name           = item.key();
         nlohmann::json tensor_info = item.value();
@@ -1060,9 +1060,9 @@ bool ModelLoader::init_from_safetensors_file(const std::string& file_path, const
             n_dims = 1;
         }
 
-        if(i++==0 && starts_with(name,prefix)){
-            LOG_WARN("Tensors have built-in %s prefix.\n", prefix.c_str());
-            if(prefix == "model.diffusion_model."){
+        if (!prefix.empty() && i++ == 0 && starts_with(name, prefix)) {
+            LOG_WARN("Tensors have built-in \"%s\" prefix.\n", prefix.c_str());
+            if (prefix == "model.diffusion_model.") {
                 // the user probably used `--diffusion-model` instead of `-m`
                 LOG_WARN("Try using `-m`or `--model` instead of `--diffusion-model`\n");
             }
@@ -1451,9 +1451,9 @@ bool ModelLoader::init_from_ckpt_file(const std::string& file_path, const std::s
         {
             std::string name = zip_entry_name(zip);
             size_t pos       = name.find("data.pkl");
-            if(i==0 && starts_with(name,prefix)){
-                LOG_WARN("Tensors have built-in %s prefix.\n", prefix.c_str());
-                if(prefix == "model.diffusion_model."){
+            if (!prefix.empty() && i == 0 && starts_with(name, prefix)) {
+                LOG_WARN("Tensors have built-in \"%s\" prefix.\n", prefix.c_str());
+                if (prefix == "model.diffusion_model.") {
                     // the user probably used `--diffusion-model` instead of `-m`
                     LOG_WARN("Try using `-m`or `--model` instead of `--diffusion-model`\n");
                 }

--- a/model.cpp
+++ b/model.cpp
@@ -922,7 +922,7 @@ bool ModelLoader::init_from_gguf_file(const std::string& file_path, const std::s
         size_t offset             = data_offset + gguf_get_tensor_offset(ctx_gguf_, i);
 
         if(i==0 && starts_with(name,prefix)){
-            LOG_WARN("Tensors have built-in %s prefix.\n", prefix);
+            LOG_WARN("Tensors have built-in %s prefix.\n", prefix.c_str());
             if(prefix == "model.diffusion_model."){
                 // the user probably used `--diffusion-model` instead of `-m`
                 LOG_WARN("Try using `-m`or `--model` instead of `--diffusion-model`\n");
@@ -1061,7 +1061,7 @@ bool ModelLoader::init_from_safetensors_file(const std::string& file_path, const
         }
 
         if(i++==0 && starts_with(name,prefix)){
-            LOG_WARN("Tensors have built-in %s prefix.\n", prefix);
+            LOG_WARN("Tensors have built-in %s prefix.\n", prefix.c_str());
             if(prefix == "model.diffusion_model."){
                 // the user probably used `--diffusion-model` instead of `-m`
                 LOG_WARN("Try using `-m`or `--model` instead of `--diffusion-model`\n");
@@ -1452,7 +1452,7 @@ bool ModelLoader::init_from_ckpt_file(const std::string& file_path, const std::s
             std::string name = zip_entry_name(zip);
             size_t pos       = name.find("data.pkl");
             if(i==0 && starts_with(name,prefix)){
-                LOG_WARN("Tensors have built-in %s prefix.\n", prefix);
+                LOG_WARN("Tensors have built-in %s prefix.\n", prefix.c_str());
                 if(prefix == "model.diffusion_model."){
                     // the user probably used `--diffusion-model` instead of `-m`
                     LOG_WARN("Try using `-m`or `--model` instead of `--diffusion-model`\n");


### PR DESCRIPTION
Fixes https://github.com/leejet/stable-diffusion.cpp/issues/434
Related to https://github.com/leejet/stable-diffusion.cpp/pull/403

Warn users if the model needs to be loaded using `--model` instead of `--diffusion-model`