### PR TITLE
Add flow shift parameter (for SD3 and Wan)

### DIFF
--- a/denoiser.hpp
+++ b/denoiser.hpp
@@ -382,7 +382,7 @@ struct DiscreteFlowDenoiser : public Denoiser {
 
     float sigma_data = 1.0f;
 
-    DiscreteFlowDenoiser() {
+    DiscreteFlowDenoiser(float shift = 3.0f) : shift(shift) {
         set_parameters();
     }
 

--- a/denoiser.hpp
+++ b/denoiser.hpp
@@ -382,7 +382,8 @@ struct DiscreteFlowDenoiser : public Denoiser {
 
     float sigma_data = 1.0f;
 
-    DiscreteFlowDenoiser(float shift = 3.0f) : shift(shift) {
+    DiscreteFlowDenoiser(float shift = 3.0f)
+        : shift(shift) {
         set_parameters();
     }
 

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -115,6 +115,7 @@ struct SDParams {
     bool chroma_use_dit_mask = true;
     bool chroma_use_t5_mask  = false;
     int chroma_t5_mask_pad   = 1;
+    float flow_shift         = INFINITY;
 
     SDParams() {
         sd_sample_params_init(&sample_params);
@@ -278,8 +279,9 @@ void print_usage(int argc, const char* argv[]) {
     printf("  --chroma-t5-mask-pad  PAD_SIZE     t5 mask pad size of chroma\n");
     printf("  --video-frames                     video frames (default: 1)\n");
     printf("  --fps                              fps (default: 24)\n");
-    printf("  --moe-boundary BOUNDARY            Timestep boundary for Wan2.2 MoE model. (default: 0.875)\n");
-    printf("                                     Only enabled if `--high-noise-steps` is set to -1\n");
+    printf("  --moe-boundary BOUNDARY            timestep boundary for Wan2.2 MoE model. (default: 0.875)\n");
+    printf("                                     only enabled if `--high-noise-steps` is set to -1\n");
+    printf("  --flow-shift SHIFT                 shift value for Flow models like SD3.x or WAN (default: auto)\n"); 
     printf("  -v, --verbose                      print extra info\n");
 }
 
@@ -514,6 +516,7 @@ void parse_args(int argc, const char** argv, SDParams& params) {
         {"", "--style-ratio", "", &params.style_ratio},
         {"", "--control-strength", "", &params.control_strength},
         {"", "--moe-boundary", "", &params.moe_boundary},
+        {"", "--flow-shift", "", &params.flow_shift},
     };
 
     options.bool_options = {
@@ -1181,6 +1184,7 @@ int main(int argc, const char* argv[]) {
         params.chroma_use_dit_mask,
         params.chroma_use_t5_mask,
         params.chroma_t5_mask_pad,
+        params.flow_shift,
     };
 
     sd_ctx_t* sd_ctx = new_sd_ctx(&sd_ctx_params);

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -172,6 +172,7 @@ void print_params(SDParams params) {
     printf("    sample_params:                     %s\n", SAFE_STR(sample_params_str));
     printf("    high_noise_sample_params:          %s\n", SAFE_STR(high_noise_sample_params_str));
     printf("    moe_boundary:                      %.3f\n", params.moe_boundary);
+    printf("    flow_shift:                        %.2f\n", params.flow_shift);
     printf("    strength(img2img):                 %.2f\n", params.strength);
     printf("    rng:                               %s\n", sd_rng_type_name(params.rng_type));
     printf("    seed:                              %ld\n", params.seed);
@@ -281,7 +282,7 @@ void print_usage(int argc, const char* argv[]) {
     printf("  --fps                              fps (default: 24)\n");
     printf("  --moe-boundary BOUNDARY            timestep boundary for Wan2.2 MoE model. (default: 0.875)\n");
     printf("                                     only enabled if `--high-noise-steps` is set to -1\n");
-    printf("  --flow-shift SHIFT                 shift value for Flow models like SD3.x or WAN (default: auto)\n"); 
+    printf("  --flow-shift SHIFT                 shift value for Flow models like SD3.x or WAN (default: auto)\n");
     printf("  -v, --verbose                      print extra info\n");
 }
 

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -681,7 +681,11 @@ public:
 
         if (sd_version_is_sd3(version)) {
             LOG_INFO("running in FLOW mode");
-            denoiser = std::make_shared<DiscreteFlowDenoiser>();
+            float shift = sd_ctx_params->flow_shift;
+            if( shift == INFINITY){
+                shift = 3.0;
+            }
+            denoiser = std::make_shared<DiscreteFlowDenoiser>(shift);
         } else if (sd_version_is_flux(version)) {
             LOG_INFO("running in Flux FLOW mode");
             float shift = 1.0f;  // TODO: validate
@@ -694,7 +698,14 @@ public:
             denoiser = std::make_shared<FluxFlowDenoiser>(shift);
         } else if (sd_version_is_wan(version)) {
             LOG_INFO("running in FLOW mode");
-            denoiser = std::make_shared<DiscreteFlowDenoiser>();
+            float shift = sd_ctx_params->flow_shift;
+            if(shift == INFINITY) {
+                shift = 5.0;
+                if (version == VERSION_WAN2){
+                    shift = 12.0;
+                }
+            }
+            denoiser = std::make_shared<DiscreteFlowDenoiser>(shift);
         } else if (is_using_v_parameterization) {
             LOG_INFO("running in v-prediction mode");
             denoiser = std::make_shared<CompVisVDenoiser>();
@@ -1553,6 +1564,7 @@ void sd_ctx_params_init(sd_ctx_params_t* sd_ctx_params) {
     sd_ctx_params->chroma_use_dit_mask     = true;
     sd_ctx_params->chroma_use_t5_mask      = false;
     sd_ctx_params->chroma_t5_mask_pad      = 1;
+    sd_ctx_params->flow_shift              = INFINITY;
 }
 
 char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -682,7 +682,7 @@ public:
         if (sd_version_is_sd3(version)) {
             LOG_INFO("running in FLOW mode");
             float shift = sd_ctx_params->flow_shift;
-            if( shift == INFINITY){
+            if (shift == INFINITY) {
                 shift = 3.0;
             }
             denoiser = std::make_shared<DiscreteFlowDenoiser>(shift);
@@ -699,11 +699,8 @@ public:
         } else if (sd_version_is_wan(version)) {
             LOG_INFO("running in FLOW mode");
             float shift = sd_ctx_params->flow_shift;
-            if(shift == INFINITY) {
+            if (shift == INFINITY) {
                 shift = 5.0;
-                if (version == VERSION_WAN2){
-                    shift = 12.0;
-                }
             }
             denoiser = std::make_shared<DiscreteFlowDenoiser>(shift);
         } else if (is_using_v_parameterization) {

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -142,6 +142,7 @@ typedef struct {
     bool chroma_use_dit_mask;
     bool chroma_use_t5_mask;
     int chroma_t5_mask_pad;
+    float flow_shift;
 } sd_ctx_params_t;
 
 typedef struct {


### PR DESCRIPTION
 Targets #778 but could easily be applied to master for SD3.x alone.

## Examples:

### T2I

| model | shift 1.5 | shift 3 | shift 6 | shift 12 | shift 24 |
| --- | --- | --- | --- | --- | --- |
| Wan2.2 T2V (with 20 total steps, using #779) | <img width="512" height="512" alt="shift1 5" src="https://github.com/user-attachments/assets/5fe01ba9-2624-4a68-93dd-d9211eea519f" /> | <img width="512" height="512" alt="shift3" src="https://github.com/user-attachments/assets/2ea849ee-f19c-4eb1-94bc-68f698e10b56" /> | <img width="512" height="512" alt="shift6" src="https://github.com/user-attachments/assets/20140d0b-4719-41f2-8c19-cbeab0d854aa" /> | <img width="512" height="512" alt="shift12" src="https://github.com/user-attachments/assets/f44541aa-9980-429c-9a06-b35861f8b51a" /> | <img width="512" height="512" alt="shift24" src="https://github.com/user-attachments/assets/482e819f-3023-43dc-a139-4c65c8a39001" /> |
| Wan2.2 T2V (with 10+10 steps) | <img width="512" height="512" alt="shift1 5" src="https://github.com/user-attachments/assets/900e20eb-2711-4e5c-86e1-4fda431808d0" /> | <img width="512" height="512" alt="shift3" src="https://github.com/user-attachments/assets/3179f030-2d27-4b2b-9144-d7097c3185c1" /> | <img width="512" height="512" alt="shift6" src="https://github.com/user-attachments/assets/e3fb2c78-e982-45f8-97ce-d89efc0ed9d7" /> | <img width="512" height="512" alt="shift12" src="https://github.com/user-attachments/assets/5d7fb199-f347-40bf-8a2f-d20b283de345" /> | <img width="512" height="512" alt="shift24" src="https://github.com/user-attachments/assets/55e0cb23-0b25-42c5-b032-1f8c01be3ffc" /> |
| Wan2.2 TI2V 5B (40 steps) | <img width="512" height="512" alt="shift1 5" src="https://github.com/user-attachments/assets/5b07beaa-b146-4df0-98eb-b76765934d8c" /> | <img width="512" height="512" alt="shift3" src="https://github.com/user-attachments/assets/c2939032-6520-4e3a-9b27-c08c4f602ad3" /> | <img width="512" height="512" alt="shift6" src="https://github.com/user-attachments/assets/dfa7e430-9190-4555-9b19-8922bf3e49fe" /> | <img width="512" height="512" alt="shift12" src="https://github.com/user-attachments/assets/055ba131-0d34-4b1b-9aee-ba669bd8c7b9" /> | <img width="512" height="512" alt="shift24" src="https://github.com/user-attachments/assets/90986db2-f7aa-4fb0-83e7-a42b6b8f3eab" /> |
| SD3.5 medium (20 steps) | <img width="512" height="512" alt="shift1 5" src="https://github.com/user-attachments/assets/24a1abad-22b3-4a01-a090-a268d43efb08" /> | <img width="512" height="512" alt="shift3" src="https://github.com/user-attachments/assets/56d4f3e5-4f03-4914-a791-9df459101759" /> | <img width="512" height="512" alt="shift6" src="https://github.com/user-attachments/assets/159dc291-8129-4c55-accb-ca7c75f10998" /> | <img width="512" height="512" alt="shift12" src="https://github.com/user-attachments/assets/6f19a565-9460-4f8c-a312-2fca9ce8ba9b" /> | <img width="512" height="512" alt="shift24" src="https://github.com/user-attachments/assets/02b68bb9-a563-4955-afb0-63d49d5661fa" /> |
| SD3.5 Large Turbo (6 steps) | <img width="512" height="512" alt="shift1 5" src="https://github.com/user-attachments/assets/7d89481f-9beb-44ef-a1ac-36cb35c3fef3" /> | <img width="512" height="512" alt="shift3" src="https://github.com/user-attachments/assets/049af4ef-ebf8-4552-90f1-8b1c90956ba8" /> | <img width="512" height="512" alt="shift6" src="https://github.com/user-attachments/assets/d1d4d170-0497-4fa5-b355-140cf205990e" /> | <img width="512" height="512" alt="shift12" src="https://github.com/user-attachments/assets/5402122f-20a1-448e-8614-b526f91f1e40" /> | <img width="512" height="512" alt="shift24" src="https://github.com/user-attachments/assets/faf6da37-516b-4b21-8735-a78944bbf493" /> |
| SD3.5 Large (20 steps) | <img width="512" height="512" alt="shift1 5" src="https://github.com/user-attachments/assets/43ea618b-9eec-4720-bb88-0b2c63c5809b" /> | <img width="512" height="512" alt="shift3" src="https://github.com/user-attachments/assets/eb282d76-255a-4aa6-9c07-9ef627940274" /> | <img width="512" height="512" alt="shift6" src="https://github.com/user-attachments/assets/91a53ad6-a8a2-4ca6-bc81-4a6bfe2fc5ef" /> | <img width="512" height="512" alt="shift12" src="https://github.com/user-attachments/assets/945cf703-3a75-4ce8-9a24-1d6822a6115f" /> | <img width="512" height="512" alt="shift24" src="https://github.com/user-attachments/assets/3416859c-202e-4fa7-b317-20563519e916" />|






(note that when using 10+10 steps on Wan2.2 A14B, sampling falls out of distribution for extreme shift values, resulting in very poor quality. Using the automatic switching step introduced in #779 fixes that )


### T2V

| model | shift 3 | shift 6 | shift 12 | 
| --- | --- | --- | --- |
| Wan2.2 T2V (with 20 total steps, using #779) | ![shift3](https://github.com/user-attachments/assets/c0404a5a-8130-448c-af2c-cb833fbc3ab1) | ![shift6](https://github.com/user-attachments/assets/12a05e3f-34f5-4362-ba8d-0d5062ce9364) | ![shift12](https://github.com/user-attachments/assets/2aa7581e-ba31-46a0-b450-c063d751354b) |
| Wan2.2 T2V (with 10+10 steps) | ![shift3](https://github.com/user-attachments/assets/f7659cdc-3776-4fbc-9a47-064ac4acec24) | ![shift6](https://github.com/user-attachments/assets/aab5d759-de9e-4fdb-b124-126f20390b06) | ![shift12](https://github.com/user-attachments/assets/ca2b4280-f70d-427b-98fb-e12c5508b87d) |
| Wan2.2 TI2V 5B (40 steps) | ![shift3](https://github.com/user-attachments/assets/5f3366cc-526e-4919-bca0-867294fee1f4) | ![shift6](https://github.com/user-attachments/assets/86f1c682-9f6d-4590-b31c-acdd86210cca) | ![shift12](https://github.com/user-attachments/assets/04381131-18e1-4e14-ada1-63d15b0ec64d) |




