### PR TITLE
Add Custom Scheduler

### DIFF
--- a/denoiser.hpp
+++ b/denoiser.hpp
@@ -485,6 +485,10 @@ static void sample_k_diffusion(sample_method_t method,
 
             for (int i = 0; i < steps; i++) {
                 float sigma = sigmas[i];
+                float sigma_next = sigmas[i+1]; // For logging
+
+                // Log the sigma values for the current step
+                LOG_INFO("Step %d/%zu: sigma_current = %.4f, sigma_next = %.4f", i + 1, steps, sigma, sigma_next);
 
                 // denoise
                 ggml_tensor* denoised = model(x, sigma, i + 1);

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -172,6 +172,8 @@ SD_API sd_image_t* txt2img(sd_ctx_t* sd_ctx,
                            float style_strength,
                            bool normalize_input,
                            const char* input_id_images_path,
+                           const float* custom_sigmas,
+                           int custom_sigmas_count,
                            int* skip_layers,
                            size_t skip_layers_count,
                            float slg_scale,
@@ -199,6 +201,8 @@ SD_API sd_image_t* img2img(sd_ctx_t* sd_ctx,
                            float style_strength,
                            bool normalize_input,
                            const char* input_id_images_path,
+                           const float* custom_sigmas,
+                           int custom_sigmas_count,
                            int* skip_layers,
                            size_t skip_layers_count,
                            float slg_scale,
@@ -218,7 +222,9 @@ SD_API sd_image_t* img2vid(sd_ctx_t* sd_ctx,
                            enum sample_method_t sample_method,
                            int sample_steps,
                            float strength,
-                           int64_t seed);
+                           int64_t seed,
+                           const float* custom_sigmas,
+                           int custom_sigmas_count);
 
 typedef struct upscaler_ctx_t upscaler_ctx_t;
 


### PR DESCRIPTION
Inspired by https://github.com/BlakeOne/ComfyUI-CustomScheduler

![318997896-c5c258ec-49ba-4062-a3aa-9d019d693bfd](https://github.com/user-attachments/assets/6d413914-1921-4768-bec8-43426989739b)

This PR adds a custom scheduler that allows users to manually specify the sigma values for each step.

This is especially useful for debugging when integrating new models that don't work with existing schedulers, or for inference with distilled models such as [SID](https://arxiv.org/pdf/2505.12674), [SIDA](https://arxiv.org/pdf/2410.14919) or [SwD](https://arxiv.org/pdf/2503.16397)

The number of sigma values must match the number of steps. If n_sigmas < steps, the missing values will currently be filled with zeros. I'm considering whether to keep this behavior or instead repeat the last sigma value to fill the vector.

Example command:

`./build/bin/sd -m SiDA_SD15_4.54.54.5_1_lsd100_lsggan0.001_NoEMA_SNR_025634_checkpoint.safetensors  -v -p "A photograph of a cat in winter wonderland. 8k resolution" --cfg-scale 1 --steps 1 --sigmas "2.5" --seed 2025`

For multi-steps, use for example`--sigmas "sigma_0,sigma_1,sigma_2,sigma_3....."`

| Step | sigma_0 = 2.5 | Default Scheduler |
|------|---------------|-------------------|
| Step 1 | ![sigma_on](https://github.com/user-attachments/assets/cfe0774e-51cc-4429-9ef6-26175b2ffd56) | ![sigma_off](https://github.com/user-attachments/assets/2f932399-c428-4fb2-be4d-5cecee7cfdbc) |

I've uploaded a SiDA model checkpoint if someone want to test : [SIDA 1.5](https://huggingface.co/mrfatso/SiDA/blob/main/SiDA_SD15_4.54.54.5_1_lsd100_lsggan0.001_NoEMA_SNR_025634_checkpoint.safetensors)


