### PR TITLE
musa: fix docker build

### DIFF
--- a/Dockerfile.musa
+++ b/Dockerfile.musa
@@ -2,14 +2,17 @@ ARG MUSA_VERSION=rc3.1.1
 
 FROM mthreads/musa:${MUSA_VERSION}-devel-ubuntu22.04 as build
 
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get install -y ccache cmake git
 
 WORKDIR /sd.cpp
 
 COPY . .
 
 RUN mkdir build && cd build && \
-    cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSD_MUSA=ON -DCMAKE_BUILD_TYPE=Release && \
+    cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fopenmp -I/usr/lib/llvm-14/lib/clang/14.0.0/include -L/usr/lib/llvm-14/lib" \
+        -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fopenmp -I/usr/lib/llvm-14/lib/clang/14.0.0/include -L/usr/lib/llvm-14/lib" \
+        -DSD_MUSA=ON -DCMAKE_BUILD_TYPE=Release && \
     cmake --build . --config Release
 
 FROM mthreads/musa:${MUSA_VERSION}-runtime-ubuntu22.04 as runtime


### PR DESCRIPTION
Install `git` and `ccache`, and configure OpenMP support for `cmake`.

```bash
 > [build 5/5] RUN mkdir build && cd build &&     cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DSD_MUSA=ON -DCMAKE_BUILD_TYPE=Release &&     cmake --build . --config Release:                                           
0.330 -- The C compiler identification is Clang 14.0.0                                                                
0.415 -- The CXX compiler identification is Clang 14.0.0                                                              
0.420 -- Detecting C compiler ABI info                                                                                
0.489 -- Detecting C compiler ABI info - done
0.495 -- Check for working C compiler: /usr/local/musa/bin/clang - skipped
0.496 -- Detecting C compile features
0.496 -- Detecting C compile features - done
0.500 -- Detecting CXX compiler ABI info
0.597 -- Detecting CXX compiler ABI info - done
0.601 -- Check for working CXX compiler: /usr/local/musa/bin/clang++ - skipped
0.602 -- Detecting CXX compile features
0.602 -- Detecting CXX compile features - done
0.602 -- Use MUSA as backend stable-diffusion
0.603 -- Build static library
0.604 -- Looking for pthread.h
0.670 -- Looking for pthread.h - found
0.670 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD
0.744 -- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
0.745 -- Found Threads: TRUE  
0.748 -- Warning: ccache not found - consider installing it for faster compilation or disable this warning with GGML_CCACHE=OFF
0.774 -- CMAKE_SYSTEM_PROCESSOR: x86_64
0.775 -- Including CPU backend
1.014 -- Could NOT find OpenMP_C (missing: OpenMP_C_FLAGS OpenMP_C_LIB_NAMES) 
1.014 -- Could NOT find OpenMP_CXX (missing: OpenMP_CXX_FLAGS OpenMP_CXX_LIB_NAMES) 
1.014 -- Could NOT find OpenMP (missing: OpenMP_C_FOUND OpenMP_CXX_FOUND) 
1.014 CMake Warning at ggml/src/ggml-cpu/CMakeLists.txt:53 (message):
1.014   OpenMP not found
1.014 Call Stack (most recent call first):
1.014   ggml/src/CMakeLists.txt:321 (ggml_add_cpu_backend_variant_impl)
1.014 
1.014 
1.015 -- x86 detected
1.015 -- Adding CPU backend variant ggml-cpu: -march=native 
1.045 -- Found MUSAToolkit: /usr/local/musa/include  
1.070 -- MUSA Toolkit found
1.070 -- Using MUSA architectures: 21;22
1.072 -- Including MUSA backend
1.074 CMake Error at ggml/CMakeLists.txt:282 (find_program):
1.074   Could not find GIT_EXE using the following names: git, git.exe
1.074 
1.074 
1.074 -- Configuring incomplete, errors occurred!
1.074 See also "/sd.cpp/build/CMakeFiles/CMakeOutput.log".
1.074 See also "/sd.cpp/build/CMakeFiles/CMakeError.log".
```

=>

```bash
root@5024fc5c1724:/ws/build# cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
        -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fopenmp -I/usr/lib/llvm-14/lib/clang/14.0.0/include -L/usr/lib/llvm-14/lib" \
        -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fopenmp -I/usr/lib/llvm-14/lib/clang/14.0.0/include -L/usr/lib/llvm-14/lib" \
        -DSD_MUSA=ON -DCMAKE_BUILD_TYPE=Release 
-- The C compiler identification is Clang 14.0.0
-- The CXX compiler identification is Clang 14.0.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/local/musa/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/local/musa/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Use MUSA as backend stable-diffusion
-- Build static library
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- ccache found, compilation results will be cached. Disable with GGML_CCACHE=OFF.
-- CMAKE_SYSTEM_PROCESSOR: x86_64
-- Including CPU backend
-- Found OpenMP_C: -fopenmp=libomp (found version "5.0") 
-- Found OpenMP_CXX: -fopenmp=libomp (found version "5.0") 
-- Found OpenMP: TRUE (found version "5.0")  
-- x86 detected
-- Adding CPU backend variant ggml-cpu: -march=native 
-- Found MUSAToolkit: /usr/local/musa/include  
-- MUSA Toolkit found
-- Using MUSA architectures: 21;22
-- Including MUSA backend
-- Configuring done
-- Generating done
-- Build files have been written to: /ws/build
```