### PR TITLE
fix: further increase LORA_GRAPH_SIZE

### DIFF
--- a/lora.hpp
+++ b/lora.hpp
@@ -3,7 +3,7 @@
 
 #include "ggml_extend.hpp"
 
-#define LORA_GRAPH_SIZE 15360
+#define LORA_GRAPH_SIZE 20480
 
 struct LoraModel : public GGMLRunner {
     enum lora_t {


### PR DESCRIPTION
It turns out 15360 is still not enough for some SDXL LoRAs; for instance, a quantized SDXL model with the DMD2 LoRA.

Koboldcpp has been using 20480 for some time, so this value should be enough.

Hopefully fixes #648 , #684 and #688 .