### PR TITLE
Ability to split model components to different backend devices

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -5,6 +5,7 @@
 #include <random>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 // #include "preprocessing.hpp"
 #include "flux.hpp"
@@ -119,6 +120,10 @@ struct SDParams {
     bool canny_preprocess         = false;
     bool color                    = false;
     int upscale_repeats           = 1;
+    
+    int model_backend_index = -1;
+    int clip_backend_index = -1;
+    int vae_backend_index = -1;
 };
 
 void print_params(SDParams params) {
@@ -164,6 +169,9 @@ void print_params(SDParams params) {
     printf("    batch_count:       %d\n", params.batch_count);
     printf("    vae_tiling:        %s\n", params.vae_tiling ? "true" : "false");
     printf("    upscale_repeats:   %d\n", params.upscale_repeats);
+    printf("	model_backend_index %d\n", params.model_backend_index);
+    printf("	clip_backend_index %d\n", params.clip_backend_index);
+    printf("	vae_backend_index  %d\n", params.vae_backend_index);
 }
 
 void print_usage(int argc, const char* argv[]) {
@@ -219,6 +227,9 @@ void print_usage(int argc, const char* argv[]) {
     printf("  --canny                            apply canny preprocessor (edge detection)\n");
     printf("  --color                            Colors the logging tags according to level\n");
     printf("  -v, --verbose                      print extra info\n");
+    printf("  --model-backend-index              specify which device the model defaults to using\n");
+	printf("  --clip-backend-index               specify which device the CLIP model uses\n");
+    printf("  --vae-backend-index                specify which device the VAE model uses\n");
 }
 
 void parse_args(int argc, const char** argv, SDParams& params) {
@@ -534,7 +545,14 @@ void parse_args(int argc, const char** argv, SDParams& params) {
             params.verbose = true;
         } else if (arg == "--color") {
             params.color = true;
-        } else {
+        }
+        else if (arg == "--model-backend-index") {
+			params.model_backend_index = std::stoi(argv[++i]);
+		} else if (arg == "--clip-backend-index") {
+			params.clip_backend_index = std::stoi(argv[++i]);
+		} else if (arg == "--vae-backend-index") {
+			params.vae_backend_index = std::stoi(argv[++i]);
+		} else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
             print_usage(argc, argv);
             exit(1);
@@ -791,7 +809,10 @@ int main(int argc, const char* argv[]) {
                                   params.schedule,
                                   params.clip_on_cpu,
                                   params.control_net_cpu,
-                                  params.vae_on_cpu);
+                                  params.vae_on_cpu,
+                                  params.model_backend_index,
+                                  params.clip_backend_index,
+								  params.vae_backend_index);
 
     if (sd_ctx == NULL) {
         printf("new_sd_ctx_t failed\n");

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -5,7 +5,6 @@
 #include <random>
 #include <string>
 #include <vector>
-#include <stdexcept>
 
 // #include "preprocessing.hpp"
 #include "flux.hpp"

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -123,8 +123,8 @@ public:
         } else if (rng_type == CUDA_RNG) {
             rng = std::make_shared<PhiloxRNG>();
         }
-    }					
-	
+    }
+
     ~StableDiffusionGGML() {
         if (clip_backend != backend) {
             ggml_backend_free(clip_backend);
@@ -171,16 +171,15 @@ public:
 #ifdef SD_USE_VULKAN
         LOG_DEBUG("Using Vulkan backend");
         if (model_backend_index == -1) {
-			// default behavior, last device selected
-			for (int device = 0; device < ggml_backend_vk_get_device_count(); ++device) {
-				backend = ggml_backend_vk_init(device);
-			}
-			if (!backend) {
-				LOG_WARN("Failed to initialize Vulkan backend");
-			}
-		} else {
-			backend = ggml_backend_vk_init(model_backend_index);
+		// default behavior, use last device selected
+		int device = ggml_backend_vk_get_device_count() - 1;
+		backend = ggml_backend_vk_init(device);
+		if (!backend) {
+			LOG_WARN("Failed to initialize Vulkan backend");
 		}
+	} else {
+		backend = ggml_backend_vk_init(model_backend_index);
+	}
 #endif
 #ifdef SD_USE_SYCL
         LOG_DEBUG("Using SYCL backend");

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -143,9 +143,9 @@ SD_API sd_ctx_t* new_sd_ctx(const char* model_path,
                             bool keep_clip_on_cpu,
                             bool keep_control_net_cpu,
                             bool keep_vae_on_cpu,
-                            int model_backend_index = -1,
-                            int clip_backend_index = -1,
-							int vae_backend_index = -1);
+                            int model_backend_index,
+                            int clip_backend_index,
+			    int vae_backend_index);
 
 SD_API void free_sd_ctx(sd_ctx_t* sd_ctx);
 

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -142,7 +142,10 @@ SD_API sd_ctx_t* new_sd_ctx(const char* model_path,
                             enum schedule_t s,
                             bool keep_clip_on_cpu,
                             bool keep_control_net_cpu,
-                            bool keep_vae_on_cpu);
+                            bool keep_vae_on_cpu,
+                            int model_backend_index = -1,
+                            int clip_backend_index = -1,
+							int vae_backend_index = -1);
 
 SD_API void free_sd_ctx(sd_ctx_t* sd_ctx);
 


### PR DESCRIPTION
The ability to specify separate backend device indexes for CLIP, Unet, and VAE was implemented. This works for all backends that accept a device index as an initialization parameter (CUDA, Vulkan, and SYCL.) The aim of this was to support splitting the parts of the model across multiple GPUs.