### PR TITLE
Change image dimensions requirement for DiT models

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -596,13 +596,13 @@ void parse_args(int argc, const char** argv, SDParams& params) {
         exit(1);
     }
 
-    if (params.width <= 0 || params.width % 64 != 0) {
-        fprintf(stderr, "error: the width must be a multiple of 64\n");
+    if (params.width <= 0) {
+        fprintf(stderr, "error: the width must be greater than 0\n");
         exit(1);
     }
 
-    if (params.height <= 0 || params.height % 64 != 0) {
-        fprintf(stderr, "error: the height must be a multiple of 64\n");
+    if (params.height <= 0) {
+        fprintf(stderr, "error: the height must be greater than 0\n");
         exit(1);
     }
 

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1875,6 +1875,15 @@ ggml_tensor* generate_init_latent(sd_ctx_t* sd_ctx,
 sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_gen_params) {
     int width  = sd_img_gen_params->width;
     int height = sd_img_gen_params->height;
+    if (sd_version_is_dit(sd_ctx->sd->version)) {
+        if (width % 16 || height % 16) {
+            LOG_ERROR("Image dimensions must be must be a multiple of 16 on each axis for %s models. (Got %dx%d)", model_version_to_str[sd_ctx->sd->version], width, height);
+            return NULL;
+        }
+    } else if (width % 64 || height % 64) {
+        LOG_ERROR("Image dimensions must be must be a multiple of 64 on each axis for %s models. (Got %dx%d)", model_version_to_str[sd_ctx->sd->version], width, height);
+        return NULL;
+    }
     LOG_DEBUG("generate_image %dx%d", width, height);
     if (sd_ctx == NULL || sd_img_gen_params == NULL) {
         return NULL;


### PR DESCRIPTION
Currently, there is a requirement on the CLI to ensure that the image dimensions are multiple of 64. This is because the unet architecture of stable diffusion expects the latent image to be divisible by 8 (8 latent pixels is 64 pixels) in each dimension, but the supported DiT models like SD3 and Flux don't have the same requirements

With Flux and SD3.x, the image dimensions need to be divisible by 8 for the VAE, but then the transformer can run without crashing on latent images of arbitrary size.  I've noticed that the images look very broken if the dimensions of the latents are odd (and it would also break VAE tiling), so I added a requirement for the dimensions to be multiple of 16. (looks like a positional encoding issue that could be fixable?)

As there is no way to know the architecture of the model from the CLI, I had to move the check to the stable-diffusion.cpp file in the generate_image function. The downside of doing so is that the model has to be loaded (which can take some time) at the creation of the sd_ctx, before we can check if the image dimensions are correct.  