### PR TITLE
Fix CI windows release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,13 +155,13 @@ jobs:
       matrix:
         include:
           - build: "noavx"
-            defines: "-DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DSD_BUILD_SHARED_LIBS=ON"
+            defines: "-DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DSD_BUILD_SHARED_LIBS=ON"
           - build: "avx2"
-            defines: "-DGGML_AVX2=ON -DSD_BUILD_SHARED_LIBS=ON"
+            defines: "-DGGML_NATIVE=OFF -DGGML_AVX2=ON -DSD_BUILD_SHARED_LIBS=ON"
           - build: "avx"
-            defines: "-DGGML_AVX2=OFF -DSD_BUILD_SHARED_LIBS=ON"
+            defines: "-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=OFF -DSD_BUILD_SHARED_LIBS=ON"
           - build: "avx512"
-            defines: "-DGGML_AVX512=ON -DSD_BUILD_SHARED_LIBS=ON"
+            defines: "-DGGML_NATIVE=OFF -DGGML_AVX512=ON -DGGML_AVX=ON -DGGML_AVX2=ON -DSD_BUILD_SHARED_LIBS=ON"
           - build: "cuda12"
             defines: "-DSD_CUDA=ON -DSD_BUILD_SHARED_LIBS=ON"
           # - build: "rocm5.5"


### PR DESCRIPTION
The windows noavx build causes "Illegal instruction" errors on machines which lack AVX/AVX2 support.
Also stable-diffusion.cpp reports in verbose mode the following system info:
```
System Info:
    SSE3 = 1
    AVX = 1
    AVX2 = 1
    AVX512 = 0
    AVX512_VBMI = 0
    AVX512_VNNI = 0
    FMA = 1
    NEON = 0
    ARM_FMA = 0
    F16C = 1
    FP16_VA = 0
    WASM_SIMD = 0
    VSX = 0
```
even through the machine has no AVX, AVX2, etc. support.

Depending on the github action runner the CI workflow is executed on the windows release artifacts seem to have deviating optimizations enabled.
It seems to be caused by GGML enabling `GGML_NATIVE` by default which influences the enabled optimizations according to [ggerganov/ggml/CMakeLists.txt#L96-L100](https://github.com/ggerganov/ggml/blob/6a7a034e117f189df4d13665b9b604638ddca468/CMakeLists.txt#L96-L100) and [ggerganov/ggml/CMakeLists.txt#L104-L106](https://github.com/ggerganov/ggml/blob/6a7a034e117f189df4d13665b9b604638ddca468/CMakeLists.txt#L104-L106).