### PR TITLE
fix amd rocm build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif ()
 
 if (SD_HIPBLAS)
     message("-- Use HIPBLAS as backend stable-diffusion")
-    set(GGML_HIPBLAS ON)
+    set(GGML_HIP ON)
     add_definitions(-DSD_USE_CUDA)
     if(SD_FAST_SOFTMAX)
         set(GGML_CUDA_FAST_SOFTMAX ON)


### PR DESCRIPTION
fix AMD ROCm build, change flag for ROCm from GGML_HIPBLAS to GGML_HIP according to https://github.com/ggerganov/ggml/blob/f196832b59684030515962711db4b19d848c8b68/CMakeLists.txt#L155