### PR TITLE
add missing models and parameters to image metadata

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -677,10 +677,16 @@ std::string get_image_params(SDParams params, int64_t seed) {
     parameter_string += "Model: " + sd_basename(params.model_path) + ", ";
     parameter_string += "RNG: " + std::string(sd_rng_type_name(params.rng_type)) + ", ";
     parameter_string += "Sampler: " + std::string(sd_sample_method_name(params.sample_method));
-    if (params.schedule == KARRAS) {
-        parameter_string += " karras";
+    if (params.schedule != DEFAULT) {
+        parameter_string += " " + std::string(sd_schedule_name(params.schedule));
     }
     parameter_string += ", ";
+    if (!params.vae_path.empty()) {
+        parameter_string += "VAE: " + sd_basename(params.vae_path) + ", ";
+    }
+    if (params.clip_skip != -1) {
+        parameter_string += "Clip skip: " + std::to_string(params.clip_skip) + ", ";
+    }
     parameter_string += "Version: stable-diffusion.cpp";
     return parameter_string;
 }

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -681,6 +681,14 @@ std::string get_image_params(SDParams params, int64_t seed) {
         parameter_string += " " + std::string(sd_schedule_name(params.schedule));
     }
     parameter_string += ", ";
+    for (const auto& te : {params.clip_l_path, params.clip_g_path, params.t5xxl_path}) {
+        if (!te.empty()) {
+            parameter_string += "TE: " + sd_basename(te) + ", ";
+        }
+    }
+    if (!params.diffusion_model_path.empty()) {
+        parameter_string += "Unet: " + sd_basename(params.diffusion_model_path) + ", ";
+    }
     if (!params.vae_path.empty()) {
         parameter_string += "VAE: " + sd_basename(params.vae_path) + ", ";
     }


### PR DESCRIPTION
This updates and supersedes #316 . I adjusted the original PR to make use of the new API functions, but preserved the original author, since it was just a minor tweak.

I also included diffusion and text encoder models into the metadata, following the auto111 format. But it's not clear how multiple text encoders should be included: all examples I've found used a simple 'TE:' prefix.