### PR TITLE
cmake install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 build*/
+cmake-build-*/
 test/
 .vscode/
+.idea/
 .cache/
 *.swp
 .vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,3 +130,7 @@ if (SD_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+set(SD_PUBLIC_HEADERS stable-diffusion.h)
+set_target_properties(${SD_LIB} PROPERTIES PUBLIC_HEADER "${SD_PUBLIC_HEADERS}")
+
+install(TARGETS ${SD_LIB} LIBRARY PUBLIC_HEADER)


### PR DESCRIPTION
PR allows installing stable-diffusion.h and stable-diffusion library to specified location. Example:

```
cmake --install build --prefix ./build/app
```