### PR TITLE
Apply LoRA during model conversion

### DIFF
--- a/clip.hpp
+++ b/clip.hpp
@@ -6,7 +6,7 @@
 
 /*================================================== CLIPTokenizer ===================================================*/
 
-std::pair<std::unordered_map<std::string, float>, std::string> extract_and_remove_lora(std::string text) {
+static inline std::pair<std::unordered_map<std::string, float>, std::string> extract_and_remove_lora(std::string text) {
     std::regex re("<lora:([^:]+):([^>]+)>");
     std::smatch matches;
     std::unordered_map<std::string, float> filename2multiplier;
@@ -31,7 +31,7 @@ std::pair<std::unordered_map<std::string, float>, std::string> extract_and_remov
     return std::make_pair(filename2multiplier, text);
 }
 
-std::vector<std::pair<int, std::u32string>> bytes_to_unicode() {
+static inline std::vector<std::pair<int, std::u32string>> bytes_to_unicode() {
     std::vector<std::pair<int, std::u32string>> byte_unicode_pairs;
     std::set<int> byte_set;
     for (int b = static_cast<int>('!'); b <= static_cast<int>('~'); ++b) {

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -840,7 +840,7 @@ int main(int argc, const char* argv[]) {
     }
 
     if (params.mode == CONVERT) {
-        bool success = convert(params.model_path.c_str(), params.vae_path.c_str(), params.output_path.c_str(), params.wtype);
+        bool success = convert(params.model_path.c_str(), params.vae_path.c_str(), params.output_path.c_str(), params.wtype, params.prompt.c_str(), params.lora_model_dir.c_str());
         if (!success) {
             fprintf(stderr,
                     "convert '%s'/'%s' to '%s' failed\n",

--- a/lora.hpp
+++ b/lora.hpp
@@ -247,7 +247,7 @@ struct LoraModel : public GGMLRunner {
         std::set<std::string> applied_lora_tensors;
         for (auto it : model_tensors) {
             std::string k_tensor       = it.first;
-            struct ggml_tensor* weight = model_tensors[it.first];
+            struct ggml_tensor* weight = it.second;
 
             std::vector<std::string> keys = to_lora_keys(k_tensor, version);
             if (keys.size() == 0)

--- a/model.cpp
+++ b/model.cpp
@@ -10,6 +10,8 @@
 #include "stable-diffusion.h"
 #include "util.h"
 #include "vocab.hpp"
+#include "clip.hpp"
+#include "lora.hpp"
 
 #include "ggml-alloc.h"
 #include "ggml-backend.h"
@@ -1977,7 +1979,7 @@ bool ModelLoader::tensor_should_be_converted(const TensorStorage& tensor_storage
     return false;
 }
 
-bool ModelLoader::save_to_gguf_file(const std::string& file_path, ggml_type type) {
+bool ModelLoader::save_to_gguf_file(const std::string& file_path, ggml_type type, const std::unordered_map<std::string, float>& loras) {
     auto backend    = ggml_backend_cpu_init();
     size_t mem_size = 1 * 1024 * 1024;  // for padding
     mem_size += tensor_storages.size() * ggml_tensor_overhead();
@@ -1986,6 +1988,9 @@ bool ModelLoader::save_to_gguf_file(const std::string& file_path, ggml_type type
     ggml_context* ggml_ctx = ggml_init({mem_size, NULL, false});
 
     gguf_context* gguf_ctx = gguf_init_empty();
+
+    // lora lookup table
+    std::map<std::string, struct ggml_tensor*> tensors;
 
     auto on_new_tensor_cb = [&](const TensorStorage& tensor_storage, ggml_tensor** dst_tensor) -> bool {
         const std::string& name = tensor_storage.name;
@@ -2012,19 +2017,44 @@ bool ModelLoader::save_to_gguf_file(const std::string& file_path, ggml_type type
 
         gguf_add_tensor(gguf_ctx, tensor);
 
+        tensors[name] = tensor;
+
         return true;
     };
 
-    bool success = load_tensors(on_new_tensor_cb, backend);
-    ggml_backend_free(backend);
-    LOG_INFO("load tensors done");
-    LOG_INFO("trying to save tensors to %s", file_path.c_str());
-    if (success) {
-        gguf_write_to_file(gguf_ctx, file_path.c_str(), false);
+    if (!load_tensors(on_new_tensor_cb, backend)) {
+        ggml_backend_free(backend);
+        ggml_free(ggml_ctx);
+        gguf_free(gguf_ctx);
+        return false;
     }
+
+    LOG_INFO("load tensors done");
+
+    for (const auto& [lora_path, lora_scale] : loras) {
+        LoraModel lora(backend, lora_path);
+        if (!lora.load_from_file()) {
+            LOG_WARN("load lora tensors from '%s' failed", lora_path.c_str());
+            ggml_backend_free(backend);
+            ggml_free(ggml_ctx);
+            gguf_free(gguf_ctx);
+            return false;
+        }
+
+        lora.multiplier = lora_scale;
+        lora.apply(tensors, get_sd_version(), 4);
+        lora.free_params_buffer();
+        LOG_INFO("applied '%s':%f", lora_path.c_str(), lora_scale);
+    }
+
+    ggml_backend_free(backend);
+
+    LOG_INFO("trying to save tensors to %s", file_path.c_str());
+    gguf_write_to_file(gguf_ctx, file_path.c_str(), false);
+
     ggml_free(ggml_ctx);
     gguf_free(gguf_ctx);
-    return success;
+    return true;
 }
 
 int64_t ModelLoader::get_params_mem_size(ggml_backend_t backend, ggml_type type) {
@@ -2051,7 +2081,7 @@ int64_t ModelLoader::get_params_mem_size(ggml_backend_t backend, ggml_type type)
     return mem_size;
 }
 
-bool convert(const char* input_path, const char* vae_path, const char* output_path, sd_type_t output_type) {
+bool convert(const char* input_path, const char* vae_path, const char* output_path, sd_type_t output_type, const char* prompt, const char* lora_model_dir) {
     ModelLoader model_loader;
 
     if (!model_loader.init_from_file(input_path)) {
@@ -2065,6 +2095,38 @@ bool convert(const char* input_path, const char* vae_path, const char* output_pa
             return false;
         }
     }
-    bool success = model_loader.save_to_gguf_file(output_path, (ggml_type)output_type);
+
+    // process prompt for loras
+    std::unordered_map<std::string, float> loras;
+    if (prompt != nullptr && lora_model_dir != nullptr) {
+        auto result_pair = extract_and_remove_lora(prompt);
+        std::unordered_map<std::string, float> extracted_loras = result_pair.first;
+
+        for (auto& kv : extracted_loras) {
+            LOG_INFO("lora %s:%.2f", kv.first.c_str(), kv.second);
+
+            // save_to_gguf_file expects file paths
+            std::string st_file_path   = path_join(lora_model_dir, kv.first + ".safetensors");
+            std::string ckpt_file_path = path_join(lora_model_dir, kv.first + ".ckpt");
+            std::string file_path;
+            if (file_exists(st_file_path)) {
+                file_path = st_file_path;
+            } else if (file_exists(ckpt_file_path)) {
+                file_path = ckpt_file_path;
+            } else {
+                LOG_WARN("can not find %s or %s for lora %s", st_file_path.c_str(), ckpt_file_path.c_str(), kv.first.c_str());
+                continue;
+            }
+
+            LOG_INFO("found at '%s'", file_path.c_str());
+            loras[file_path] = kv.second;
+        }
+
+        if (result_pair.second != "") {
+            LOG_WARN("unused prompt after lora extraction: '%s'", result_pair.second.c_str());
+        }
+    }
+
+    bool success = model_loader.save_to_gguf_file(output_path, (ggml_type)output_type, loras);
     return success;
 }

--- a/model.h
+++ b/model.h
@@ -221,7 +221,7 @@ public:
                       ggml_backend_t backend,
                       std::set<std::string> ignore_tensors = {});
 
-    bool save_to_gguf_file(const std::string& file_path, ggml_type type);
+    bool save_to_gguf_file(const std::string& file_path, ggml_type type, const std::unordered_map<std::string, float>& loras = {});
     bool tensor_should_be_converted(const TensorStorage& tensor_storage, ggml_type type);
     int64_t get_params_mem_size(ggml_backend_t backend, ggml_type type = GGML_TYPE_COUNT);
     ~ModelLoader() = default;

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -257,7 +257,7 @@ SD_API void free_upscaler_ctx(upscaler_ctx_t* upscaler_ctx);
 
 SD_API sd_image_t upscale(upscaler_ctx_t* upscaler_ctx, sd_image_t input_image, uint32_t upscale_factor);
 
-SD_API bool convert(const char* input_path, const char* vae_path, const char* output_path, enum sd_type_t output_type);
+SD_API bool convert(const char* input_path, const char* vae_path, const char* output_path, enum sd_type_t output_type, const char* prompt, const char* lora_model_dir);
 
 SD_API uint8_t* preprocess_canny(uint8_t* img,
                                  int width,


### PR DESCRIPTION
Very rough code, but works.
Useful for avoiding the lora overhead during inference, or just mixing your own model from loras.

Patch based on (outdated) @stduhpf / bleedingedge : https://github.com/Green-Sky/stable-diffusion.cpp/commit/69028c722d4a128e1e74ea235e914ea16d3f807f


Keep in mind that the weights are first quantized, and then it tries to apply the loras. (which is very not ideal)

### Example

merging lcm lora into a sd1.5 finetune:
```
$ result/bin/sd -M convert -m models/CyberRealistic_V9_FP16.safetensors --lora-model-dir models/loras/sd1/ -p "<lora:lcm-lora-sdv1-5:1>" -o models/CyberRealistic_V9-lcm-q8_0.gguf
[INFO ] model.cpp:910  - load models/CyberRealistic_V9_FP16.safetensors using safetensors format
[INFO ] model.cpp:2106 - lora lcm-lora-sdv1-5:1.00
[INFO ] model.cpp:2121 - found at 'models/loras/sd1/lcm-lora-sdv1-5.safetensors'
[INFO ] model.cpp:1987 - model tensors mem size: 2035.18MB
  |==================================================| 1131/1131 - 500.00it/s
[INFO ] model.cpp:2032 - load tensors done
[INFO ] model.cpp:910  - load models/loras/sd1/lcm-lora-sdv1-5.safetensors using safetensors format
[INFO ] lora.hpp:117  - loading LoRA from 'models/loras/sd1/lcm-lora-sdv1-5.safetensors'
  |==================================================| 834/834 - 0.00it/s
[INFO ] model.cpp:2047 - applied 'models/loras/sd1/lcm-lora-sdv1-5.safetensors':1.000000
[INFO ] model.cpp:2052 - trying to save tensors to models/CyberRealistic_V9-lcm-q8_0.gguf
convert 'models/CyberRealistic_V9_FP16.safetensors'/'' to 'models/CyberRealistic_V9-lcm-q8_0.gguf' success
```