### PR TITLE
docs: Add missing `--mask` and `--guidance` options to `print_usage`

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -202,11 +202,13 @@ void print_usage(int argc, const char* argv[]) {
     printf("                                     If not specified, the default is the type of the weight file\n");
     printf("  --lora-model-dir [DIR]             lora model directory\n");
     printf("  -i, --init-img [IMAGE]             path to the input image, required by img2img\n");
+    printf("  --mask [MASK]                      path to the mask image, required by img2img with mask\n");
     printf("  --control-image [IMAGE]            path to image condition, control net\n");
     printf("  -o, --output OUTPUT                path to write result image to (default: ./output.png)\n");
     printf("  -p, --prompt [PROMPT]              the prompt to render\n");
     printf("  -n, --negative-prompt PROMPT       the negative prompt (default: \"\")\n");
     printf("  --cfg-scale SCALE                  unconditional guidance scale: (default: 7.0)\n");
+    printf("  --guidance SCALE                   guidance scale for img2img (default: 3.5)\n");
     printf("  --slg-scale SCALE                  skip layer guidance (SLG) scale, only for DiT models: (default: 0)\n");
     printf("                                     0 means disabled, a value of 2.5 is nice for sd3.5 medium\n");
     printf("  --skip-layers LAYERS               Layers to skip for SLG steps: (default: [7,8,9])\n");


### PR DESCRIPTION
### **PR Description**

- Add missing `--mask` and `--guidance` options to `print_usage`

#### **Changes**

1. **`--mask`**: Specifies the path to the mask image, required for `img2img` mode with masking.
2. **`--guidance`**: Specifies the guidance scale for `img2img` mode, with a default value of `3.5`.

If there are any mistakes, please let me know, thanks.

Translated by AI.