### PR TITLE
fix(metal): remove deprecated functions

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -1138,11 +1138,6 @@ public:
             ggml_backend_cpu_set_n_threads(backend, n_threads);
         }
 
-#ifdef SD_USE_METAL
-        if (ggml_backend_is_metal(backend)) {
-            ggml_backend_metal_set_n_cb(backend, n_threads);
-        }
-#endif
         ggml_backend_graph_compute(backend, gf);
 
 #ifdef GGML_PERF

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -161,7 +161,6 @@ public:
 #endif
 #ifdef SD_USE_METAL
         LOG_DEBUG("Using Metal backend");
-        ggml_backend_metal_log_set_callback(ggml_log_callback_default, nullptr);
         backend = ggml_backend_metal_init();
 #endif
 #ifdef SD_USE_VULKAN

--- a/upscaler.cpp
+++ b/upscaler.cpp
@@ -21,7 +21,6 @@ struct UpscalerGGML {
 #endif
 #ifdef SD_USE_METAL
         LOG_DEBUG("Using Metal backend");
-        ggml_backend_metal_log_set_callback(ggml_log_callback_default, nullptr);
         backend = ggml_backend_metal_init();
 #endif
 #ifdef SD_USE_VULKAN


### PR DESCRIPTION
Some functions seems to be deprecated from ggml, but are still used and there are compiling errors.

In the CI, it works since the option `SD_METAL` is not passed to the cmake in [the command](https://github.com/leejet/stable-diffusion.cpp/blob/9578fdcc4632dc3de5565f28e2fb16b7c18f8d48/.github/workflows/build.yml#L110C1-L117C43), so the metal build is not tested.