### PR TITLE
fix: allow resetting clip_skip to its default value

### DIFF
--- a/clip.hpp
+++ b/clip.hpp
@@ -678,8 +678,8 @@ public:
     bool with_final_ln        = true;
 
     CLIPTextModel(CLIPVersion version = OPENAI_CLIP_VIT_L_14,
-                  int clip_skip_value = -1,
-                  bool with_final_ln  = true)
+                  bool with_final_ln  = true,
+                  int clip_skip_value = -1)
         : version(version), with_final_ln(with_final_ln) {
         if (version == OPEN_CLIP_VIT_H_14) {
             hidden_size       = 1024;
@@ -701,7 +701,7 @@ public:
 
     void set_clip_skip(int skip) {
         if (skip <= 0) {
-            return;
+            skip = -1;
         }
         clip_skip = skip;
     }
@@ -871,9 +871,9 @@ struct CLIPTextModelRunner : public GGMLRunner {
                         std::map<std::string, enum ggml_type>& tensor_types,
                         const std::string prefix,
                         CLIPVersion version = OPENAI_CLIP_VIT_L_14,
-                        int clip_skip_value = 1,
-                        bool with_final_ln  = true)
-        : GGMLRunner(backend), model(version, clip_skip_value, with_final_ln) {
+                        bool with_final_ln  = true,
+                        int clip_skip_value = -1)
+        : GGMLRunner(backend), model(version, with_final_ln, clip_skip_value) {
         model.init(params_ctx, tensor_types, prefix);
     }
 


### PR DESCRIPTION
CLIPTextModel currently ignores attempts to set clip_skip back to -1, retaining the previously set value instead. While this is not an issue to the sd command (which does not support changing clip_skip between generations), it affects frontends that reuse model instances for multiple images.

Since each model version's default clip_skip value is defined by its respective Conditioner class, it needs to be applied every time they get a different clip_skip value, so move that logic from their constructors into their set_clip_skip methods.

Related: LostRuins/koboldcpp#1546

(the original PR #687 was closed because I submitted it on the master branch by mistake)