### PR TITLE
Fix: actually use embeddings with SDXL

### DIFF
--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -458,8 +458,8 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
                 if (sd_version_is_sdxl(version)) {
                     text_model2->compute(n_threads,
                                          input_ids2,
-                                         0,
-                                         NULL,
+                                         num_custom_embeddings,
+                                         token_embed_custom.data(),
                                          max_token_idx,
                                          false,
                                          &chunk_hidden_states2, work_ctx);
@@ -469,8 +469,8 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
                     if (chunk_idx == 0) {
                         text_model2->compute(n_threads,
                                              input_ids2,
-                                             0,
-                                             NULL,
+                                             num_custom_embeddings,
+                                             token_embed_custom.data(),
                                              max_token_idx,
                                              true,
                                              &pooled,


### PR DESCRIPTION
Should fix https://github.com/leejet/stable-diffusion.cpp/issues/656

SDXL Embeddings were not actually being applied to the second text encoder, oopsie. It seems this was causing a crash when running clip on CPU backends too.

Example: 

`sd.exe --model  models\sdXL_v10VAEFix.safetensors -p 'JenniferLawrenceExl, portrait, smiling' -n "nsfw" --cfg-scale 7 --sampling-method euler --steps 50 -t 24 --vae-tiling -W 896 -H 1152 --embd-dir embeddings\sdxl\ --vae models\vae\sdxl_vae.safetensors`

| PR | master | no trigger word | 
| --- | --- | --- |
| ![output](https://github.com/user-attachments/assets/2fa3d84b-ea2c-48f9-987c-c024836aa181) | ![output](https://github.com/user-attachments/assets/ac4f3acd-7524-49ab-9ead-e29013c22042) | ![output](https://github.com/user-attachments/assets/9a81d479-6e3e-48ce-8324-1dfa53326aa9) |

