### PR TITLE
Tae: fix race condition causing inconsistent value for `decoder_only`

### DIFF
--- a/tae.hpp
+++ b/tae.hpp
@@ -201,7 +201,7 @@ struct TinyAutoEncoder : public GGMLRunner {
                     bool decoder_only = true,
                     SDVersion version = VERSION_SD1)
         : decode_only(decoder_only),
-          taesd(decode_only, version),
+          taesd(decoder_only, version),
           GGMLRunner(backend) {
         taesd.init(params_ctx, tensor_types, prefix);
     }


### PR DESCRIPTION
One char diff!
Fixes https://github.com/leejet/stable-diffusion.cpp/issues/608