### PR TITLE
Refactor: Replace manual memory management with smart pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ add_subdirectory(thirdparty)
 
 target_link_libraries(${SD_LIB} PUBLIC ggml zip)
 target_include_directories(${SD_LIB} PUBLIC . thirdparty)
-target_compile_features(${SD_LIB} PUBLIC cxx_std_11)
+target_compile_features(${SD_LIB} PUBLIC cxx_std_14)
 
 
 if (SD_BUILD_EXAMPLES)


### PR DESCRIPTION
Replaced all `malloc`/`free` calls with `std::unique_ptr` to leverage RAII for memory management. Used custom deleters where needed to handle specific free functions, such as `stbi_image_free` and `free_sd_ctx`. Simplified resource cleanup by removing explicit `free` calls, reducing the risk of memory leaks and improving code readability. Adjusted function calls to align with smart pointer usage, ensuring compatibility and preventing raw pointer access