### PR TITLE
The ggml logs go through SD log_printf

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -52,11 +52,23 @@
 #define __STATIC_INLINE__ static inline
 #endif
 
-__STATIC_INLINE__ void ggml_log_callback_default(ggml_log_level level, const char* text, void* user_data) {
-    (void)level;
-    (void)user_data;
-    fputs(text, stderr);
-    fflush(stderr);
+__STATIC_INLINE__ void ggml_log_callback_default(ggml_log_level level, const char* text, void*) {
+    switch (level) {
+        case GGML_LOG_LEVEL_DEBUG:
+            LOG_DEBUG(text);
+        break;
+        case GGML_LOG_LEVEL_INFO:
+            LOG_INFO(text);
+        break;
+        case GGML_LOG_LEVEL_WARN:
+            LOG_WARN(text);
+        break;
+        case GGML_LOG_LEVEL_ERROR:
+            LOG_ERROR(text);
+        break;
+        default:
+            LOG_DEBUG(text);
+    }
 }
 
 __STATIC_INLINE__ void ggml_tensor_set_f32_randn(struct ggml_tensor* tensor, std::shared_ptr<RNG> rng) {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -159,13 +159,14 @@ public:
                         bool vae_on_cpu,
                         bool diffusion_flash_attn) {
         use_tiny_autoencoder = taesd_path.size() > 0;
+
+        ggml_log_set(ggml_log_callback_default, nullptr);
 #ifdef SD_USE_CUDA
         LOG_DEBUG("Using CUDA backend");
         backend = ggml_backend_cuda_init(0);
 #endif
 #ifdef SD_USE_METAL
         LOG_DEBUG("Using Metal backend");
-        ggml_log_set(ggml_log_callback_default, nullptr);
         backend = ggml_backend_metal_init();
 #endif
 #ifdef SD_USE_VULKAN

--- a/upscaler.cpp
+++ b/upscaler.cpp
@@ -15,13 +15,13 @@ struct UpscalerGGML {
     }
 
     bool load_from_file(const std::string& esrgan_path) {
+        ggml_log_set(ggml_log_callback_default, nullptr);
 #ifdef SD_USE_CUDA
         LOG_DEBUG("Using CUDA backend");
         backend = ggml_backend_cuda_init(0);
 #endif
 #ifdef SD_USE_METAL
         LOG_DEBUG("Using Metal backend");
-        ggml_log_set(ggml_log_callback_default, nullptr);
         backend = ggml_backend_metal_init();
 #endif
 #ifdef SD_USE_VULKAN

--- a/util.cpp
+++ b/util.cpp
@@ -390,7 +390,10 @@ void log_printf(sd_log_level_t level, const char* file, int line, const char* fo
     if (written >= 0 && written < LOG_BUFFER_SIZE) {
         vsnprintf(log_buffer + written, LOG_BUFFER_SIZE - written, format, args);
     }
-    strncat(log_buffer, "\n", LOG_BUFFER_SIZE - strlen(log_buffer));
+    size_t len = strlen(log_buffer);
+    if (log_buffer[len - 1] != '\n') {
+        strncat(log_buffer, "\n", LOG_BUFFER_SIZE - len);
+    }
 
     if (sd_log_cb) {
         sd_log_cb(level, log_buffer, sd_log_cb_data);


### PR DESCRIPTION
Currently, there is no straightforward way to disable ggml logs. This PR redirects ggml logs to go through the SD log_printf function. For example:

```
[INFO ] ggml_extend.hpp:61   - ggml_cuda_init: GGML_CUDA_FORCE_MMQ:    no
[INFO ] ggml_extend.hpp:61   - ggml_cuda_init: GGML_CUDA_FORCE_CUBLAS: no
[INFO ] ggml_extend.hpp:61   - ggml_cuda_init: found 1 CUDA devices:
...
[INFO ] stable-diffusion.cpp:243  - Version: SD 1.x 
[INFO ] stable-diffusion.cpp:276  - Weight type:                 f32
[INFO ] stable-diffusion.cpp:277  - Conditioner weight type:     f32
[INFO ] stable-diffusion.cpp:278  - Diffusion model weight type: f32
[INFO ] stable-diffusion.cpp:279  - VAE weight type:             f32
```