### PR TITLE
Convert: mixed k-quant with legacy quant fallback

### DIFF
--- a/model.h
+++ b/model.h
@@ -157,12 +157,14 @@ public:
     bool load_tensors(std::map<std::string, struct ggml_tensor*>& tensors,
                       ggml_backend_t backend,
                       std::set<std::string> ignore_tensors = {});
-    bool save_to_gguf_file(const std::string& file_path, ggml_type type);
+    bool save_to_gguf_file(const std::string& file_path, ggml_type type, ggml_type fallback_type = GGML_TYPE_COUNT);
     bool tensor_should_be_converted(const TensorStorage& tensor_storage, ggml_type type);
-    int64_t get_params_mem_size(ggml_backend_t backend, ggml_type type = GGML_TYPE_COUNT);
+    bool tensor_can_be_converted(const TensorStorage& tensor_storage, ggml_type type);
+    int64_t get_params_mem_size(ggml_backend_t backend, ggml_type type = GGML_TYPE_COUNT, ggml_type fallback_type = GGML_TYPE_COUNT);
     ~ModelLoader() = default;
+    void tensor_set_type(ggml_type& tensor_type, const TensorStorage& tensor_storage, ggml_type type = GGML_TYPE_COUNT, ggml_type fallback_type = GGML_TYPE_COUNT);
 
-    static std::string load_merges();
+        static std::string load_merges();
     static std::string load_t5_tokenizer_json();
 };
 

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -208,7 +208,7 @@ SD_API void free_upscaler_ctx(upscaler_ctx_t* upscaler_ctx);
 
 SD_API sd_image_t upscale(upscaler_ctx_t* upscaler_ctx, sd_image_t input_image, uint32_t upscale_factor);
 
-SD_API bool convert(const char* input_path, const char* vae_path, const char* output_path, enum sd_type_t output_type);
+SD_API bool convert(const char* input_path, const char* vae_path, const char* output_path, enum sd_type_t output_type, enum sd_type_t fallback_type = SD_TYPE_COUNT);
 
 SD_API uint8_t* preprocess_canny(uint8_t* img,
                                  int width,


### PR DESCRIPTION
Adds a new cli argument: `--fallback-type`.

If tensors cannot be quantized to a k-quant because of block size issues, the fallback type will be used instead of full precision.

Very useful for SD3.5 models, because 90% of SD3.5 8B weights can't be quantized to k quants.

`--type q4_k --fallback-type q4_0` has always the exact same output size as  `--type q4_0`, but with less degradation.

Somewhat adresses https://github.com/leejet/stable-diffusion.cpp/issues/446