### PR TITLE
cleanup: do not force VAE type to f32 on SDXL

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -292,11 +292,6 @@ public:
             model_loader.set_wtype_override(wtype);
         }
 
-        if (sd_version_is_sdxl(version)) {
-            vae_wtype = GGML_TYPE_F32;
-            model_loader.set_wtype_override(GGML_TYPE_F32, "vae.");
-        }
-
         LOG_INFO("Weight type:                 %s", ggml_type_name(model_wtype));
         LOG_INFO("Conditioner weight type:     %s", ggml_type_name(conditioner_wtype));
         LOG_INFO("Diffusion model weight type: %s", ggml_type_name(diffusion_model_wtype));


### PR DESCRIPTION
This seems to be a leftover from the initial SDXL support: it's not enough to avoid NaN issues, and it's not not needed for the fixed sdxl-vae-fp16-fix .