### PR TITLE
Vulkan: Select device with env variable, and skip initialize for unused devices.

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -177,12 +177,22 @@ public:
         if (device_count) {
             const char* SD_VK_DEVICE = getenv("SD_VK_DEVICE");
             if (SD_VK_DEVICE != nullptr) {
-                device = (size_t)std::stoull(SD_VK_DEVICE);
+                std::string sd_vk_device_str = SD_VK_DEVICE;
+                try {
+                    device = std::stoull(sd_vk_device_str);
+                } catch (const std::invalid_argument&) {
+                    LOG_WARN("SD_VK_DEVICE environment variable is not a valid integer (%s). Falling back to device 0.", SD_VK_DEVICE);
+                    device = 0;
+                } catch (const std::out_of_range&) {
+                    LOG_WARN("SD_VK_DEVICE environment variable value is out of range for `unsigned long long` type (%s). Falling back to device 0.", SD_VK_DEVICE);
+                    device = 0;
+                }
                 if (device >= device_count) {
-                    LOG_WARN("Cannot find targeted vulkan device (%lld), falling back to device 0...", device);
+                    LOG_WARN("Cannot find targeted vulkan device (%llu). Falling back to device 0.", device);
                     device = 0;
                 }
             }
+            LOG_INFO("Vulkan: Using device %llu", device);
             backend = ggml_backend_vk_init(device);
         }
         if (!backend) {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -172,7 +172,17 @@ public:
 #endif
 #ifdef SD_USE_VULKAN
         LOG_DEBUG("Using Vulkan backend");
-        for (int device = 0; device < ggml_backend_vk_get_device_count(); ++device) {
+        size_t device          = 0;
+        const int device_count = ggml_backend_vk_get_device_count();
+        if (device_count) {
+            const char* SD_VK_DEVICE = getenv("SD_VK_DEVICE");
+            if (SD_VK_DEVICE != nullptr) {
+                device = (size_t)std::stoull(SD_VK_DEVICE);
+                if (device >= device_count) {
+                    LOG_WARN("Cannot find targeted vulkan device (%lld), falling back to device 0...", device);
+                    device = 0;
+                }
+            }
             backend = ggml_backend_vk_init(device);
         }
         if (!backend) {


### PR DESCRIPTION
Introduces the `SD_VK_DEVICE` env variable that can be used to chose the device to run inference on. 

Also backend was initialized on every device for no apparent reason.

I know it was already possible to hide some devices from the Vulkan backend by setting the `GGML_VK_VISIBLE_DEVICES` env variable, but this isn't ideal, as it affects every program that uses Vulkan GGML. 

(Maybe the same should be done for CUDA and SYCL backends)