### PR TITLE
fix: avoid crash on sdxl loras

### DIFF
--- a/lora.hpp
+++ b/lora.hpp
@@ -3,7 +3,7 @@
 
 #include "ggml_extend.hpp"
 
-#define LORA_GRAPH_SIZE 10240
+#define LORA_GRAPH_SIZE 15360
 
 struct LoraModel : public GGMLRunner {
     enum lora_t {


### PR DESCRIPTION
Some SDXL LoRAs (eg. PCM) can exceed 12k nodes.

Also tested with DMD2 4 step:

```text
stable-diffusion.cpp/ggml/src/ggml.c:5764: GGML_ASSERT(cgraph->n_nodes < cgraph->size) failed
(...)
#12 0x000055769307cfa3 in ggml_build_forward_expand ()
#13 0x0000557692f0ff56 in LoraModel::build_lora_graph(std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ggml_tensor*, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, ggml_tensor*> > >, SDVersion) ()
```
Before the assertion, the LoRA graph reaches 12608 nodes.