### PR TITLE
vae tiling improvements: encoding support and adaptative overlap 

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,9 @@ arguments:
   --clip-skip N                      ignore last_dot_pos layers of CLIP network; 1 ignores none, 2 ignores one layer (default: -1)
                                      <= 0 represents unspecified, will be 1 for SD1.x, 2 for SD2.x
   --vae-tiling                       process vae in tiles to reduce memory usage
+  --vae-tile-size [X]x[Y]            tile size for vae tiling (default: 32x32)
+  --vae-relative-tile-size [X]x[Y]   relative tile size for vae tiling, in fraction of image size if < 1, in number of tiles per dim if >=1 (overrides --vae-tile-size)
+  --vae-tile-overlap OVERLAP         tile overlap for vae tiling, in fraction of tile size (default: 0.5)
   --vae-on-cpu                       keep vae in cpu (for low vram)
   --clip-on-cpu                      keep clip in cpu (for low vram)
   --diffusion-fa                     use flash attention in the diffusion model (for low vram)

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -118,7 +118,7 @@ struct SDParams {
     int chroma_t5_mask_pad   = 1;
     float flow_shift         = INFINITY;
 
-    sd_tiling_params_t vae_tiling_params = {false, 32, 32, 0.5f, false, 0.0f, 0.0f};
+    sd_tiling_params_t vae_tiling_params = {false, 0, 0, 0.5f, 0.0f, 0.0f};
 
     SDParams() {
         sd_sample_params_init(&sample_params);
@@ -749,7 +749,6 @@ void parse_args(int argc, const char** argv, SDParams& params) {
         } catch (const std::out_of_range& e) {
             return -1;
         }
-        params.vae_tiling_params.relative = false;
         return 1;
     };
 
@@ -773,7 +772,6 @@ void parse_args(int argc, const char** argv, SDParams& params) {
         } catch (const std::out_of_range& e) {
             return -1;
         }
-        params.vae_tiling_params.relative = true;
         return 1;
     };
 

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -526,6 +526,7 @@ void parse_args(int argc, const char** argv, SDParams& params) {
         {"", "--control-strength", "", &params.control_strength},
         {"", "--moe-boundary", "", &params.moe_boundary},
         {"", "--flow-shift", "", &params.flow_shift},
+        {"", "--vae-tile-overlap", "", &params.vae_tiling_params.target_overlap},
     };
 
     options.bool_options = {
@@ -775,14 +776,6 @@ void parse_args(int argc, const char** argv, SDParams& params) {
         return 1;
     };
 
-    auto on_tile_overlap_arg = [&](int argc, const char** argv, int index) {
-        if (++index >= argc) {
-            return -1;
-        }
-        params.vae_tiling_params.target_overlap = std::stof(argv[index]);
-        return 1;
-    };
-
     options.manual_options = {
         {"-M", "--mode", "", on_mode_arg},
         {"", "--type", "", on_type_arg},
@@ -798,7 +791,6 @@ void parse_args(int argc, const char** argv, SDParams& params) {
         {"-h", "--help", "", on_help_arg},
         {"", "--vae-tile-size", "", on_tile_size_arg},
         {"", "--vae-relative-tile-size", "", on_relative_tile_size_arg},
-        {"", "--vae-tile-overlap", "", on_tile_overlap_arg},
     };
 
     if (!parse_options(argc, argv, options)) {

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -765,7 +765,7 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
         input_tile_size  = tile_size * scale;
         output_tile_size = tile_size;
     }
-    int num_tiles_x             = (input_width - (int)(input_tile_size * tile_overlap_factor)) / (int)(input_tile_size * (1. - tile_overlap_factor));
+    int num_tiles_x             = (input_width - (int)(input_tile_size * tile_overlap_factor)) / (int)(input_tile_size * (1 - tile_overlap_factor));
     float tile_overlap_factor_x = (float)(input_tile_size * num_tiles_x - input_width) / (float)(input_tile_size * (num_tiles_x - 1));
     if (num_tiles_x <= 1) {
         if (input_width == input_tile_size) {

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -748,8 +748,38 @@ __STATIC_INLINE__ std::vector<struct ggml_tensor*> ggml_chunk(struct ggml_contex
 
 typedef std::function<void(ggml_tensor*, ggml_tensor*, bool)> on_tile_process;
 
+__STATIC_INLINE__ void
+sd_tiling_calc_tiles(int &num_tiles_dim, float& tile_overlap_factor_dim, int small_dim, int tile_size, const float tile_overlap_factor) {
+
+    int tile_overlap     = (tile_size * tile_overlap_factor);
+    int non_tile_overlap = tile_size - tile_overlap;
+
+    num_tiles_dim = (small_dim - tile_overlap) / non_tile_overlap;
+    int overshoot_dim = ((num_tiles_dim + 1) * non_tile_overlap + tile_overlap) % small_dim;
+
+    if ((overshoot_dim != non_tile_overlap) && (overshoot_dim <= num_tiles_dim * (tile_size / 2 - tile_overlap))) {
+        // if tiles don't fit perfectly using the desired overlap
+        // and there is enough room to squeeze an extra tile without overlap becoming >0.5
+        num_tiles_dim++;
+    }
+
+    tile_overlap_factor_dim = (float)(tile_size * num_tiles_dim - small_dim) / (float)(tile_size * (num_tiles_dim - 1));
+    if (num_tiles_dim <= 2) {
+        if (small_dim <= tile_size) {
+            num_tiles_dim           = 1;
+            tile_overlap_factor_dim = 0;
+        } else {
+            num_tiles_dim           = 2;
+            tile_overlap_factor_dim = (2 * tile_size - small_dim) / (float)tile_size;
+        }
+    }
+}
+
 // Tiling
-__STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const int scale, const int tile_size, const float tile_overlap_factor, on_tile_process on_processing) {
+__STATIC_INLINE__ void sd_tiling_non_square(ggml_tensor* input, ggml_tensor* output, const int scale,
+                                            const int p_tile_size_x, const int p_tile_size_y,
+                                            const float tile_overlap_factor, on_tile_process on_processing) {
+
     output = ggml_set_f32(output, 0);
 
     int input_width   = (int)input->ne[0];
@@ -770,62 +800,27 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
         small_height = input_height;
     }
 
-    int tile_overlap     = (tile_size * tile_overlap_factor);
-    int non_tile_overlap = tile_size - tile_overlap;
+    int num_tiles_x;
+    float tile_overlap_factor_x;
+    sd_tiling_calc_tiles(num_tiles_x, tile_overlap_factor_x, small_width, p_tile_size_x, tile_overlap_factor);
 
-    int num_tiles_x = (small_width - tile_overlap) / non_tile_overlap;
-    int overshoot_x = ((num_tiles_x + 1) * non_tile_overlap + tile_overlap) % small_width;
-
-    if ((overshoot_x != non_tile_overlap) && (overshoot_x <= num_tiles_x * (tile_size / 2 - tile_overlap))) {
-        // if tiles don't fit perfectly using the desired overlap
-        // and there is enough room to squeeze an extra tile without overlap becoming >0.5
-        num_tiles_x++;
-    }
-
-    float tile_overlap_factor_x = (float)(tile_size * num_tiles_x - small_width) / (float)(tile_size * (num_tiles_x - 1));
-    if (num_tiles_x <= 2) {
-        if (small_width <= tile_size) {
-            num_tiles_x           = 1;
-            tile_overlap_factor_x = 0;
-        } else {
-            num_tiles_x           = 2;
-            tile_overlap_factor_x = (2 * tile_size - small_width) / (float)tile_size;
-        }
-    }
-
-    int num_tiles_y = (small_height - tile_overlap) / non_tile_overlap;
-    int overshoot_y = ((num_tiles_y + 1) * non_tile_overlap + tile_overlap) % small_height;
-
-    if ((overshoot_y != non_tile_overlap) && (overshoot_y <= num_tiles_y * (tile_size / 2 - tile_overlap))) {
-        // if tiles don't fit perfectly using the desired overlap
-        // and there is enough room to squeeze an extra tile without overlap becoming >0.5
-        num_tiles_y++;
-    }
-
-    float tile_overlap_factor_y = (float)(tile_size * num_tiles_y - small_height) / (float)(tile_size * (num_tiles_y - 1));
-    if (num_tiles_y <= 2) {
-        if (small_height <= tile_size) {
-            num_tiles_y           = 1;
-            tile_overlap_factor_y = 0;
-        } else {
-            num_tiles_y           = 2;
-            tile_overlap_factor_y = (2 * tile_size - small_height) / (float)tile_size;
-        }
-    }
+    int num_tiles_y;
+    float tile_overlap_factor_y;
+    sd_tiling_calc_tiles(num_tiles_y, tile_overlap_factor_y, small_height, p_tile_size_y, tile_overlap_factor);
 
     LOG_DEBUG("num tiles : %d, %d ", num_tiles_x, num_tiles_y);
     LOG_DEBUG("optimal overlap : %f, %f (targeting %f)", tile_overlap_factor_x, tile_overlap_factor_y, tile_overlap_factor);
 
     GGML_ASSERT(input_width % 2 == 0 && input_height % 2 == 0 && output_width % 2 == 0 && output_height % 2 == 0);  // should be multiple of 2
 
-    int tile_overlap_x     = (int32_t)(tile_size * tile_overlap_factor_x);
-    int non_tile_overlap_x = tile_size - tile_overlap_x;
+    int tile_overlap_x     = (int32_t)(p_tile_size_x * tile_overlap_factor_x);
+    int non_tile_overlap_x = p_tile_size_x - tile_overlap_x;
 
-    int tile_overlap_y     = (int32_t)(tile_size * tile_overlap_factor_y);
-    int non_tile_overlap_y = tile_size - tile_overlap_y;
+    int tile_overlap_y     = (int32_t)(p_tile_size_y * tile_overlap_factor_y);
+    int non_tile_overlap_y = p_tile_size_y - tile_overlap_y;
 
-    int tile_size_x = tile_size < small_width ? tile_size : small_width;
-    int tile_size_y = tile_size < small_height ? tile_size : small_height;
+    int tile_size_x = p_tile_size_x < small_width ? p_tile_size_x : small_width;
+    int tile_size_y = p_tile_size_y < small_height ? p_tile_size_y : small_height;
 
     int input_tile_size_x  = tile_size_x;
     int input_tile_size_y  = tile_size_y;
@@ -912,6 +907,11 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
         pretty_progress(num_tiles, num_tiles, last_time);
     }
     ggml_free(tiles_ctx);
+}
+
+__STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const int scale,
+    const int tile_size, const float tile_overlap_factor, on_tile_process on_processing) {
+    sd_tiling_non_square(input, output, scale, tile_size, tile_size, tile_overlap_factor, on_processing);
 }
 
 __STATIC_INLINE__ struct ggml_tensor* ggml_group_norm_32(struct ggml_context* ctx,

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -779,7 +779,7 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
 
     float tile_overlap_factor_x = (float)(input_tile_size * num_tiles_x - input_width) / (float)(input_tile_size * (num_tiles_x - 1));
     if (num_tiles_x <= 2) {
-        if (input_width == input_tile_size) {
+        if (input_width <= input_tile_size) {
             num_tiles_x           = 1;
             tile_overlap_factor_x = 0;
         } else {
@@ -799,7 +799,7 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
 
     float tile_overlap_factor_y = (float)(input_tile_size * num_tiles_y - input_height) / (float)(input_tile_size * (num_tiles_y - 1));
     if (num_tiles_y <= 2) {
-        if (input_height == input_tile_size) {
+        if (input_height <= input_tile_size) {
             num_tiles_y           = 1;
             tile_overlap_factor_y = 0;
         } else {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1539,8 +1539,7 @@ public:
             int tile_size_y    = 32;
     
             get_vae_tile_overlap(tile_overlap);
-            get_vae_tile_sizes(tile_size_x, tile_size_y, tile_overlap, x->ne[0] / 8, x->ne[1] / 8);
-    
+            get_vae_tile_sizes(tile_size_x, tile_size_y, tile_overlap, x->ne[0], x->ne[1]);
             process_latent_out(x);
             // x = load_tensor_from_file(work_ctx, "wan_vae_z.bin");
             if (vae_tiling && !decode_video) {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1317,6 +1317,11 @@ public:
                 LOG_WARN("OOR");
             }
         }
+        if(!decode){
+            // TODO: also use and arg for this one?
+            // to keep the compute buffer size consistent
+            tile_size*=1.30539;
+        }
         if (!use_tiny_autoencoder) {
             process_vae_input_tensor(x);
             if (vae_tiling && !decode_video) {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1487,7 +1487,7 @@ public:
         if (!use_tiny_autoencoder) {
             float tile_overlap;
             int tile_size_x, tile_size_y;
-            get_tile_sizes(tile_size_x, tile_size_y, tile_overlap, vae_tiling_params, W, H);
+            get_tile_sizes(tile_size_x, tile_size_y, tile_overlap, vae_tiling_params, x->ne[0], x->ne[1]);
 
             LOG_DEBUG("VAE Tile size: %dx%d", tile_size_x, tile_size_y);
 

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -118,7 +118,6 @@ typedef struct {
     int tile_size_x;
     int tile_size_y;
     float target_overlap;
-    bool relative;
     float rel_size_x;
     float rel_size_y;
 } sd_tiling_params_t;

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -114,6 +114,16 @@ enum sd_log_level_t {
 };
 
 typedef struct {
+    bool enabled;
+    int tile_size_x;
+    int tile_size_y;
+    float target_overlap;
+    bool relative;
+    float rel_size_x;
+    float rel_size_y;
+} sd_tiling_params_t;
+
+typedef struct {
     const char* model_path;
     const char* clip_l_path;
     const char* clip_g_path;
@@ -128,7 +138,6 @@ typedef struct {
     const char* embedding_dir;
     const char* stacked_id_embed_dir;
     bool vae_decode_only;
-    bool vae_tiling;
     bool free_params_immediately;
     int n_threads;
     enum sd_type_t wtype;
@@ -196,6 +205,7 @@ typedef struct {
     float style_strength;
     bool normalize_input;
     const char* input_id_images_path;
+    sd_tiling_params_t vae_tiling_params;
 } sd_img_gen_params_t;
 
 typedef struct {


### PR DESCRIPTION
- Added a mechanism to automatically fix the tile overlaps in cases of mismatch between image size and tile size. 
- Added a way to change tile size for VAE decoding with the `SD_TILE_SIZE` environment variable. (tile size for vae encoding will be about 1.3x bigger, for the same memory requirement)

With these changes, vae encoding can now be tiled, and a small (unreported?) issue with the upscaler (or tae) over-brightening some parts of the image is now fixed. This could also be a step toward tiled diffusion support. 

Fixes https://github.com/leejet/stable-diffusion.cpp/issues/588,  https://github.com/leejet/stable-diffusion.cpp/issues/564 and  https://github.com/leejet/stable-diffusion.cpp/issues/666