### PR TITLE
Add sd.cpp-webui as an available frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ These projects use `stable-diffusion.cpp` as a backend for their image generatio
 - [Stable Diffusion GUI](https://github.com/fszontagh/sd.cpp.gui.wx)
 - [Stable Diffusion CLI-GUI](https://github.com/piallai/stable-diffusion.cpp)
 - [Local Diffusion](https://github.com/rmatif/Local-Diffusion)
+- [sd.cpp-webui](https://github.com/daniandtheweb/sd.cpp-webui)
 
 ## Contributors
 


### PR DESCRIPTION
[sd.cpp-webui](https://github.com/daniandtheweb/sd.cpp-webui) is a frontend for stable-diffusion.cpp that I've been developing for a while.
It started as a simple way to test changes to the backend as it's mostly a command generator that calls directly the sd binary but that allows to easily swap between versions just by pasting in the main sd.cpp-webui folder a different binary version, no reload required.

Right now this frontend has most of the features of the main program (I'm working on adding the missing ones) and has a built in gallery with a metadata reader to easily access the image information of the images generated with this program (there's also a fallback that tries to read the metadata of images originally created on ComfyUI so that prompts can be easily reused).

I'd love to get some feedback on this and if anyone has any improvement to suggest I'd be happy to hear it.