### PR TITLE
Instruct-Pix2pix/CosXL-Edit support

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -234,7 +234,7 @@ void print_usage(int argc, const char* argv[]) {
     printf("  -p, --prompt [PROMPT]              the prompt to render\n");
     printf("  -n, --negative-prompt PROMPT       the negative prompt (default: \"\")\n");
     printf("  --cfg-scale SCALE                  unconditional guidance scale: (default: 7.0)\n");
-    printf("  --img_cfg-scale SCALE              image guidance scale for inpaint or instruct-pix2pix models: (default: same as --cfg-scale)\n");
+    printf("  --img-cfg-scale SCALE              image guidance scale for inpaint or instruct-pix2pix models: (default: same as --cfg-scale)\n");
     printf("  --guidance SCALE                   distilled guidance scale for models with guidance input (default: 3.5)\n");
     printf("  --slg-scale SCALE                  skip layer guidance (SLG) scale, only for DiT models: (default: 0)\n");
     printf("                                     0 means disabled, a value of 2.5 is nice for sd3.5 medium\n");

--- a/model.cpp
+++ b/model.cpp
@@ -1674,10 +1674,13 @@ SDVersion ModelLoader::get_sd_version() {
         }
     }
     bool is_inpaint = input_block_weight.ne[2] == 9;
-    bool is_ip2p =  input_block_weight.ne[2] == 8;
+    bool is_ip2p    = input_block_weight.ne[2] == 8;
     if (is_xl) {
         if (is_inpaint) {
             return VERSION_SDXL_INPAINT;
+        }
+        if (is_ip2p) {
+            return VERSION_SDXL_PIX2PIX;
         }
         return VERSION_SDXL;
     }
@@ -1694,7 +1697,7 @@ SDVersion ModelLoader::get_sd_version() {
         if (is_inpaint) {
             return VERSION_SD1_INPAINT;
         }
-        if(is_ip2p) {
+        if (is_ip2p) {
             return VERSION_SD1_PIX2PIX;
         }
         return VERSION_SD1;

--- a/model.cpp
+++ b/model.cpp
@@ -100,7 +100,7 @@ const char* unused_tensors[] = {
     "model_ema.diffusion_model",
     "embedding_manager",
     "denoiser.sigmas",
-    "text_encoders.t5xxl.transformer.encoder.embed_tokens.weight", // only used during training
+    "text_encoders.t5xxl.transformer.encoder.embed_tokens.weight",  // only used during training
 };
 
 bool is_unused_tensor(std::string name) {
@@ -1169,7 +1169,6 @@ bool ModelLoader::init_from_safetensors_file(const std::string& file_path, const
             n_dims = 1;
         }
 
-
         TensorStorage tensor_storage(prefix + name, type, ne, n_dims, file_index, ST_HEADER_SIZE_LEN + header_size_ + begin);
         tensor_storage.reverse_ne();
 
@@ -1921,7 +1920,7 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb, ggml_backend
         };
         int tensor_count = 0;
         int64_t t1       = ggml_time_ms();
-        bool partial = false;
+        bool partial     = false;
         for (auto& tensor_storage : processed_tensor_storages) {
             if (tensor_storage.file_index != file_index) {
                 ++tensor_count;
@@ -2004,9 +2003,9 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb, ggml_backend
                 }
             }
             size_t tensor_max = processed_tensor_storages.size();
-            int64_t t2 = ggml_time_ms();
+            int64_t t2        = ggml_time_ms();
             pretty_progress(++tensor_count, tensor_max, (t2 - t1) / 1000.0f);
-            t1 = t2;
+            t1      = t2;
             partial = tensor_count != tensor_max;
         }
 

--- a/model.cpp
+++ b/model.cpp
@@ -1695,7 +1695,7 @@ SDVersion ModelLoader::get_sd_version() {
             return VERSION_SD1_INPAINT;
         }
         if(is_ip2p) {
-            return VERSION_INSTRUCT_PIX2PIX;
+            return VERSION_SD1_PIX2PIX;
         }
         return VERSION_SD1;
     } else if (token_embedding_weight.ne[0] == 1024) {

--- a/model.cpp
+++ b/model.cpp
@@ -1674,6 +1674,7 @@ SDVersion ModelLoader::get_sd_version() {
         }
     }
     bool is_inpaint = input_block_weight.ne[2] == 9;
+    bool is_ip2p =  input_block_weight.ne[2] == 8;
     if (is_xl) {
         if (is_inpaint) {
             return VERSION_SDXL_INPAINT;
@@ -1692,6 +1693,9 @@ SDVersion ModelLoader::get_sd_version() {
     if (token_embedding_weight.ne[0] == 768) {
         if (is_inpaint) {
             return VERSION_SD1_INPAINT;
+        }
+        if(is_ip2p) {
+            return VERSION_INSTRUCT_PIX2PIX;
         }
         return VERSION_SD1;
     } else if (token_embedding_weight.ne[0] == 1024) {

--- a/model.h
+++ b/model.h
@@ -21,7 +21,7 @@
 enum SDVersion {
     VERSION_SD1,
     VERSION_SD1_INPAINT,
-    VERSION_INSTRUCT_PIX2PIX,
+    VERSION_SD1_PIX2PIX,
     VERSION_SD2,
     VERSION_SD2_INPAINT,
     VERSION_SDXL,
@@ -48,7 +48,7 @@ static inline bool sd_version_is_sd3(SDVersion version) {
 }
 
 static inline bool sd_version_is_sd1(SDVersion version) {
-    if (version == VERSION_SD1 || version == VERSION_SD1_INPAINT || version == VERSION_INSTRUCT_PIX2PIX) {
+    if (version == VERSION_SD1 || version == VERSION_SD1_INPAINT || version == VERSION_SD1_PIX2PIX) {
         return true;
     }
     return false;
@@ -82,8 +82,12 @@ static inline bool sd_version_is_dit(SDVersion version) {
     return false;
 }
 
+static inline bool sd_version_is_edit(SDVersion version) {
+    return version == VERSION_SD1_PIX2PIX;
+}
+
 static bool sd_version_use_concat(SDVersion version) {
-    return version == VERSION_INSTRUCT_PIX2PIX || sd_version_is_inpaint(version);
+    return sd_version_is_edit(version) || sd_version_is_inpaint(version);
 }
 
 enum PMVersion {

--- a/model.h
+++ b/model.h
@@ -21,6 +21,7 @@
 enum SDVersion {
     VERSION_SD1,
     VERSION_SD1_INPAINT,
+    VERSION_INSTRUCT_PIX2PIX,
     VERSION_SD2,
     VERSION_SD2_INPAINT,
     VERSION_SDXL,
@@ -47,7 +48,7 @@ static inline bool sd_version_is_sd3(SDVersion version) {
 }
 
 static inline bool sd_version_is_sd1(SDVersion version) {
-    if (version == VERSION_SD1 || version == VERSION_SD1_INPAINT) {
+    if (version == VERSION_SD1 || version == VERSION_SD1_INPAINT || version == VERSION_INSTRUCT_PIX2PIX) {
         return true;
     }
     return false;

--- a/model.h
+++ b/model.h
@@ -26,6 +26,7 @@ enum SDVersion {
     VERSION_SD2_INPAINT,
     VERSION_SDXL,
     VERSION_SDXL_INPAINT,
+    VERSION_SDXL_PIX2PIX,
     VERSION_SVD,
     VERSION_SD3,
     VERSION_FLUX,
@@ -62,7 +63,7 @@ static inline bool sd_version_is_sd2(SDVersion version) {
 }
 
 static inline bool sd_version_is_sdxl(SDVersion version) {
-    if (version == VERSION_SDXL || version == VERSION_SDXL_INPAINT) {
+    if (version == VERSION_SDXL || version == VERSION_SDXL_INPAINT || version == VERSION_SDXL_PIX2PIX) {
         return true;
     }
     return false;
@@ -83,7 +84,7 @@ static inline bool sd_version_is_dit(SDVersion version) {
 }
 
 static inline bool sd_version_is_edit(SDVersion version) {
-    return version == VERSION_SD1_PIX2PIX;
+    return version == VERSION_SD1_PIX2PIX || version == VERSION_SDXL_PIX2PIX;
 }
 
 static bool sd_version_use_concat(SDVersion version) {

--- a/model.h
+++ b/model.h
@@ -82,6 +82,10 @@ static inline bool sd_version_is_dit(SDVersion version) {
     return false;
 }
 
+static bool sd_version_use_concat(SDVersion version) {
+    return version == VERSION_INSTRUCT_PIX2PIX || sd_version_is_inpaint(version);
+}
+
 enum PMVersion {
     PM_VERSION_1,
     PM_VERSION_2,

--- a/model.h
+++ b/model.h
@@ -83,12 +83,12 @@ static inline bool sd_version_is_dit(SDVersion version) {
     return false;
 }
 
-static inline bool sd_version_is_edit(SDVersion version) {
+static inline bool sd_version_is_unet_edit(SDVersion version) {
     return version == VERSION_SD1_PIX2PIX || version == VERSION_SDXL_PIX2PIX;
 }
 
 static bool sd_version_use_concat(SDVersion version) {
-    return sd_version_is_edit(version) || sd_version_is_inpaint(version);
+    return sd_version_is_unet_edit(version) || sd_version_is_inpaint(version);
 }
 
 enum PMVersion {

--- a/model.h
+++ b/model.h
@@ -87,7 +87,7 @@ static inline bool sd_version_is_unet_edit(SDVersion version) {
     return version == VERSION_SD1_PIX2PIX || version == VERSION_SDXL_PIX2PIX;
 }
 
-static bool sd_version_use_concat(SDVersion version) {
+static bool sd_version_is_inpaint_or_unet_edit(SDVersion version) {
     return sd_version_is_unet_edit(version) || sd_version_is_inpaint(version);
 }
 

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -32,6 +32,7 @@ const char* model_version_to_str[] = {
     "SD 2.x Inpaint",
     "SDXL",
     "SDXL Inpaint",
+    "SDXL Instruct-Pix2Pix",
     "SVD",
     "SD3.x",
     "Flux",

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1113,6 +1113,30 @@ public:
         return latent;
     }
 
+    ggml_tensor*
+    get_first_stage_encoding_mode(ggml_context* work_ctx, ggml_tensor* moments) {
+        // ldm.modules.distributions.distributions.DiagonalGaussianDistribution.sample
+        ggml_tensor* latent       = ggml_new_tensor_4d(work_ctx, moments->type, moments->ne[0], moments->ne[1], moments->ne[2] / 2, moments->ne[3]);
+        struct ggml_tensor* noise = ggml_dup_tensor(work_ctx, latent);
+        ggml_tensor_set_f32_randn(noise, rng);
+        // noise = load_tensor_from_file(work_ctx, "noise.bin");
+        {
+            float mean = 0;
+            for (int i = 0; i < latent->ne[3]; i++) {
+                for (int j = 0; j < latent->ne[2]; j++) {
+                    for (int k = 0; k < latent->ne[1]; k++) {
+                        for (int l = 0; l < latent->ne[0]; l++) {
+                            // mode and mean are the same for gaussians
+                            mean = ggml_tensor_get_f32(moments, l, k, j, i);
+                            ggml_tensor_set_f32(latent, mean, l, k, j, i);
+                        }
+                    }
+                }
+            }
+        }
+        return latent;
+    }
+
     ggml_tensor* compute_first_stage(ggml_context* work_ctx, ggml_tensor* x, bool decode) {
         int64_t W = x->ne[0];
         int64_t H = x->ne[1];
@@ -1298,7 +1322,7 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx,
                            float slg_scale              = 0,
                            float skip_layer_start       = 0.01,
                            float skip_layer_end         = 0.2,
-                           ggml_tensor* masked_image    = NULL) {
+                           ggml_tensor* masked_latent    = NULL) {
     if (seed < 0) {
         // Generally, when using the provided command line, the seed is always >0.
         // However, to prevent potential issues if 'stable-diffusion.cpp' is invoked as a library
@@ -1487,42 +1511,43 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx,
     LOG_INFO("sampling using %s method", sampling_methods_str[sample_method]);
     ggml_tensor* noise_mask = nullptr;
     if (sd_version_is_inpaint(sd_ctx->sd->version)) {
-        if (masked_image == NULL) {
-            int64_t mask_channels = 1;
-            if (sd_ctx->sd->version == VERSION_FLUX_FILL) {
-                mask_channels = 8 * 8;  // flatten the whole mask
-            }
-            // no mask, set the whole image as masked
-            masked_image = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, init_latent->ne[0], init_latent->ne[1], mask_channels + init_latent->ne[2], 1);
-            for (int64_t x = 0; x < masked_image->ne[0]; x++) {
-                for (int64_t y = 0; y < masked_image->ne[1]; y++) {
-                    if (sd_ctx->sd->version == VERSION_FLUX_FILL) {
-                        // TODO: this might be wrong
-                        for (int64_t c = 0; c < init_latent->ne[2]; c++) {
-                            ggml_tensor_set_f32(masked_image, 0, x, y, c);
-                        }
-                        for (int64_t c = init_latent->ne[2]; c < masked_image->ne[2]; c++) {
-                            ggml_tensor_set_f32(masked_image, 1, x, y, c);
-                        }
-                    } else {
-                        ggml_tensor_set_f32(masked_image, 1, x, y, 0);
-                        for (int64_t c = 1; c < masked_image->ne[2]; c++) {
-                            ggml_tensor_set_f32(masked_image, 0, x, y, c);
-                        }
+        int64_t mask_channels = 1;
+        if (sd_ctx->sd->version == VERSION_FLUX_FILL) {
+            mask_channels = 8 * 8;  // flatten the whole mask
+        }
+        auto empty_latent = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, init_latent->ne[0], init_latent->ne[1], mask_channels + init_latent->ne[2], 1);
+        // no mask, set the whole image as masked
+        for (int64_t x = 0; x < empty_latent->ne[0]; x++) {
+            for (int64_t y = 0; y < empty_latent->ne[1]; y++) {
+                if (sd_ctx->sd->version == VERSION_FLUX_FILL) {
+                    // TODO: this might be wrong
+                    for (int64_t c = 0; c < init_latent->ne[2]; c++) {
+                        ggml_tensor_set_f32(empty_latent, 0, x, y, c);
+                    }
+                    for (int64_t c = init_latent->ne[2]; c < empty_latent->ne[2]; c++) {
+                        ggml_tensor_set_f32(empty_latent, 1, x, y, c);
+                    }
+                } else {
+                    ggml_tensor_set_f32(empty_latent, 1, x, y, 0);
+                    for (int64_t c = 1; c < empty_latent->ne[2]; c++) {
+                        ggml_tensor_set_f32(empty_latent, 0, x, y, c);
                     }
                 }
             }
         }
-        cond.c_concat   = masked_image;
-        uncond.c_concat = masked_image;
-        // noise_mask = masked_image;
+        if (masked_latent == NULL) {
+            masked_latent = empty_latent;
+        }
+        cond.c_concat   = masked_latent;
+        uncond.c_concat = empty_latent;
+        // noise_mask = masked_latent;
     } else if (sd_ctx->sd->version == VERSION_INSTRUCT_PIX2PIX) {
-        cond.c_concat  = masked_image;
-        auto empty_img = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, masked_image->ne[0], masked_image->ne[1], masked_image->ne[2], masked_image->ne[3]);
-        ggml_set_f32(empty_img, 0);
-        uncond.c_concat = empty_img;
+        cond.c_concat     = masked_latent;
+        auto empty_latent = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, masked_latent->ne[0], masked_latent->ne[1], masked_latent->ne[2], masked_latent->ne[3]);
+        ggml_set_f32(empty_latent, 0);
+        uncond.c_concat = empty_latent;
     } else {
-        noise_mask = masked_image;
+        noise_mask = masked_latent;
     }
 
     for (int b = 0; b < batch_count; b++) {
@@ -1802,15 +1827,16 @@ sd_image_t* img2img(sd_ctx_t* sd_ctx,
 
     sd_image_to_tensor(init_image.data, init_img);
 
-    ggml_tensor* init_latent = NULL;
+    ggml_tensor* masked_latent;
+
+    ggml_tensor* init_latent  = NULL;
+    ggml_tensor* init_moments = NULL;
     if (!sd_ctx->sd->use_tiny_autoencoder) {
-        ggml_tensor* moments = sd_ctx->sd->encode_first_stage(work_ctx, init_img);
-        init_latent          = sd_ctx->sd->get_first_stage_encoding(work_ctx, moments);
+        init_moments = sd_ctx->sd->encode_first_stage(work_ctx, init_img);
+        init_latent               = sd_ctx->sd->get_first_stage_encoding(work_ctx, init_moments);
     } else {
         init_latent = sd_ctx->sd->encode_first_stage(work_ctx, init_img);
     }
-
-    ggml_tensor* masked_image;
 
     if (sd_version_is_inpaint(sd_ctx->sd->version)) {
         int64_t mask_channels = 1;
@@ -1818,23 +1844,25 @@ sd_image_t* img2img(sd_ctx_t* sd_ctx,
             mask_channels = 8 * 8;  // flatten the whole mask
         }
         ggml_tensor* masked_img = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, width, height, 3, 1);
+        // Restore init_img (encode_first_stage has side effects) TODO: remove the side effects?
+        sd_image_to_tensor(init_image.data, init_img);
         sd_apply_mask(init_img, mask_img, masked_img);
-        ggml_tensor* masked_image_0 = NULL;
+        ggml_tensor* masked_latent_0 = NULL;
         if (!sd_ctx->sd->use_tiny_autoencoder) {
             ggml_tensor* moments = sd_ctx->sd->encode_first_stage(work_ctx, masked_img);
-            masked_image_0       = sd_ctx->sd->get_first_stage_encoding(work_ctx, moments);
+            masked_latent_0      = sd_ctx->sd->get_first_stage_encoding(work_ctx, moments);
         } else {
-            masked_image_0 = sd_ctx->sd->encode_first_stage(work_ctx, masked_img);
+            masked_latent_0 = sd_ctx->sd->encode_first_stage(work_ctx, masked_img);
         }
-        masked_image = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, masked_image_0->ne[0], masked_image_0->ne[1], mask_channels + masked_image_0->ne[2], 1);
-        for (int ix = 0; ix < masked_image_0->ne[0]; ix++) {
-            for (int iy = 0; iy < masked_image_0->ne[1]; iy++) {
+        masked_latent = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, masked_latent_0->ne[0], masked_latent_0->ne[1], mask_channels + masked_latent_0->ne[2], 1);
+        for (int ix = 0; ix < masked_latent_0->ne[0]; ix++) {
+            for (int iy = 0; iy < masked_latent_0->ne[1]; iy++) {
                 int mx = ix * 8;
                 int my = iy * 8;
                 if (sd_ctx->sd->version == VERSION_FLUX_FILL) {
-                    for (int k = 0; k < masked_image_0->ne[2]; k++) {
-                        float v = ggml_tensor_get_f32(masked_image_0, ix, iy, k);
-                        ggml_tensor_set_f32(masked_image, v, ix, iy, k);
+                    for (int k = 0; k < masked_latent_0->ne[2]; k++) {
+                        float v = ggml_tensor_get_f32(masked_latent_0, ix, iy, k);
+                        ggml_tensor_set_f32(masked_latent, v, ix, iy, k);
                     }
                     // "Encode" 8x8 mask chunks into a flattened 1x64 vector, and concatenate to masked image
                     for (int x = 0; x < 8; x++) {
@@ -1842,31 +1870,35 @@ sd_image_t* img2img(sd_ctx_t* sd_ctx,
                             float m = ggml_tensor_get_f32(mask_img, mx + x, my + y);
                             // TODO: check if the way the mask is flattened is correct (is it supposed to be x*8+y or x+8*y?)
                             // python code was using "b (h 8) (w 8) -> b (8 8) h w"
-                            ggml_tensor_set_f32(masked_image, m, ix, iy, masked_image_0->ne[2] + x * 8 + y);
+                            ggml_tensor_set_f32(masked_latent, m, ix, iy, masked_latent_0->ne[2] + x * 8 + y);
                         }
                     }
                 } else {
                     float m = ggml_tensor_get_f32(mask_img, mx, my);
-                    ggml_tensor_set_f32(masked_image, m, ix, iy, 0);
-                    for (int k = 0; k < masked_image_0->ne[2]; k++) {
-                        float v = ggml_tensor_get_f32(masked_image_0, ix, iy, k);
-                        ggml_tensor_set_f32(masked_image, v, ix, iy, k + mask_channels);
+                    ggml_tensor_set_f32(masked_latent, m, ix, iy, 0);
+                    for (int k = 0; k < masked_latent_0->ne[2]; k++) {
+                        float v = ggml_tensor_get_f32(masked_latent_0, ix, iy, k);
+                        ggml_tensor_set_f32(masked_latent, v, ix, iy, k + mask_channels);
                     }
                 }
             }
         }
     } else if (sd_ctx->sd->version == VERSION_INSTRUCT_PIX2PIX) {
-        // Not actually masked, we're just highjacking the masked_image variable since it will be used the same way
-        masked_image = init_latent;
+        // Not actually masked, we're just highjacking the masked_latent variable since it will be used the same way
+        if (!sd_ctx->sd->use_tiny_autoencoder) {
+            masked_latent = sd_ctx->sd->get_first_stage_encoding_mode(work_ctx, init_moments);
+        } else {
+            masked_latent = init_latent;
+        }
     } else {
         // LOG_WARN("Inpainting with a base model is not great");
-        masked_image = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, width / 8, height / 8, 1, 1);
-        for (int ix = 0; ix < masked_image->ne[0]; ix++) {
-            for (int iy = 0; iy < masked_image->ne[1]; iy++) {
+        masked_latent = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, width / 8, height / 8, 1, 1);
+        for (int ix = 0; ix < masked_latent->ne[0]; ix++) {
+            for (int iy = 0; iy < masked_latent->ne[1]; iy++) {
                 int mx  = ix * 8;
                 int my  = iy * 8;
                 float m = ggml_tensor_get_f32(mask_img, mx, my);
-                ggml_tensor_set_f32(masked_image, m, ix, iy);
+                ggml_tensor_set_f32(masked_latent, m, ix, iy);
             }
         }
     }
@@ -1908,7 +1940,7 @@ sd_image_t* img2img(sd_ctx_t* sd_ctx,
                                                slg_scale,
                                                skip_layer_start,
                                                skip_layer_end,
-                                               masked_image);
+                                               masked_latent);
 
     size_t t2 = ggml_time_ms();
 

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1444,7 +1444,7 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx,
                                                                            sd_ctx->sd->diffusion_model->get_adm_in_channels());
 
     SDCondition uncond;
-    if (guidance.txt_cfg != 1.0 || \
+    if (guidance.txt_cfg != 1.0 ||
         (sd_version_is_inpaint_or_unet_edit(sd_ctx->sd->version) && guidance.txt_cfg != guidance.img_cfg)) {
         bool force_zero_embeddings = false;
         if (sd_version_is_sdxl(sd_ctx->sd->version) && negative_prompt.size() == 0 && !sd_ctx->sd->is_using_edm_v_parameterization) {
@@ -1522,11 +1522,11 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx,
         if (concat_latent == NULL) {
             concat_latent = empty_latent;
         }
-        cond.c_concat   = ref_latents[0];
+        cond.c_concat = ref_latents[0];
     }
     SDCondition img_cond;
-    if (uncond.c_crossattn != NULL && \
-       (sd_version_is_inpaint_or_unet_edit(sd_ctx->sd->version) && guidance.txt_cfg != guidance.img_cfg)) {
+    if (uncond.c_crossattn != NULL &&
+        (sd_version_is_inpaint_or_unet_edit(sd_ctx->sd->version) && guidance.txt_cfg != guidance.img_cfg)) {
         img_cond = SDCondition(uncond.c_crossattn, uncond.c_vector, cond.c_concat);
     }
     for (int b = 0; b < batch_count; b++) {
@@ -1798,7 +1798,7 @@ sd_image_t* img2img(sd_ctx_t* sd_ctx,
         ggml_tensor* masked_latent = NULL;
         if (!sd_ctx->sd->use_tiny_autoencoder) {
             ggml_tensor* moments = sd_ctx->sd->encode_first_stage(work_ctx, masked_img);
-            masked_latent      = sd_ctx->sd->get_first_stage_encoding(work_ctx, moments);
+            masked_latent        = sd_ctx->sd->get_first_stage_encoding(work_ctx, moments);
         } else {
             masked_latent = sd_ctx->sd->encode_first_stage(work_ctx, masked_img);
         }
@@ -1832,7 +1832,7 @@ sd_image_t* img2img(sd_ctx_t* sd_ctx,
             }
         }
     }
-    
+
     {
         // LOG_WARN("Inpainting with a base model is not great");
         denoise_mask = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, width / 8, height / 8, 1, 1);

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1887,7 +1887,12 @@ sd_image_t* img2img(sd_ctx_t* sd_ctx,
     } else if (sd_version_is_edit(sd_ctx->sd->version)) {
         // Not actually masked, we're just highjacking the masked_latent variable since it will be used the same way
         if (!sd_ctx->sd->use_tiny_autoencoder) {
-            masked_latent = sd_ctx->sd->get_first_stage_encoding_mode(work_ctx, init_moments);
+            if (sd_ctx->sd->is_using_edm_v_parameterization) {
+                // for CosXL edit
+                masked_latent = sd_ctx->sd->get_first_stage_encoding(work_ctx, init_moments);
+            } else {
+                masked_latent = sd_ctx->sd->get_first_stage_encoding_mode(work_ctx, init_moments);
+            }
         } else {
             masked_latent = init_latent;
         }

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1470,7 +1470,7 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx,
                                                                            sd_ctx->sd->diffusion_model->get_adm_in_channels());
 
     SDCondition uncond;
-    if (cfg_scale != 1.0 || sd_ctx->sd->version == VERSION_INSTRUCT_PIX2PIX && cfg_scale != guidance) {
+    if (cfg_scale != 1.0 || sd_version_use_concat(sd_ctx->sd->version) && cfg_scale != guidance) {
         bool force_zero_embeddings = false;
         if (sd_version_is_sdxl(sd_ctx->sd->version) && negative_prompt.size() == 0 && !sd_ctx->sd->is_using_edm_v_parameterization) {
             force_zero_embeddings = true;
@@ -1541,7 +1541,7 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx,
         cond.c_concat   = masked_latent;
         uncond.c_concat = empty_latent;
         // noise_mask = masked_latent;
-    } else if (sd_ctx->sd->version == VERSION_INSTRUCT_PIX2PIX) {
+    } else if (sd_version_is_edit(sd_ctx->sd->version)) {
         cond.c_concat     = masked_latent;
         auto empty_latent = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, masked_latent->ne[0], masked_latent->ne[1], masked_latent->ne[2], masked_latent->ne[3]);
         ggml_set_f32(empty_latent, 0);
@@ -1883,7 +1883,7 @@ sd_image_t* img2img(sd_ctx_t* sd_ctx,
                 }
             }
         }
-    } else if (sd_ctx->sd->version == VERSION_INSTRUCT_PIX2PIX) {
+    } else if (sd_version_is_edit(sd_ctx->sd->version)) {
         // Not actually masked, we're just highjacking the masked_latent variable since it will be used the same way
         if (!sd_ctx->sd->use_tiny_autoencoder) {
             masked_latent = sd_ctx->sd->get_first_stage_encoding_mode(work_ctx, init_moments);

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -129,14 +129,15 @@ typedef struct {
 
 typedef struct sd_ctx_t sd_ctx_t;
 
-typedef struct sd_slg_params_t {
+typedef struct {
     int* layers;
     size_t layer_count;
     float layer_start;
     float layer_end;
     float scale;
 } sd_slg_params_t;
-typedef struct sd_guidance_params_t {
+
+typedef struct {
     float txt_cfg;
     float img_cfg;
     float min_cfg;

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -129,6 +129,21 @@ typedef struct {
 
 typedef struct sd_ctx_t sd_ctx_t;
 
+typedef struct sd_slg_params_t {
+    int* layers;
+    size_t layer_count;
+    float layer_start;
+    float layer_end;
+    float scale;
+} sd_slg_params_t;
+typedef struct sd_guidance_params_t {
+    float txt_cfg;
+    float img_cfg;
+    float min_cfg;
+    float distilled_guidance;
+    sd_slg_params_t slg;
+} sd_guidance_params_t;
+
 SD_API sd_ctx_t* new_sd_ctx(const char* model_path,
                             const char* clip_l_path,
                             const char* clip_g_path,
@@ -161,8 +176,7 @@ SD_API sd_image_t* txt2img(sd_ctx_t* sd_ctx,
                            const char* prompt,
                            const char* negative_prompt,
                            int clip_skip,
-                           float cfg_scale,
-                           float guidance,
+                           sd_guidance_params_t guidance,
                            float eta,
                            int width,
                            int height,
@@ -174,12 +188,7 @@ SD_API sd_image_t* txt2img(sd_ctx_t* sd_ctx,
                            float control_strength,
                            float style_strength,
                            bool normalize_input,
-                           const char* input_id_images_path,
-                           int* skip_layers,
-                           size_t skip_layers_count,
-                           float slg_scale,
-                           float skip_layer_start,
-                           float skip_layer_end);
+                           const char* input_id_images_path);
 
 SD_API sd_image_t* img2img(sd_ctx_t* sd_ctx,
                            sd_image_t init_image,
@@ -187,8 +196,7 @@ SD_API sd_image_t* img2img(sd_ctx_t* sd_ctx,
                            const char* prompt,
                            const char* negative_prompt,
                            int clip_skip,
-                           float cfg_scale,
-                           float guidance,
+                           sd_guidance_params_t guidance,
                            float eta,
                            int width,
                            int height,
@@ -201,12 +209,7 @@ SD_API sd_image_t* img2img(sd_ctx_t* sd_ctx,
                            float control_strength,
                            float style_strength,
                            bool normalize_input,
-                           const char* input_id_images_path,
-                           int* skip_layers,
-                           size_t skip_layers_count,
-                           float slg_scale,
-                           float skip_layer_start,
-                           float skip_layer_end);
+                           const char* input_id_images_path);
 
 SD_API sd_image_t* img2vid(sd_ctx_t* sd_ctx,
                            sd_image_t init_image,
@@ -216,8 +219,7 @@ SD_API sd_image_t* img2vid(sd_ctx_t* sd_ctx,
                            int motion_bucket_id,
                            int fps,
                            float augmentation_level,
-                           float min_cfg,
-                           float cfg_scale,
+                           sd_guidance_params_t guidance,
                            enum sample_method_t sample_method,
                            int sample_steps,
                            float strength,
@@ -229,25 +231,19 @@ SD_API sd_image_t* edit(sd_ctx_t* sd_ctx,
                         const char* prompt,
                         const char* negative_prompt,
                         int clip_skip,
-                        float cfg_scale,
-                        float guidance,
+                        sd_guidance_params_t guidance,
                         float eta,
                         int width,
                         int height,
                         enum sample_method_t sample_method,
                         int sample_steps,
-                        float strength,
                         int64_t seed,
                         int batch_count,
                         const sd_image_t* control_cond,
                         float control_strength,
                         float style_strength,
                         bool normalize_input,
-                        int* skip_layers,
-                        size_t skip_layers_count,
-                        float slg_scale,
-                        float skip_layer_start,
-                        float skip_layer_end);
+                        const char* input_id_images_path);
 
 typedef struct upscaler_ctx_t upscaler_ctx_t;
 

--- a/unet.hpp
+++ b/unet.hpp
@@ -207,6 +207,8 @@ public:
         }
         if (sd_version_is_inpaint(version)) {
             in_channels = 9;
+        } else if (version == VERSION_INSTRUCT_PIX2PIX) {
+            in_channels = 8;
         }
 
         // dims is always 2

--- a/unet.hpp
+++ b/unet.hpp
@@ -207,7 +207,7 @@ public:
         }
         if (sd_version_is_inpaint(version)) {
             in_channels = 9;
-        } else if (version == VERSION_SD1_PIX2PIX) {
+        } else if (sd_version_is_edit(version)) {
             in_channels = 8;
         }
 

--- a/unet.hpp
+++ b/unet.hpp
@@ -207,7 +207,7 @@ public:
         }
         if (sd_version_is_inpaint(version)) {
             in_channels = 9;
-        } else if (version == VERSION_INSTRUCT_PIX2PIX) {
+        } else if (version == VERSION_SD1_PIX2PIX) {
             in_channels = 8;
         }
 

--- a/unet.hpp
+++ b/unet.hpp
@@ -207,7 +207,7 @@ public:
         }
         if (sd_version_is_inpaint(version)) {
             in_channels = 9;
-        } else if (sd_version_is_edit(version)) {
+        } else if (sd_version_is_unet_edit(version)) {
             in_channels = 8;
         }
 


### PR DESCRIPTION
ref: https://github.com/leejet/stable-diffusion.cpp/discussions/61

`sd.exe -M img2img --model instruct-pix2pix-00-22000.safetensors -p "turn him into a cyborg" --color --strength 1 -i 
.\example.jpg --steps 50 --cfg-scale 7.5 --img-cfg-scale 1.2 --sampling-method euler_a`

| input | output |
| --- | --- | 
| ![example](https://github.com/user-attachments/assets/e5cecf23-fde9-4420-8327-1987ab49660c)  | ![output](https://github.com/user-attachments/assets/784f594a-c4fe-44d7-ac01-e062b93c8f94) |

`sd.exe -M img2img --model instruct-pix2pix-00-22000.safetensors -p "Make it a cat" --strength 1 -i input.png --steps 100 --cfg-scale 7.5 --img-cfg-scale 1.5 --sampling-method euler_a --schedule karras`

| input | output |
| --- | --- | 
| ![input](https://github.com/user-attachments/assets/ed76c83c-c1fc-4759-894c-08b8b0092e14) | ![output](https://github.com/user-attachments/assets/58af9ba2-1536-4092-9ff9-0e8df26c0cdb) | 

TODOs:
- [x] Classifier-free guidance (CFG) for two conditionings
- [x] Fix UX (probably best not to reuse distlled guidance for something completely different like img conditionning)
- [x] Check if implementation is correct