### PR TITLE
add fp8 e3m4 support

### DIFF
--- a/model.h
+++ b/model.h
@@ -89,6 +89,7 @@ struct TensorStorage {
     std::string name;
     ggml_type type          = GGML_TYPE_F32;
     bool is_bf16            = false;
+    bool is_f8_e3m4         = false;
     bool is_f8_e4m3         = false;
     bool is_f8_e5m2         = false;
     int64_t ne[SD_MAX_DIMS] = {1, 1, 1, 1, 1};
@@ -120,7 +121,7 @@ struct TensorStorage {
     }
 
     int64_t nbytes_to_read() const {
-        if (is_bf16 || is_f8_e4m3 || is_f8_e5m2) {
+        if (is_bf16 || is_f8_e3m4 || is_f8_e4m3 || is_f8_e5m2) {
             return nbytes() / 2;
         } else {
             return nbytes();
@@ -168,6 +169,8 @@ struct TensorStorage {
         const char* type_name = ggml_type_name(type);
         if (is_bf16) {
             type_name = "bf16";
+        } else if (is_f8_e3m4) {
+            type_name = "f8_e3m4";
         } else if (is_f8_e4m3) {
             type_name = "f8_e4m3";
         } else if (is_f8_e5m2) {


### PR DESCRIPTION
I also simplified conversion for the other fp8 formats

Fp8 e3m4 is very much non standard, so I don't know if it will ever be used, but it could be useful [to store some models like taef1](https://github.com/leejet/stable-diffusion.cpp/pull/527#issuecomment-2577788048)