### PR TITLE
model.cpp: add t5xxl encoder.embed_tokens.weight as unused tensor

### DIFF
--- a/model.cpp
+++ b/model.cpp
@@ -100,6 +100,7 @@ const char* unused_tensors[] = {
     "model_ema.diffusion_model",
     "embedding_manager",
     "denoiser.sigmas",
+    "text_encoders.t5xxl.transformer.encoder.embed_tokens.weight", // only used during training
 };
 
 bool is_unused_tensor(std::string name) {


### PR DESCRIPTION
In some unstripped t5xxl models there is an additional tensor which is used during training, but results in a message when loaded into stable-diffusion.cpp like the following:

`model.cpp:1868 - unknown tensor 'text_encoders.t5xxl.transformer.encoder.embed_tokens.weight | q4_K | 2 [4096, 32128, 1, 1, 1]' in model file`

Should be able to safely skip it without the message.