### PR TITLE
flash attention: correct head dim check and L_k padding

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -840,18 +840,34 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_attention_ext(struct ggml_context*
 
     float scale = (1.0f / sqrt((float)d_head));
 
-    // if (flash_attn) {
-    //     LOG_DEBUG("attention_ext L_q:%d L_k:%d n_head:%d C:%d d_head:%d N:%d", L_q, L_k, n_head, C, d_head, N);
-    // }
+    int kv_pad = 0;
+    if (flash_attn) {
+        LOG_DEBUG("attention_ext L_q:%d L_k:%d n_head:%d C:%d d_head:%d N:%d", L_q, L_k, n_head, C, d_head, N);
+    }
     //  is there anything oddly shaped?? ping Green-Sky if you can trip this assert
     GGML_ASSERT(((L_k % 256 == 0) && L_q == L_k) || !(L_k % 256 == 0));
 
     bool can_use_flash_attn = true;
+    can_use_flash_attn = can_use_flash_attn && (
+        d_head == 64 ||
+        d_head == 80 ||
+        d_head == 96 ||
+        d_head == 112 ||
+        d_head == 128 ||
+        d_head == 256
+    );
+#if 0
     can_use_flash_attn      = can_use_flash_attn && L_k % 256 == 0;
-    can_use_flash_attn      = can_use_flash_attn && d_head % 64 == 0;  // double check
-
-    // cuda max d_head seems to be 256, cpu does seem to work with 512
-    can_use_flash_attn = can_use_flash_attn && d_head <= 256;  // double check
+#else
+    if (can_use_flash_attn && L_k % 256 != 0) {
+        // TODO(Green-Sky): might be worth just padding by default
+        if (L_k == 77 || L_k == 4208 || L_k == 3952) {
+            kv_pad = GGML_PAD(L_k, 256) - L_k;
+        } else {
+            can_use_flash_attn = false;
+        }
+    }
+#endif
 
     if (mask != nullptr) {
         // TODO(Green-Sky): figure out if we can bend t5 to work too
@@ -864,11 +880,18 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_attention_ext(struct ggml_context*
     ggml_tensor* kqv = nullptr;
     // GGML_ASSERT((flash_attn && can_use_flash_attn) || !flash_attn);
     if (can_use_flash_attn && flash_attn) {
-        // LOG_DEBUG("using flash attention");
+        LOG_DEBUG(" uses flash attention");
+        if (kv_pad != 0) {
+            LOG_DEBUG(" padding k and v dim1 by %d", kv_pad);
+            k = ggml_pad(ctx, k, 0, kv_pad, 0, 0);
+        }
         k = ggml_cast(ctx, k, GGML_TYPE_F16);
 
         v = ggml_cont(ctx, ggml_permute(ctx, v, 0, 2, 1, 3));  // [N, n_head, L_k, d_head]
         v = ggml_reshape_3d(ctx, v, d_head, L_k, n_head * N);  // [N * n_head, L_k, d_head]
+        if (kv_pad != 0) {
+            v = ggml_pad(ctx, v, 0, kv_pad, 0, 0);
+        }
         v = ggml_cast(ctx, v, GGML_TYPE_F16);
 
         if (mask != nullptr) {

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -841,9 +841,9 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_attention_ext(struct ggml_context*
     float scale = (1.0f / sqrt((float)d_head));
 
     int kv_pad = 0;
-    if (flash_attn) {
-        LOG_DEBUG("attention_ext L_q:%d L_k:%d n_head:%d C:%d d_head:%d N:%d", L_q, L_k, n_head, C, d_head, N);
-    }
+    //if (flash_attn) {
+    //    LOG_DEBUG("attention_ext L_q:%d L_k:%d n_head:%d C:%d d_head:%d N:%d", L_q, L_k, n_head, C, d_head, N);
+    //}
     //  is there anything oddly shaped?? ping Green-Sky if you can trip this assert
     GGML_ASSERT(((L_k % 256 == 0) && L_q == L_k) || !(L_k % 256 == 0));
 
@@ -880,9 +880,9 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_attention_ext(struct ggml_context*
     ggml_tensor* kqv = nullptr;
     // GGML_ASSERT((flash_attn && can_use_flash_attn) || !flash_attn);
     if (can_use_flash_attn && flash_attn) {
-        LOG_DEBUG(" uses flash attention");
+        //LOG_DEBUG(" uses flash attention");
         if (kv_pad != 0) {
-            LOG_DEBUG(" padding k and v dim1 by %d", kv_pad);
+            //LOG_DEBUG(" padding k and v dim1 by %d", kv_pad);
             k = ggml_pad(ctx, k, 0, kv_pad, 0, 0);
         }
         k = ggml_cast(ctx, k, GGML_TYPE_F16);


### PR DESCRIPTION
Gains are minimal, if any.
SD1 now has some usage of flash attention.

Some numbers where found by @bssrdf in #386 .

From what I can tell, the numbers should translate to vulkan and probably rocm pretty well.

## sd1

| model | backend | resolution | before sampling time | after sampling time | before comp buff | after comp buff
|--------|--------|--------|--------|--------|--------|--------|
| CyberRealistic_V9_FP16, 30steps, 5cfg | cuda | 512x768 | 20.37s | **19.57s** | 1220.07 MB | **1218.29 MB** |
| CyberRealistic_V9-q8_0, 30steps, 5cfg | cuda | 512x768 | 20.99s | **20.01s** | 1220.07 MB | **1218.29 MB** |
| CyberRealistic_V9_FP16, 30steps, 5cfg | cuda | 768x1024 | 69.43s | **66.23s** | 4736.59 MB | **4734.80 MB** |
| CyberRealistic_V9-q8_0, 30steps, 5cfg | cuda | 768x1024 | 69.66s | **66.77s** | 4736.59 MB | **4734.80 MB** |

<details><summary>fattn log</summary>

```
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:6144 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:77 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:6144 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:77 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:1536 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:77 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:1536 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:77 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:384 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:77 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:384 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:77 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:96 L_k:96 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:96 L_k:77 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:384 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:77 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:384 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:77 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:384 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:384 L_k:77 n_head:8 C:1280 d_head:160 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:1536 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:77 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:1536 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:77 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:1536 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:1536 L_k:77 n_head:8 C:640 d_head:80 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:6144 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:77 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:6144 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:77 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:6144 n_head:8 C:320 d_head:40 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:6144 L_k:77 n_head:8 C:320 d_head:40 N:1

```

</details> 

# SDXL

Affected from padding L_k.

| model | backend | resolution | before sampling time | after sampling time | before comp buff | after comp buff
|--------|--------|--------|--------|--------|--------|--------|
| RealVisXL_V3.0_Turbo, q8_0, 8steps, 3cfg | cuda | 768x768 | 7.67s | **7.52s** | 280.89 MB | **277.01 MB** |
| RealVisXL_V3.0_Turbo, q8_0, 8steps, 3cfg | cuda | 1024x1024 | 11.07s | **10.81s** | **440.86 MB** | 491.99 MB |
| RealVisXL_V3.0_Turbo, q8_0, 8steps, 3cfg | vulkan | 768x768 | **10.49s** | 10.68s | 280.89 MB | **277.01 MB** |
| RealVisXL_V3.0_Turbo, q8_0, 8steps, 3cfg | vulkan | 1024x1024 | **18.66s** | 18.77s | **440.86 MB** | 491.99 MB |

<details><summary>fattn log 768x768</summary>

```
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:576 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:576 L_k:77 n_head:20 C:1280 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:2304 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:845  - attention_ext L_q:2304 L_k:77 n_head:10 C:640 d_head:64 N:1
[DEBUG] ggml_extend.hpp:883  -  uses flash attention
[DEBUG] ggml_extend.hpp:885  -  padding k and v dim1 by 179
```

</details> 

SD2 and flux stay the same, besides some wonky resolutions.

Device is rtx2070 8gig mobile.
Vulkan with `coopmat1` only.