### PR TITLE
fix: adjust timestep calculations for DDIM and TCD

### DIFF
--- a/denoiser.hpp
+++ b/denoiser.hpp
@@ -671,6 +671,7 @@ static void sample_k_diffusion(sample_method_t method,
                                ggml_context* work_ctx,
                                ggml_tensor* x,
                                std::vector<float> sigmas,
+                               int initial_step,
                                std::shared_ptr<RNG> rng,
                                float eta) {
     size_t steps = sigmas.size() - 1;
@@ -1248,12 +1249,13 @@ static void sample_k_diffusion(sample_method_t method,
                 // - pred_sample_direction -> "direction pointing to
                 //   x_t"
                 // - pred_prev_sample -> "x_t-1"
-                int timestep =
-                    roundf(TIMESTEPS -
-                           i * ((float)TIMESTEPS / steps)) -
-                    1;
+                int timestep = TIMESTEPS - 1 -
+                               (int)roundf((initial_step + i) *
+                                   (TIMESTEPS / float(initial_step + steps)));
                 // 1. get previous step value (=t-1)
-                int prev_timestep = timestep - TIMESTEPS / steps;
+                int prev_timestep = TIMESTEPS - 1 -
+                               (int)roundf((initial_step + i + 1) *
+                                   (TIMESTEPS / float(initial_step + steps)));
                 // The sigma here is chosen to cause the
                 // CompVisDenoiser to produce t = timestep
                 float sigma = compvis_sigmas[timestep];
@@ -1425,9 +1427,14 @@ static void sample_k_diffusion(sample_method_t method,
                 // Analytic form for TCD timesteps
                 int timestep = TIMESTEPS - 1 -
                                (TIMESTEPS / original_steps) *
-                                   (int)floor(i * ((float)original_steps / steps));
+                                   (int)floor((initial_step + i) *
+                                       ((float)original_steps / (initial_step + steps)));
                 // 1. get previous step value
-                int prev_timestep = i >= steps - 1 ? 0 : TIMESTEPS - 1 - (TIMESTEPS / original_steps) * (int)floor((i + 1) * ((float)original_steps / steps));
+                int prev_timestep = i >= steps - 1 ? 0 :
+                               TIMESTEPS - 1 -
+                               (TIMESTEPS / original_steps) *
+                                   (int)floor((initial_step + i + 1) *
+                                       ((float)original_steps / (initial_step + steps)));
                 // Here timestep_s is tau_n' in Algorithm 4. The _s
                 // notation appears to be that from C. Lu,
                 // "DPM-Solver: A Fast ODE Solver for Diffusion


### PR DESCRIPTION
On img2img, the number of steps correspond to the last precalculated sigma values, but the internal alphas_cumprod and compvis_sigmas were being computed over the entire step range.

Also, tweaks the prev_timestep calculation on DDIM to better match the current timestamp (like on TCD), to avoid inconsistencies due to rounding.

This partially fixes #663 , and seems enough to at least generate coherent images. But low strength generations still produce noisy outputs.