### PR TITLE
fix: allow changing clip_skip back to its default value

### DIFF
--- a/clip.hpp
+++ b/clip.hpp
@@ -701,7 +701,7 @@ public:
 
     void set_clip_skip(int skip) {
         if (skip <= 0) {
-            return;
+            skip = -1;
         }
         clip_skip = skip;
     }


### PR DESCRIPTION
CLIPTextModel ignored setting clip_skip back to -1, instead retaining whatever value was previously defined.

This is not relevant to command-line sd, since it's currently not possible to change clip_skip between generations, but could affect any frontend that reuses model instances for multiple images.