### PR TITLE
Modernize use nullptr

### DIFF
--- a/clip.hpp
+++ b/clip.hpp
@@ -575,7 +575,7 @@ public:
 
         GGML_ASSERT(input_ids->ne[0] == position_embed_weight->ne[1]);
         input_ids            = ggml_reshape_3d(ctx, input_ids, input_ids->ne[0], 1, input_ids->ne[1]);
-        auto token_embedding = ggml_get_rows(ctx, custom_embed_weight != NULL ? custom_embed_weight : token_embed_weight, input_ids);
+        auto token_embedding = ggml_get_rows(ctx, custom_embed_weight != nullptr ? custom_embed_weight : token_embed_weight, input_ids);
         token_embedding      = ggml_reshape_3d(ctx, token_embedding, token_embedding->ne[0], token_embedding->ne[1], token_embedding->ne[3]);
 
         // token_embedding + position_embedding
@@ -629,7 +629,7 @@ public:
         // concat(patch_embedding, class_embedding) + position_embedding
         struct ggml_tensor* patch_embedding;
         int64_t N       = pixel_values->ne[3];
-        patch_embedding = ggml_nn_conv_2d(ctx, pixel_values, patch_embed_weight, NULL, patch_size, patch_size);  // [N, embed_dim, image_size // pacht_size, image_size // pacht_size]
+        patch_embedding = ggml_nn_conv_2d(ctx, pixel_values, patch_embed_weight, nullptr, patch_size, patch_size);  // [N, embed_dim, image_size // pacht_size, image_size // pacht_size]
         patch_embedding = ggml_reshape_3d(ctx, patch_embedding, num_patches, embed_dim, N);                      // [N, embed_dim, num_patches]
         patch_embedding = ggml_cont(ctx, ggml_permute(ctx, patch_embedding, 1, 0, 2, 3));                        // [N, num_patches, embed_dim]
         patch_embedding = ggml_reshape_4d(ctx, patch_embedding, 1, embed_dim, num_patches, N);                   // [N, num_patches, embed_dim, 1]
@@ -730,8 +730,8 @@ public:
         if (return_pooled) {
             auto text_projection = params["text_projection"];
             ggml_tensor* pooled  = ggml_view_1d(ctx, x, hidden_size, x->nb[1] * max_token_idx);
-            if (text_projection != NULL) {
-                pooled = ggml_nn_linear(ctx, pooled, text_projection, NULL);
+            if (text_projection != nullptr) {
+                pooled = ggml_nn_linear(ctx, pooled, text_projection, nullptr);
             } else {
                 LOG_DEBUG("identity projection");
             }
@@ -830,7 +830,7 @@ public:
         if (transpose_weight) {
             w = ggml_cont(ctx, ggml_transpose(ctx, w));
         }
-        return ggml_nn_linear(ctx, x, w, NULL);
+        return ggml_nn_linear(ctx, x, w, nullptr);
     }
 };
 
@@ -916,16 +916,16 @@ struct CLIPTextModelRunner : public GGMLRunner {
 
     struct ggml_cgraph* build_graph(struct ggml_tensor* input_ids,
                                     int num_custom_embeddings    = 0,
-                                    void* custom_embeddings_data = NULL,
+                                    void* custom_embeddings_data = nullptr,
                                     size_t max_token_idx         = 0,
                                     bool return_pooled           = false) {
         struct ggml_cgraph* gf = ggml_new_graph(compute_ctx);
 
         input_ids = to_backend(input_ids);
 
-        struct ggml_tensor* embeddings = NULL;
+        struct ggml_tensor* embeddings = nullptr;
 
-        if (num_custom_embeddings > 0 && custom_embeddings_data != NULL) {
+        if (num_custom_embeddings > 0 && custom_embeddings_data != nullptr) {
             auto token_embed_weight = model.get_token_embed_weight();
             auto custom_embeddings  = ggml_new_tensor_2d(compute_ctx,
                                                          token_embed_weight->type,
@@ -951,7 +951,7 @@ struct CLIPTextModelRunner : public GGMLRunner {
                  size_t max_token_idx,
                  bool return_pooled,
                  ggml_tensor** output,
-                 ggml_context* output_ctx = NULL) {
+                 ggml_context* output_ctx = nullptr) {
         auto get_graph = [&]() -> struct ggml_cgraph* {
             return build_graph(input_ids, num_custom_embeddings, custom_embeddings_data, max_token_idx, return_pooled);
         };

--- a/common.hpp
+++ b/common.hpp
@@ -121,7 +121,7 @@ public:
         }
     }
 
-    virtual struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x, struct ggml_tensor* emb = NULL) {
+    virtual struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x, struct ggml_tensor* emb = nullptr) {
         // For dims==3, we reduce dimension from 5d to 4d by merging h and w, in order not to change ggml
         // [N, c, t, h, w] => [N, c, t, h * w]
         // x: [N, channels, h, w] if dims == 2 else [N, channels, t, h, w]
@@ -131,7 +131,7 @@ public:
         auto out_layers_0 = std::dynamic_pointer_cast<GroupNorm32>(blocks["out_layers.0"]);
         auto out_layers_3 = std::dynamic_pointer_cast<UnaryBlock>(blocks["out_layers.3"]);
 
-        if (emb == NULL) {
+        if (emb == nullptr) {
             GGML_ASSERT(skip_t_emb);
         }
 
@@ -288,7 +288,7 @@ public:
         auto k = to_k->forward(ctx, context);  // [N, n_context, inner_dim]
         auto v = to_v->forward(ctx, context);  // [N, n_context, inner_dim]
 
-        x = ggml_nn_attention_ext(ctx, q, k, v, n_head, NULL, false, false, flash_attn);  // [N, n_token, inner_dim]
+        x = ggml_nn_attention_ext(ctx, q, k, v, n_head, nullptr, false, false, flash_attn);  // [N, n_token, inner_dim]
 
         x = to_out_0->forward(ctx, x);  // [N, n_token, query_dim]
         return x;

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -5,9 +5,9 @@
 #include "t5.hpp"
 
 struct SDCondition {
-    struct ggml_tensor* c_crossattn = NULL;  // aka context
-    struct ggml_tensor* c_vector    = NULL;  // aka y
-    struct ggml_tensor* c_concat    = NULL;
+    struct ggml_tensor* c_crossattn = nullptr;  // aka context
+    struct ggml_tensor* c_vector    = nullptr;  // aka y
+    struct ggml_tensor* c_concat    = nullptr;
 
     SDCondition() = default;
     SDCondition(struct ggml_tensor* c_crossattn, struct ggml_tensor* c_vector, struct ggml_tensor* c_concat)
@@ -130,11 +130,11 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
         }
         struct ggml_init_params params;
         params.mem_size               = 10 * 1024 * 1024;  // max for custom embeddings 10 MB
-        params.mem_buffer             = NULL;
+        params.mem_buffer             = nullptr;
         params.no_alloc               = false;
         struct ggml_context* embd_ctx = ggml_init(params);
-        struct ggml_tensor* embd      = NULL;
-        struct ggml_tensor* embd2     = NULL;
+        struct ggml_tensor* embd      = nullptr;
+        struct ggml_tensor* embd2     = nullptr;
         auto on_load                  = [&](const TensorStorage& tensor_storage, ggml_tensor** dst_tensor) {
             if (tensor_storage.ne[0] != text_model->model.hidden_size) {
                 if (text_model2) {
@@ -414,11 +414,11 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
                                              bool zero_out_masked = false) {
         set_clip_skip(clip_skip);
         int64_t t0                               = ggml_time_ms();
-        struct ggml_tensor* hidden_states        = NULL;  // [N, n_token, hidden_size]
-        struct ggml_tensor* chunk_hidden_states  = NULL;  // [n_token, hidden_size] or [n_token, hidden_size + hidden_size2]
-        struct ggml_tensor* chunk_hidden_states1 = NULL;  // [n_token, hidden_size]
-        struct ggml_tensor* chunk_hidden_states2 = NULL;  // [n_token, hidden_size2]
-        struct ggml_tensor* pooled               = NULL;
+        struct ggml_tensor* hidden_states        = nullptr;  // [N, n_token, hidden_size]
+        struct ggml_tensor* chunk_hidden_states  = nullptr;  // [n_token, hidden_size] or [n_token, hidden_size + hidden_size2]
+        struct ggml_tensor* chunk_hidden_states1 = nullptr;  // [n_token, hidden_size]
+        struct ggml_tensor* chunk_hidden_states2 = nullptr;  // [n_token, hidden_size2]
+        struct ggml_tensor* pooled               = nullptr;
         std::vector<float> hidden_states_vec;
 
         size_t chunk_len   = 77;
@@ -430,7 +430,7 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
                                              weights.begin() + (chunk_idx + 1) * chunk_len);
 
             auto input_ids                 = vector_to_ggml_tensor_i32(work_ctx, chunk_tokens);
-            struct ggml_tensor* input_ids2 = NULL;
+            struct ggml_tensor* input_ids2 = nullptr;
             size_t max_token_idx           = 0;
             if (sd_version_is_sdxl(version)) {
                 auto it = std::find(chunk_tokens.begin(), chunk_tokens.end(), tokenizer.EOS_TOKEN_ID);
@@ -515,7 +515,7 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
                                         chunk_hidden_states->ne[0],
                                         ggml_nelements(hidden_states) / chunk_hidden_states->ne[0]);
 
-        ggml_tensor* vec = NULL;
+        ggml_tensor* vec = nullptr;
         if (sd_version_is_sdxl(version)) {
             int out_dim = 256;
             vec         = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, adm_in_channels);
@@ -552,7 +552,7 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
             GGML_ASSERT(offset == ggml_nbytes(vec));
         }
         // print_ggml_tensor(result);
-        return SDCondition(hidden_states, vec, NULL);
+        return SDCondition(hidden_states, vec, nullptr);
     }
 
     std::tuple<SDCondition, std::vector<bool>>
@@ -755,7 +755,7 @@ struct SD3CLIPEmbedder : public Conditioner {
 
         clip_l_tokenizer.pad_tokens(clip_l_tokens, clip_l_weights, max_length, padding);
         clip_g_tokenizer.pad_tokens(clip_g_tokens, clip_g_weights, max_length, padding);
-        t5_tokenizer.pad_tokens(t5_tokens, t5_weights, NULL, max_length, padding);
+        t5_tokenizer.pad_tokens(t5_tokens, t5_weights, nullptr, max_length, padding);
 
         // for (int i = 0; i < clip_l_tokens.size(); i++) {
         //     std::cout << clip_l_tokens[i] << ":" << clip_l_weights[i] << ", ";
@@ -789,14 +789,14 @@ struct SD3CLIPEmbedder : public Conditioner {
         auto& t5_weights     = token_and_weights[2].second;
 
         int64_t t0                                 = ggml_time_ms();
-        struct ggml_tensor* hidden_states          = NULL;  // [N, n_token*2, 4096]
-        struct ggml_tensor* chunk_hidden_states    = NULL;  // [n_token*2, 4096]
-        struct ggml_tensor* chunk_hidden_states_l  = NULL;  // [n_token, hidden_size_l]
-        struct ggml_tensor* chunk_hidden_states_g  = NULL;  // [n_token, hidden_size_g]
-        struct ggml_tensor* chunk_hidden_states_t5 = NULL;  // [n_token, hidden_size_t5]
-        struct ggml_tensor* pooled                 = NULL;
-        struct ggml_tensor* pooled_l               = NULL;  // [768,]
-        struct ggml_tensor* pooled_g               = NULL;  // [1280,]
+        struct ggml_tensor* hidden_states          = nullptr;  // [N, n_token*2, 4096]
+        struct ggml_tensor* chunk_hidden_states    = nullptr;  // [n_token*2, 4096]
+        struct ggml_tensor* chunk_hidden_states_l  = nullptr;  // [n_token, hidden_size_l]
+        struct ggml_tensor* chunk_hidden_states_g  = nullptr;  // [n_token, hidden_size_g]
+        struct ggml_tensor* chunk_hidden_states_t5 = nullptr;  // [n_token, hidden_size_t5]
+        struct ggml_tensor* pooled                 = nullptr;
+        struct ggml_tensor* pooled_l               = nullptr;  // [768,]
+        struct ggml_tensor* pooled_g               = nullptr;  // [1280,]
         std::vector<float> hidden_states_vec;
 
         size_t chunk_len   = 77;
@@ -815,7 +815,7 @@ struct SD3CLIPEmbedder : public Conditioner {
                 clip_l->compute(n_threads,
                                 input_ids,
                                 0,
-                                NULL,
+                                nullptr,
                                 max_token_idx,
                                 false,
                                 &chunk_hidden_states_l,
@@ -842,7 +842,7 @@ struct SD3CLIPEmbedder : public Conditioner {
                     clip_l->compute(n_threads,
                                     input_ids,
                                     0,
-                                    NULL,
+                                    nullptr,
                                     max_token_idx,
                                     true,
                                     &pooled_l,
@@ -863,7 +863,7 @@ struct SD3CLIPEmbedder : public Conditioner {
                 clip_g->compute(n_threads,
                                 input_ids,
                                 0,
-                                NULL,
+                                nullptr,
                                 max_token_idx,
                                 false,
                                 &chunk_hidden_states_g,
@@ -891,7 +891,7 @@ struct SD3CLIPEmbedder : public Conditioner {
                     clip_g->compute(n_threads,
                                     input_ids,
                                     0,
-                                    NULL,
+                                    nullptr,
                                     max_token_idx,
                                     true,
                                     &pooled_g,
@@ -910,7 +910,7 @@ struct SD3CLIPEmbedder : public Conditioner {
 
                 t5->compute(n_threads,
                             input_ids,
-                            NULL,
+                            nullptr,
                             &chunk_hidden_states_t5,
                             work_ctx);
                 {
@@ -975,7 +975,7 @@ struct SD3CLIPEmbedder : public Conditioner {
                                         hidden_states,
                                         chunk_hidden_states->ne[0],
                                         ggml_nelements(hidden_states) / chunk_hidden_states->ne[0]);
-        return SDCondition(hidden_states, pooled, NULL);
+        return SDCondition(hidden_states, pooled, nullptr);
     }
 
     SDCondition get_learned_condition(ggml_context* work_ctx,
@@ -1089,7 +1089,7 @@ struct FluxCLIPEmbedder : public Conditioner {
         }
 
         clip_l_tokenizer.pad_tokens(clip_l_tokens, clip_l_weights, 77, padding);
-        t5_tokenizer.pad_tokens(t5_tokens, t5_weights, NULL, max_length, padding);
+        t5_tokenizer.pad_tokens(t5_tokens, t5_weights, nullptr, max_length, padding);
 
         // for (int i = 0; i < clip_l_tokens.size(); i++) {
         //     std::cout << clip_l_tokens[i] << ":" << clip_l_weights[i] << ", ";
@@ -1116,9 +1116,9 @@ struct FluxCLIPEmbedder : public Conditioner {
         auto& t5_weights     = token_and_weights[1].second;
 
         int64_t t0                              = ggml_time_ms();
-        struct ggml_tensor* hidden_states       = NULL;  // [N, n_token, 4096]
-        struct ggml_tensor* chunk_hidden_states = NULL;  // [n_token, 4096]
-        struct ggml_tensor* pooled              = NULL;  // [768,]
+        struct ggml_tensor* hidden_states       = nullptr;  // [N, n_token, 4096]
+        struct ggml_tensor* chunk_hidden_states = nullptr;  // [n_token, 4096]
+        struct ggml_tensor* pooled              = nullptr;  // [768,]
         std::vector<float> hidden_states_vec;
 
         size_t chunk_count = t5_tokens.size() / chunk_len;
@@ -1140,7 +1140,7 @@ struct FluxCLIPEmbedder : public Conditioner {
                 clip_l->compute(n_threads,
                                 input_ids,
                                 0,
-                                NULL,
+                                nullptr,
                                 max_token_idx,
                                 true,
                                 &pooled,
@@ -1158,7 +1158,7 @@ struct FluxCLIPEmbedder : public Conditioner {
 
                 t5->compute(n_threads,
                             input_ids,
-                            NULL,
+                            nullptr,
                             &chunk_hidden_states,
                             work_ctx);
                 {
@@ -1197,7 +1197,7 @@ struct FluxCLIPEmbedder : public Conditioner {
                                         hidden_states,
                                         chunk_hidden_states->ne[0],
                                         ggml_nelements(hidden_states) / chunk_hidden_states->ne[0]);
-        return SDCondition(hidden_states, pooled, NULL);
+        return SDCondition(hidden_states, pooled, nullptr);
     }
 
     SDCondition get_learned_condition(ggml_context* work_ctx,
@@ -1333,9 +1333,9 @@ struct T5CLIPEmbedder : public Conditioner {
         auto& t5_attn_mask_vec = std::get<2>(token_and_weights);
 
         int64_t t0                              = ggml_time_ms();
-        struct ggml_tensor* hidden_states       = NULL;  // [N, n_token, 4096]
-        struct ggml_tensor* chunk_hidden_states = NULL;  // [n_token, 4096]
-        struct ggml_tensor* pooled              = NULL;
+        struct ggml_tensor* hidden_states       = nullptr;  // [N, n_token, 4096]
+        struct ggml_tensor* chunk_hidden_states = nullptr;  // [n_token, 4096]
+        struct ggml_tensor* pooled              = nullptr;
         struct ggml_tensor* t5_attn_mask        = vector_to_ggml_tensor(work_ctx, t5_attn_mask_vec);  // [n_token]
 
         std::vector<float> hidden_states_vec;
@@ -1352,7 +1352,7 @@ struct T5CLIPEmbedder : public Conditioner {
                                           t5_attn_mask_vec.begin() + (chunk_idx + 1) * chunk_len);
 
             auto input_ids          = vector_to_ggml_tensor_i32(work_ctx, chunk_tokens);
-            auto t5_attn_mask_chunk = use_mask ? vector_to_ggml_tensor(work_ctx, chunk_mask) : NULL;
+            auto t5_attn_mask_chunk = use_mask ? vector_to_ggml_tensor(work_ctx, chunk_mask) : nullptr;
 
             t5->compute(n_threads,
                         input_ids,
@@ -1404,7 +1404,7 @@ struct T5CLIPEmbedder : public Conditioner {
 
         modify_mask_to_attend_padding(t5_attn_mask, ggml_nelements(t5_attn_mask), mask_pad);
 
-        return SDCondition(hidden_states, t5_attn_mask, NULL);
+        return SDCondition(hidden_states, t5_attn_mask, nullptr);
     }
 
     SDCondition get_learned_condition(ggml_context* work_ctx,

--- a/control.hpp
+++ b/control.hpp
@@ -204,18 +204,18 @@ public:
                                              struct ggml_tensor* guided_hint,
                                              struct ggml_tensor* timesteps,
                                              struct ggml_tensor* context,
-                                             struct ggml_tensor* y = NULL) {
+                                             struct ggml_tensor* y = nullptr) {
         // x: [N, in_channels, h, w] or [N, in_channels/2, h, w]
         // timesteps: [N,]
         // context: [N, max_position, hidden_size] or [1, max_position, hidden_size]. for example, [N, 77, 768]
         // y: [N, adm_in_channels] or [1, adm_in_channels]
-        if (context != NULL) {
+        if (context != nullptr) {
             if (context->ne[2] != x->ne[3]) {
                 context = ggml_repeat(ctx, context, ggml_new_tensor_3d(ctx, GGML_TYPE_F32, context->ne[0], context->ne[1], x->ne[3]));
             }
         }
 
-        if (y != NULL) {
+        if (y != nullptr) {
             if (y->ne[1] != x->ne[3]) {
                 y = ggml_repeat(ctx, y, ggml_new_tensor_2d(ctx, GGML_TYPE_F32, y->ne[0], x->ne[3]));
             }
@@ -235,7 +235,7 @@ public:
         emb      = time_embed_2->forward(ctx, emb);  // [N, time_embed_dim]
 
         // SDXL/SVD
-        if (y != NULL) {
+        if (y != nullptr) {
             auto label_embed_0 = std::dynamic_pointer_cast<Linear>(blocks["label_emb.0.0"]);
             auto label_embed_2 = std::dynamic_pointer_cast<Linear>(blocks["label_emb.0.2"]);
 
@@ -248,7 +248,7 @@ public:
 
         std::vector<struct ggml_tensor*> outs;
 
-        if (guided_hint == NULL) {
+        if (guided_hint == nullptr) {
             guided_hint = input_hint_block_forward(ctx, hint, emb, context);
         }
         outs.push_back(guided_hint);
@@ -310,10 +310,10 @@ struct ControlNet : public GGMLRunner {
     SDVersion version = VERSION_SD1;
     ControlNetBlock control_net;
 
-    ggml_backend_buffer_t control_buffer = NULL;  // keep control output tensors in backend memory
-    ggml_context* control_ctx            = NULL;
+    ggml_backend_buffer_t control_buffer = nullptr;  // keep control output tensors in backend memory
+    ggml_context* control_ctx            = nullptr;
     std::vector<struct ggml_tensor*> controls;  // (12 input block outputs, 1 middle block output) SD 1.5
-    struct ggml_tensor* guided_hint = NULL;     // guided_hint cache, for faster inference
+    struct ggml_tensor* guided_hint = nullptr;     // guided_hint cache, for faster inference
     bool guided_hint_cached         = false;
 
     ControlNet(ggml_backend_t backend,
@@ -342,7 +342,7 @@ struct ControlNet : public GGMLRunner {
     void alloc_control_ctx(std::vector<struct ggml_tensor*> outs) {
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(outs.size() * ggml_tensor_overhead()) + 1024 * 1024;
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = true;
         control_ctx       = ggml_init(params);
 
@@ -364,15 +364,15 @@ struct ControlNet : public GGMLRunner {
     }
 
     void free_control_ctx() {
-        if (control_buffer != NULL) {
+        if (control_buffer != nullptr) {
             ggml_backend_buffer_free(control_buffer);
-            control_buffer = NULL;
+            control_buffer = nullptr;
         }
-        if (control_ctx != NULL) {
+        if (control_ctx != nullptr) {
             ggml_free(control_ctx);
-            control_ctx = NULL;
+            control_ctx = nullptr;
         }
-        guided_hint        = NULL;
+        guided_hint        = nullptr;
         guided_hint_cached = false;
         controls.clear();
     }
@@ -389,12 +389,12 @@ struct ControlNet : public GGMLRunner {
                                     struct ggml_tensor* hint,
                                     struct ggml_tensor* timesteps,
                                     struct ggml_tensor* context,
-                                    struct ggml_tensor* y = NULL) {
+                                    struct ggml_tensor* y = nullptr) {
         struct ggml_cgraph* gf = ggml_new_graph_custom(compute_ctx, CONTROL_NET_GRAPH_SIZE, false);
 
         x = to_backend(x);
         if (guided_hint_cached) {
-            hint = NULL;
+            hint = nullptr;
         } else {
             hint = to_backend(hint);
         }
@@ -405,12 +405,12 @@ struct ControlNet : public GGMLRunner {
         auto outs = control_net.forward(compute_ctx,
                                         x,
                                         hint,
-                                        guided_hint_cached ? guided_hint : NULL,
+                                        guided_hint_cached ? guided_hint : nullptr,
                                         timesteps,
                                         context,
                                         y);
 
-        if (control_ctx == NULL) {
+        if (control_ctx == nullptr) {
             alloc_control_ctx(outs);
         }
 
@@ -428,8 +428,8 @@ struct ControlNet : public GGMLRunner {
                  struct ggml_tensor* timesteps,
                  struct ggml_tensor* context,
                  struct ggml_tensor* y,
-                 struct ggml_tensor** output     = NULL,
-                 struct ggml_context* output_ctx = NULL) {
+                 struct ggml_tensor** output     = nullptr,
+                 struct ggml_context* output_ctx = nullptr) {
         // x: [N, in_channels, h, w]
         // timesteps: [N, ]
         // context: [N, max_position, hidden_size]([N, 77, 768]) or [1, max_position, hidden_size]

--- a/diffusion_model.hpp
+++ b/diffusion_model.hpp
@@ -19,8 +19,8 @@ struct DiffusionModel {
                          int num_video_frames                      = -1,
                          std::vector<struct ggml_tensor*> controls = {},
                          float control_strength                    = 0.f,
-                         struct ggml_tensor** output               = NULL,
-                         struct ggml_context* output_ctx           = NULL,
+                         struct ggml_tensor** output               = nullptr,
+                         struct ggml_context* output_ctx           = nullptr,
                          std::vector<int> skip_layers              = std::vector<int>())             = 0;
     virtual void alloc_params_buffer()                                                  = 0;
     virtual void free_params_buffer()                                                   = 0;
@@ -80,8 +80,8 @@ struct UNetModel : public DiffusionModel {
                  int num_video_frames                      = -1,
                  std::vector<struct ggml_tensor*> controls = {},
                  float control_strength                    = 0.f,
-                 struct ggml_tensor** output               = NULL,
-                 struct ggml_context* output_ctx           = NULL,
+                 struct ggml_tensor** output               = nullptr,
+                 struct ggml_context* output_ctx           = nullptr,
                  std::vector<int> skip_layers              = std::vector<int>()) {
         (void)skip_layers;  // SLG doesn't work with UNet models
         return unet.compute(n_threads, x, timesteps, context, c_concat, y, num_video_frames, controls, control_strength, output, output_ctx);
@@ -136,8 +136,8 @@ struct MMDiTModel : public DiffusionModel {
                  int num_video_frames                      = -1,
                  std::vector<struct ggml_tensor*> controls = {},
                  float control_strength                    = 0.f,
-                 struct ggml_tensor** output               = NULL,
-                 struct ggml_context* output_ctx           = NULL,
+                 struct ggml_tensor** output               = nullptr,
+                 struct ggml_context* output_ctx           = nullptr,
                  std::vector<int> skip_layers              = std::vector<int>()) {
         return mmdit.compute(n_threads, x, timesteps, context, y, output, output_ctx, skip_layers);
     }
@@ -194,8 +194,8 @@ struct FluxModel : public DiffusionModel {
                  int num_video_frames                      = -1,
                  std::vector<struct ggml_tensor*> controls = {},
                  float control_strength                    = 0.f,
-                 struct ggml_tensor** output               = NULL,
-                 struct ggml_context* output_ctx           = NULL,
+                 struct ggml_tensor** output               = nullptr,
+                 struct ggml_context* output_ctx           = nullptr,
                  std::vector<int> skip_layers              = std::vector<int>()) {
         return flux.compute(n_threads, x, timesteps, context, c_concat, y, guidance, ref_latents, output, output_ctx, skip_layers);
     }
@@ -253,10 +253,10 @@ struct WanModel : public DiffusionModel {
                  int num_video_frames                      = -1,
                  std::vector<struct ggml_tensor*> controls = {},
                  float control_strength                    = 0.f,
-                 struct ggml_tensor** output               = NULL,
-                 struct ggml_context* output_ctx           = NULL,
+                 struct ggml_tensor** output               = nullptr,
+                 struct ggml_context* output_ctx           = nullptr,
                  std::vector<int> skip_layers              = std::vector<int>()) {
-        return wan.compute(n_threads, x, timesteps, context, y, c_concat, NULL, output, output_ctx);
+        return wan.compute(n_threads, x, timesteps, context, y, c_concat, nullptr, output, output_ctx);
     }
 };
 

--- a/esrgan.hpp
+++ b/esrgan.hpp
@@ -199,7 +199,7 @@ struct ESRGAN : public GGMLRunner {
     void compute(const int n_threads,
                  struct ggml_tensor* x,
                  ggml_tensor** output,
-                 ggml_context* output_ctx = NULL) {
+                 ggml_context* output_ctx = nullptr) {
         auto get_graph = [&]() -> struct ggml_cgraph* {
             return build_graph(x);
         };

--- a/examples/cli/avi_writer.h
+++ b/examples/cli/avi_writer.h
@@ -149,7 +149,7 @@ int create_mjpg_avi_from_sd_images(const char* filename, sd_image_t* images, int
     } jpeg_data;
 
     for (int i = 0; i < num_images; i++) {
-        jpeg_data.buf  = NULL;
+        jpeg_data.buf  = nullptr;
         jpeg_data.size = 0;
 
         // Callback function to collect JPEG data into memory

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -543,7 +543,7 @@ void parse_args(int argc, const char** argv, SDParams& params) {
             return -1;
         }
         const char* mode = argv[index];
-        if (mode != NULL) {
+        if (mode != nullptr) {
             int mode_found = -1;
             for (int i = 0; i < MODE_COUNT; i++) {
                 if (!strcmp(mode, modes_str[i])) {
@@ -807,7 +807,7 @@ void parse_args(int argc, const char** argv, SDParams& params) {
     }
 
     if (params.seed < 0) {
-        srand((int)time(NULL));
+        srand((int)time(nullptr));
         params.seed = rand();
     }
 
@@ -930,9 +930,9 @@ void sd_log_cb(enum sd_log_level_t level, const char* log, void* data) {
 uint8_t* load_image(const char* image_path, int& width, int& height, int expected_width = 0, int expected_height = 0, int expected_channel = 3) {
     int c                 = 0;
     uint8_t* image_buffer = (uint8_t*)stbi_load(image_path, &width, &height, &c, expected_channel);
-    if (image_buffer == NULL) {
+    if (image_buffer == nullptr) {
         fprintf(stderr, "load image from '%s' failed\n", image_path);
-        return NULL;
+        return nullptr;
     }
     if (c < expected_channel) {
         fprintf(stderr,
@@ -942,17 +942,17 @@ uint8_t* load_image(const char* image_path, int& width, int& height, int expecte
                 c,
                 image_path);
         free(image_buffer);
-        return NULL;
+        return nullptr;
     }
     if (width <= 0) {
         fprintf(stderr, "error: the width of image must be greater than 0, image_path = %s\n", image_path);
         free(image_buffer);
-        return NULL;
+        return nullptr;
     }
     if (height <= 0) {
         fprintf(stderr, "error: the height of image must be greater than 0, image_path = %s\n", image_path);
         free(image_buffer);
-        return NULL;
+        return nullptr;
     }
 
     // Resize input image ...
@@ -974,10 +974,10 @@ uint8_t* load_image(const char* image_path, int& width, int& height, int expecte
         if (crop_x != 0 || crop_y != 0) {
             printf("crop input image from %dx%d to %dx%d, image_path = %s\n", width, height, crop_w, crop_h, image_path);
             uint8_t* cropped_image_buffer = (uint8_t*)malloc(crop_w * crop_h * expected_channel);
-            if (cropped_image_buffer == NULL) {
+            if (cropped_image_buffer == nullptr) {
                 fprintf(stderr, "error: allocate memory for crop\n");
                 free(image_buffer);
-                return NULL;
+                return nullptr;
             }
             for (int row = 0; row < crop_h; row++) {
                 uint8_t* src = image_buffer + ((crop_y + row) * width + crop_x) * expected_channel;
@@ -996,10 +996,10 @@ uint8_t* load_image(const char* image_path, int& width, int& height, int expecte
         int resized_width  = expected_width;
 
         uint8_t* resized_image_buffer = (uint8_t*)malloc(resized_height * resized_width * expected_channel);
-        if (resized_image_buffer == NULL) {
+        if (resized_image_buffer == nullptr) {
             fprintf(stderr, "error: allocate memory for resize input image\n");
             free(image_buffer);
-            return NULL;
+            return nullptr;
         }
         stbir_resize(image_buffer, width, height, 0,
                      resized_image_buffer, resized_width, resized_height, 0, STBIR_TYPE_UINT8,
@@ -1049,10 +1049,10 @@ int main(int argc, const char* argv[]) {
     }
 
     bool vae_decode_only     = true;
-    sd_image_t init_image    = {(uint32_t)params.width, (uint32_t)params.height, 3, NULL};
-    sd_image_t end_image     = {(uint32_t)params.width, (uint32_t)params.height, 3, NULL};
-    sd_image_t control_image = {(uint32_t)params.width, (uint32_t)params.height, 3, NULL};
-    sd_image_t mask_image    = {(uint32_t)params.width, (uint32_t)params.height, 1, NULL};
+    sd_image_t init_image    = {(uint32_t)params.width, (uint32_t)params.height, 3, nullptr};
+    sd_image_t end_image     = {(uint32_t)params.width, (uint32_t)params.height, 3, nullptr};
+    sd_image_t control_image = {(uint32_t)params.width, (uint32_t)params.height, 3, nullptr};
+    sd_image_t mask_image    = {(uint32_t)params.width, (uint32_t)params.height, 1, nullptr};
     std::vector<sd_image_t> ref_images;
 
     auto release_all_resources = [&]() {
@@ -1062,7 +1062,7 @@ int main(int argc, const char* argv[]) {
         free(mask_image.data);
         for (auto ref_image : ref_images) {
             free(ref_image.data);
-            ref_image.data = NULL;
+            ref_image.data = nullptr;
         }
         ref_images.clear();
     };
@@ -1073,7 +1073,7 @@ int main(int argc, const char* argv[]) {
         int width       = 0;
         int height      = 0;
         init_image.data = load_image(params.init_image_path.c_str(), width, height, params.width, params.height);
-        if (init_image.data == NULL) {
+        if (init_image.data == nullptr) {
             fprintf(stderr, "load image from '%s' failed\n", params.init_image_path.c_str());
             release_all_resources();
             return 1;
@@ -1086,7 +1086,7 @@ int main(int argc, const char* argv[]) {
         int width      = 0;
         int height     = 0;
         end_image.data = load_image(params.end_image_path.c_str(), width, height, params.width, params.height);
-        if (end_image.data == NULL) {
+        if (end_image.data == nullptr) {
             fprintf(stderr, "load image from '%s' failed\n", params.end_image_path.c_str());
             release_all_resources();
             return 1;
@@ -1098,7 +1098,7 @@ int main(int argc, const char* argv[]) {
         int width       = 0;
         int height      = 0;
         mask_image.data = load_image(params.mask_image_path.c_str(), width, height, params.width, params.height, 1);
-        if (mask_image.data == NULL) {
+        if (mask_image.data == nullptr) {
             fprintf(stderr, "load image from '%s' failed\n", params.mask_image_path.c_str());
             release_all_resources();
             return 1;
@@ -1106,7 +1106,7 @@ int main(int argc, const char* argv[]) {
     } else {
         mask_image.data = (uint8_t*)malloc(params.width * params.height);
         memset(mask_image.data, 255, params.width * params.height);
-        if (mask_image.data == NULL) {
+        if (mask_image.data == nullptr) {
             fprintf(stderr, "malloc mask image failed\n");
             release_all_resources();
             return 1;
@@ -1117,7 +1117,7 @@ int main(int argc, const char* argv[]) {
         int width          = 0;
         int height         = 0;
         control_image.data = load_image(params.control_image_path.c_str(), width, height, params.width, params.height);
-        if (control_image.data == NULL) {
+        if (control_image.data == nullptr) {
             fprintf(stderr, "load image from '%s' failed\n", params.control_image_path.c_str());
             release_all_resources();
             return 1;
@@ -1140,7 +1140,7 @@ int main(int argc, const char* argv[]) {
             int width             = 0;
             int height            = 0;
             uint8_t* image_buffer = load_image(path.c_str(), width, height);
-            if (image_buffer == NULL) {
+            if (image_buffer == nullptr) {
                 fprintf(stderr, "load image from '%s' failed\n", path.c_str());
                 release_all_resources();
                 return 1;
@@ -1191,7 +1191,7 @@ int main(int argc, const char* argv[]) {
 
     sd_ctx_t* sd_ctx = new_sd_ctx(&sd_ctx_params);
 
-    if (sd_ctx == NULL) {
+    if (sd_ctx == nullptr) {
         printf("new_sd_ctx_t failed\n");
         release_all_resources();
         return 1;
@@ -1243,7 +1243,7 @@ int main(int argc, const char* argv[]) {
         results = generate_video(sd_ctx, &vid_gen_params, &num_results);
     }
 
-    if (results == NULL) {
+    if (results == nullptr) {
         printf("generate failed\n");
         free_sd_ctx(sd_ctx);
         return 1;
@@ -1256,17 +1256,17 @@ int main(int argc, const char* argv[]) {
                                                         params.diffusion_conv_direct,
                                                         params.n_threads);
 
-        if (upscaler_ctx == NULL) {
+        if (upscaler_ctx == nullptr) {
             printf("new_upscaler_ctx failed\n");
         } else {
             for (int i = 0; i < params.batch_count; i++) {
-                if (results[i].data == NULL) {
+                if (results[i].data == nullptr) {
                     continue;
                 }
                 sd_image_t current_image = results[i];
                 for (int u = 0; u < params.upscale_repeats; ++u) {
                     sd_image_t upscaled_image = upscale(upscaler_ctx, current_image, upscale_factor);
-                    if (upscaled_image.data == NULL) {
+                    if (upscaled_image.data == nullptr) {
                         printf("upscale failed\n");
                         break;
                     }
@@ -1310,7 +1310,7 @@ int main(int argc, const char* argv[]) {
             file_ext = ".png";
         }
         for (int i = 0; i < num_results; i++) {
-            if (results[i].data == NULL) {
+            if (results[i].data == nullptr) {
                 continue;
             }
             std::string final_image_path = i > 0 ? base_path + "_" + std::to_string(i + 1) + file_ext : base_path + file_ext;
@@ -1328,7 +1328,7 @@ int main(int argc, const char* argv[]) {
 
     for (int i = 0; i < num_results; i++) {
         free(results[i].data);
-        results[i].data = NULL;
+        results[i].data = nullptr;
     }
     free(results);
     free_sd_ctx(sd_ctx);

--- a/flux.hpp
+++ b/flux.hpp
@@ -181,11 +181,11 @@ namespace Flux {
     };
 
     struct ModulationOut {
-        ggml_tensor* shift = NULL;
-        ggml_tensor* scale = NULL;
-        ggml_tensor* gate  = NULL;
+        ggml_tensor* shift = nullptr;
+        ggml_tensor* scale = nullptr;
+        ggml_tensor* gate  = nullptr;
 
-        ModulationOut(ggml_tensor* shift = NULL, ggml_tensor* scale = NULL, ggml_tensor* gate = NULL)
+        ModulationOut(ggml_tensor* shift = nullptr, ggml_tensor* scale = nullptr, ggml_tensor* gate = nullptr)
             : shift(shift), scale(scale), gate(gate) {}
 
         ModulationOut(struct ggml_context* ctx, ggml_tensor* vec, int64_t offset) {
@@ -303,7 +303,7 @@ namespace Flux {
                                                                     struct ggml_tensor* txt,
                                                                     struct ggml_tensor* vec,
                                                                     struct ggml_tensor* pe,
-                                                                    struct ggml_tensor* mask = NULL) {
+                                                                    struct ggml_tensor* mask = nullptr) {
             // img: [N, n_img_token, hidden_size]
             // txt: [N, n_txt_token, hidden_size]
             // pe: [n_img_token + n_txt_token, d_head/2, 2, 2]
@@ -449,7 +449,7 @@ namespace Flux {
                                     struct ggml_tensor* x,
                                     struct ggml_tensor* vec,
                                     struct ggml_tensor* pe,
-                                    struct ggml_tensor* mask = NULL) {
+                                    struct ggml_tensor* mask = nullptr) {
             // x: [N, n_token, hidden_size]
             // pe: [n_token, d_head/2, 2, 2]
             // return: [N, n_token, hidden_size]
@@ -528,7 +528,7 @@ namespace Flux {
             auto shift     = ggml_view_2d(ctx, vec, vec->ne[0], vec->ne[1], vec->nb[1], stride * (offset + 0));  // [N, dim]
             auto scale     = ggml_view_2d(ctx, vec, vec->ne[0], vec->ne[1], vec->nb[1], stride * (offset + 1));  // [N, dim]
             // No gate
-            return ModulationOut(shift, scale, NULL);
+            return ModulationOut(shift, scale, nullptr);
         }
 
         struct ggml_tensor* forward(struct ggml_context* ctx,
@@ -705,7 +705,7 @@ namespace Flux {
                                          struct ggml_tensor* y,
                                          struct ggml_tensor* guidance,
                                          struct ggml_tensor* pe,
-                                         struct ggml_tensor* mod_index_arange = NULL,
+                                         struct ggml_tensor* mod_index_arange = nullptr,
                                          std::vector<int> skip_layers         = {}) {
             auto img_in      = std::dynamic_pointer_cast<Linear>(blocks["img_in"]);
             auto txt_in      = std::dynamic_pointer_cast<Linear>(blocks["txt_in"]);
@@ -713,7 +713,7 @@ namespace Flux {
 
             img = img_in->forward(ctx, img);
             struct ggml_tensor* vec;
-            struct ggml_tensor* txt_img_mask = NULL;
+            struct ggml_tensor* txt_img_mask = nullptr;
             if (params.is_chroma) {
                 int64_t mod_index_length = 344;
                 auto approx              = std::dynamic_pointer_cast<ChromaApproximator>(blocks["distilled_guidance_layer"]);
@@ -722,7 +722,7 @@ namespace Flux {
 
                 // auto mod_index_arange  = ggml_arange(ctx, 0, (float)mod_index_length, 1);
                 // ggml_arange tot working on a lot of backends, precomputing it on CPU instead
-                GGML_ASSERT(arange != NULL);
+                GGML_ASSERT(arange != nullptr);
                 auto modulation_index = ggml_nn_timestep_embedding(ctx, mod_index_arange, 32, 10000, 1000.f);  // [1, 344, 32]
 
                 // Batch broadcast (will it ever be useful)
@@ -736,7 +736,7 @@ namespace Flux {
                 vec = ggml_cont(ctx, ggml_permute(ctx, vec, 0, 2, 1, 3));  // [344, N, 64]
                 vec = approx->forward(ctx, vec);                           // [344, N, hidden_size]
 
-                if (y != NULL) {
+                if (y != nullptr) {
                     txt_img_mask = ggml_pad(ctx, y, img->ne[1], 0, 0, 0);
                 }
             } else {
@@ -744,7 +744,7 @@ namespace Flux {
                 auto vector_in = std::dynamic_pointer_cast<MLPEmbedder>(blocks["vector_in"]);
                 vec            = time_in->forward(ctx, ggml_nn_timestep_embedding(ctx, timesteps, 256, 10000, 1000.f));
                 if (params.guidance_embed) {
-                    GGML_ASSERT(guidance != NULL);
+                    GGML_ASSERT(guidance != nullptr);
                     auto guidance_in = std::dynamic_pointer_cast<MLPEmbedder>(blocks["guidance_in"]);
                     // bf16 and fp16 result is different
                     auto g_in = ggml_nn_timestep_embedding(ctx, guidance, 256, 10000, 1000.f);
@@ -815,14 +815,14 @@ namespace Flux {
                                     struct ggml_tensor* y,
                                     struct ggml_tensor* guidance,
                                     struct ggml_tensor* pe,
-                                    struct ggml_tensor* mod_index_arange  = NULL,
+                                    struct ggml_tensor* mod_index_arange  = nullptr,
                                     std::vector<ggml_tensor*> ref_latents = {},
                                     std::vector<int> skip_layers          = {}) {
             // Forward pass of DiT.
             // x: (N, C, H, W) tensor of spatial inputs (images or latent representations of images)
             // timestep: (N,) tensor of diffusion timesteps
             // context: (N, L, D)
-            // c_concat: NULL, or for (N,C+M, H, W) for Fill
+            // c_concat: nullptr, or for (N,C+M, H, W) for Fill
             // y: (N, adm_in_channels) tensor of class labels
             // guidance: (N,)
             // pe: (L, d_head/2, 2, 2)
@@ -840,7 +840,7 @@ namespace Flux {
             auto img            = process_img(ctx, x);
             uint64_t img_tokens = img->ne[1];
 
-            if (c_concat != NULL) {
+            if (c_concat != nullptr) {
                 ggml_tensor* masked = ggml_view_4d(ctx, c_concat, c_concat->ne[0], c_concat->ne[1], C, 1, c_concat->nb[1], c_concat->nb[2], c_concat->nb[3], 0);
                 ggml_tensor* mask   = ggml_view_4d(ctx, c_concat, c_concat->ne[0], c_concat->ne[1], 8 * 8, 1, c_concat->nb[1], c_concat->nb[2], c_concat->nb[3], c_concat->nb[2] * C);
 
@@ -955,18 +955,18 @@ namespace Flux {
             GGML_ASSERT(x->ne[3] == 1);
             struct ggml_cgraph* gf = ggml_new_graph_custom(compute_ctx, FLUX_GRAPH_SIZE, false);
 
-            struct ggml_tensor* mod_index_arange = NULL;
+            struct ggml_tensor* mod_index_arange = nullptr;
 
             x       = to_backend(x);
             context = to_backend(context);
-            if (c_concat != NULL) {
+            if (c_concat != nullptr) {
                 c_concat = to_backend(c_concat);
             }
             if (flux_params.is_chroma) {
                 guidance = ggml_set_f32(guidance, 0);
 
                 if (!use_mask) {
-                    y = NULL;
+                    y = nullptr;
                 }
 
                 // ggml_arange is not working on some backends, precompute it
@@ -997,7 +997,7 @@ namespace Flux {
             auto pe = ggml_new_tensor_4d(compute_ctx, GGML_TYPE_F32, 2, 2, flux_params.axes_dim_sum / 2, pos_len);
             // pe->data = pe_vec.data();
             // print_ggml_tensor(pe);
-            // pe->data = NULL;
+            // pe->data = nullptr;
             set_backend_tensor_data(pe, pe_vec.data());
 
             struct ggml_tensor* out = flux.forward(compute_ctx,
@@ -1025,8 +1025,8 @@ namespace Flux {
                      struct ggml_tensor* y,
                      struct ggml_tensor* guidance,
                      std::vector<ggml_tensor*> ref_latents = {},
-                     struct ggml_tensor** output           = NULL,
-                     struct ggml_context* output_ctx       = NULL,
+                     struct ggml_tensor** output           = nullptr,
+                     struct ggml_context* output_ctx       = nullptr,
                      std::vector<int> skip_layers          = std::vector<int>()) {
             // x: [N, in_channels, h, w]
             // timesteps: [N, ]
@@ -1043,11 +1043,11 @@ namespace Flux {
         void test() {
             struct ggml_init_params params;
             params.mem_size   = static_cast<size_t>(20 * 1024 * 1024);  // 20 MB
-            params.mem_buffer = NULL;
+            params.mem_buffer = nullptr;
             params.no_alloc   = false;
 
             struct ggml_context* work_ctx = ggml_init(params);
-            GGML_ASSERT(work_ctx != NULL);
+            GGML_ASSERT(work_ctx != nullptr);
 
             {
                 // cpu f16:
@@ -1071,10 +1071,10 @@ namespace Flux {
                 ggml_set_f32(y, 0.01f);
                 // print_ggml_tensor(y);
 
-                struct ggml_tensor* out = NULL;
+                struct ggml_tensor* out = nullptr;
 
                 int t0 = ggml_time_ms();
-                compute(8, x, timesteps, context, NULL, y, guidance, {}, &out, work_ctx);
+                compute(8, x, timesteps, context, nullptr, y, guidance, {}, &out, work_ctx);
                 int t1 = ggml_time_ms();
 
                 print_ggml_tensor(out);

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -82,7 +82,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_mul_n_mode(struct ggml_context* ctx, 
     return result;
 }
 
-__STATIC_INLINE__ struct ggml_tensor* ggml_merge_lora(ggml_context* ctx, struct ggml_tensor* lora_down, struct ggml_tensor* lora_up, struct ggml_tensor* lora_mid = NULL) {
+__STATIC_INLINE__ struct ggml_tensor* ggml_merge_lora(ggml_context* ctx, struct ggml_tensor* lora_down, struct ggml_tensor* lora_up, struct ggml_tensor* lora_mid = nullptr) {
     struct ggml_tensor* updown;
     // flat lora tensors to multiply it
     int64_t lora_up_rows  = lora_up->ne[ggml_n_dims(lora_up) - 1];
@@ -95,7 +95,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_merge_lora(ggml_context* ctx, struct 
 
     // ggml_mul_mat requires tensor b transposed
     lora_down = ggml_cont(ctx, ggml_transpose(ctx, lora_down));
-    if (lora_mid == NULL) {
+    if (lora_mid == nullptr) {
         updown = ggml_mul_mat(ctx, lora_up, lora_down);
         updown = ggml_cont(ctx, ggml_transpose(ctx, updown));
     } else {
@@ -149,7 +149,7 @@ __STATIC_INLINE__ void ggml_tensor_set_f32(struct ggml_tensor* tensor, float val
 }
 
 __STATIC_INLINE__ float ggml_tensor_get_f32(const ggml_tensor* tensor, int l, int k = 0, int j = 0, int i = 0) {
-    if (tensor->buffer != NULL) {
+    if (tensor->buffer != nullptr) {
         float value;
         ggml_backend_tensor_get(tensor, &value, i * tensor->nb[3] + j * tensor->nb[2] + k * tensor->nb[1] + l * tensor->nb[0], sizeof(float));
         return value;
@@ -159,7 +159,7 @@ __STATIC_INLINE__ float ggml_tensor_get_f32(const ggml_tensor* tensor, int l, in
 }
 
 __STATIC_INLINE__ int ggml_tensor_get_i32(const ggml_tensor* tensor, int l, int k = 0, int j = 0, int i = 0) {
-    if (tensor->buffer != NULL) {
+    if (tensor->buffer != nullptr) {
         float value;
         ggml_backend_tensor_get(tensor, &value, i * tensor->nb[3] + j * tensor->nb[2] + k * tensor->nb[1] + l * tensor->nb[0], sizeof(int));
         return value;
@@ -174,7 +174,7 @@ __STATIC_INLINE__ ggml_fp16_t ggml_tensor_get_f16(const ggml_tensor* tensor, int
 }
 
 static struct ggml_tensor* get_tensor_from_graph(struct ggml_cgraph* gf, const char* name) {
-    struct ggml_tensor* res = NULL;
+    struct ggml_tensor* res = nullptr;
     for (int i = 0; i < ggml_graph_n_nodes(gf); i++) {
         struct ggml_tensor* node = ggml_graph_node(gf, i);
         // printf("%d, %s \n", i, ggml_get_name(node));
@@ -227,7 +227,7 @@ __STATIC_INLINE__ ggml_tensor* load_tensor_from_file(ggml_context* ctx, const st
     std::ifstream file(file_path, std::ios::binary);
     if (!file.is_open()) {
         LOG_ERROR("failed to open '%s'", file_path.c_str());
-        return NULL;
+        return nullptr;
     }
     int32_t n_dims;
     int32_t length;
@@ -241,7 +241,7 @@ __STATIC_INLINE__ ggml_tensor* load_tensor_from_file(ggml_context* ctx, const st
 
     if (file.eof()) {
         LOG_ERROR("incomplete file '%s'", file_path.c_str());
-        return NULL;
+        return nullptr;
     }
 
     int32_t nelements = 1;
@@ -289,7 +289,7 @@ __STATIC_INLINE__ void copy_ggml_tensor(struct ggml_tensor* dst, struct ggml_ten
     }
     struct ggml_init_params params;
     params.mem_size          = 10 * 1024 * 1024;  // for padding
-    params.mem_buffer        = NULL;
+    params.mem_buffer        = nullptr;
     params.no_alloc          = false;
     struct ggml_context* ctx = ggml_init(params);
     if (!ctx) {
@@ -415,8 +415,8 @@ __STATIC_INLINE__ void sd_apply_mask(struct ggml_tensor* image_data,
 __STATIC_INLINE__ void sd_mul_images_to_tensor(const uint8_t* image_data,
                                                struct ggml_tensor* output,
                                                int idx,
-                                               float* mean = NULL,
-                                               float* std  = NULL) {
+                                               float* mean = nullptr,
+                                               float* std  = nullptr) {
     int64_t width    = output->ne[0];
     int64_t height   = output->ne[1];
     int64_t channels = output->ne[2];
@@ -426,7 +426,7 @@ __STATIC_INLINE__ void sd_mul_images_to_tensor(const uint8_t* image_data,
             for (int k = 0; k < channels; k++) {
                 int value       = *(image_data + iy * width * channels + ix * channels + k);
                 float pixel_val = value / 255.0f;
-                if (mean != NULL && std != NULL)
+                if (mean != nullptr && std != nullptr)
                     pixel_val = (pixel_val - mean[k]) / std[k];
                 ggml_tensor_set_f32(output, pixel_val, ix, iy, k, idx);
             }
@@ -750,7 +750,7 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
     params.mem_size += tile_size * tile_size * input->ne[2] * sizeof(float);                       // input chunk
     params.mem_size += (tile_size * scale) * (tile_size * scale) * output->ne[2] * sizeof(float);  // output chunk
     params.mem_size += 3 * ggml_tensor_overhead();
-    params.mem_buffer = NULL;
+    params.mem_buffer = nullptr;
     params.no_alloc   = false;
 
     LOG_DEBUG("tile work buffer size: %.2f MB", params.mem_size / 1024.f / 1024.f);
@@ -765,7 +765,7 @@ __STATIC_INLINE__ void sd_tiling(ggml_tensor* input, ggml_tensor* output, const 
     // tiling
     ggml_tensor* input_tile  = ggml_new_tensor_4d(tiles_ctx, GGML_TYPE_F32, tile_size, tile_size, input->ne[2], 1);
     ggml_tensor* output_tile = ggml_new_tensor_4d(tiles_ctx, GGML_TYPE_F32, tile_size * scale, tile_size * scale, output->ne[2], 1);
-    on_processing(input_tile, NULL, true);
+    on_processing(input_tile, nullptr, true);
     int num_tiles = ceil((float)input_width / non_tile_overlap) * ceil((float)input_height / non_tile_overlap);
     LOG_INFO("processing %i tiles", num_tiles);
     pretty_progress(1, num_tiles, 0.0f);
@@ -810,7 +810,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_linear(struct ggml_context* ctx,
                                                      struct ggml_tensor* w,
                                                      struct ggml_tensor* b) {
     x = ggml_mul_mat(ctx, w, x);
-    if (b != NULL) {
+    if (b != nullptr) {
         x = ggml_add_inplace(ctx, x, b);
     }
     return x;
@@ -831,7 +831,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_conv_2d(struct ggml_context* ctx,
                                                       int d0 = 1,
                                                       int d1 = 1) {
     x = ggml_conv_2d(ctx, w, x, s0, s1, p0, p1, d0, d1);
-    if (b != NULL) {
+    if (b != nullptr) {
         b = ggml_reshape_4d(ctx, b, 1, 1, b->ne[0], 1);
         // b = ggml_repeat(ctx, b, x);
         x = ggml_add_inplace(ctx, x, b);
@@ -852,7 +852,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_conv_2d_direct(struct ggml_context
                                                              int d0 = 1,
                                                              int d1 = 1) {
     x = ggml_conv_2d_direct(ctx, w, x, s0, s1, p0, p1, d0, d1);
-    if (b != NULL) {
+    if (b != nullptr) {
         b = ggml_reshape_4d(ctx, b, 1, 1, b->ne[0], 1);
         // b = ggml_repeat(ctx, b, x);
         x = ggml_add(ctx, x, b);
@@ -882,7 +882,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_conv_3d(struct ggml_context* ctx,
     int64_t N  = x->ne[3] / IC;
     x          = ggml_conv_3d(ctx, w, x, IC, s0, s1, s2, p0, p1, p2, d0, d1, d2);
 
-    if (b != NULL) {
+    if (b != nullptr) {
         b = ggml_reshape_4d(ctx, b, 1, 1, 1, b->ne[0]);  // [OC, 1, 1, 1]
         x = ggml_add_inplace(ctx, x, b);
     }
@@ -901,7 +901,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_conv_3d_nx1x1(struct ggml_context*
                                                             int p2 = 1,
                                                             int d2 = 1) {
     x = ggml_conv_2d(ctx, w, x, 1, s2, 0, p2, 1, d2);  // [N, OC, T, OH * OW]
-    if (b != NULL) {
+    if (b != nullptr) {
         b = ggml_reshape_4d(ctx, b, 1, 1, b->ne[0], 1);
         x = ggml_add(ctx, x, b);
     }
@@ -1004,7 +1004,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_attention_ext(struct ggml_context*
                                                             struct ggml_tensor* k,
                                                             struct ggml_tensor* v,
                                                             int64_t n_head,
-                                                            struct ggml_tensor* mask = NULL,
+                                                            struct ggml_tensor* mask = nullptr,
                                                             bool diag_mask_inf       = false,
                                                             bool skip_reshape        = false,
                                                             bool flash_attn          = false) {
@@ -1132,9 +1132,9 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_layer_norm(struct ggml_context* ct
                                                          struct ggml_tensor* b,
                                                          float eps = EPS) {
     x = ggml_norm(ctx, x, eps);
-    if (w != NULL) {
+    if (w != nullptr) {
         x = ggml_mul_inplace(ctx, x, w);
-        if (b != NULL) {
+        if (b != nullptr) {
             x = ggml_add_inplace(ctx, x, b);
         }
     }
@@ -1146,14 +1146,14 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_group_norm(struct ggml_context* ct
                                                          struct ggml_tensor* w,
                                                          struct ggml_tensor* b,
                                                          int num_groups = 32) {
-    if (ggml_n_dims(x) >= 3 && w != NULL && b != NULL) {
+    if (ggml_n_dims(x) >= 3 && w != nullptr && b != nullptr) {
         w = ggml_reshape_4d(ctx, w, 1, 1, w->ne[0], 1);
         b = ggml_reshape_4d(ctx, b, 1, 1, b->ne[0], 1);
     }
 
     const float eps = 1e-6f;  // default eps parameter
     x               = ggml_group_norm(ctx, x, num_groups, eps);
-    if (w != NULL && b != NULL) {
+    if (w != nullptr && b != nullptr) {
         x = ggml_mul_inplace(ctx, x, w);
         // b = ggml_repeat(ctx, b, x);
         x = ggml_add_inplace(ctx, x, b);
@@ -1262,7 +1262,7 @@ __STATIC_INLINE__ struct ggml_tensor* new_timestep_embedding(struct ggml_context
         acutual_dim = dim + 1;
     }
     struct ggml_tensor* embedding = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, acutual_dim, timesteps.size());
-    if (embedding->data != NULL) {
+    if (embedding->data != nullptr) {
         memcpy(((char*)embedding->data), ((char*)embedding_vec.data()), ggml_nbytes(embedding));
     } else {
         ggml_backend_tensor_set(embedding, embedding_vec.data(), 0, ggml_nbytes(embedding));
@@ -1298,23 +1298,23 @@ struct GGMLRunner {
 protected:
     typedef std::function<struct ggml_cgraph*()> get_graph_cb_t;
 
-    ggml_backend_t params_backend  = NULL;
-    ggml_backend_t runtime_backend = NULL;
+    ggml_backend_t params_backend  = nullptr;
+    ggml_backend_t runtime_backend = nullptr;
 
-    struct ggml_context* params_ctx             = NULL;
-    ggml_backend_buffer_t params_buffer         = NULL;
-    struct ggml_context* offload_ctx            = NULL;
-    ggml_backend_buffer_t runtime_params_buffer = NULL;
+    struct ggml_context* params_ctx             = nullptr;
+    ggml_backend_buffer_t params_buffer         = nullptr;
+    struct ggml_context* offload_ctx            = nullptr;
+    ggml_backend_buffer_t runtime_params_buffer = nullptr;
     bool params_on_runtime_backend              = false;
 
-    struct ggml_context* cache_ctx     = NULL;
-    ggml_backend_buffer_t cache_buffer = NULL;
+    struct ggml_context* cache_ctx     = nullptr;
+    ggml_backend_buffer_t cache_buffer = nullptr;
 
-    struct ggml_context* compute_ctx    = NULL;
-    struct ggml_gallocr* compute_allocr = NULL;
+    struct ggml_context* compute_ctx    = nullptr;
+    struct ggml_gallocr* compute_allocr = nullptr;
 
     std::vector<float> one_vec = {1.f};
-    ggml_tensor* one_tensor    = NULL;
+    ggml_tensor* one_tensor    = nullptr;
 
     std::map<struct ggml_tensor*, const void*> backend_tensor_data_map;
     std::map<std::string, struct ggml_tensor*> cache_tensor_map;  // name -> tensor
@@ -1323,59 +1323,59 @@ protected:
     void alloc_params_ctx() {
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(MAX_PARAMS_TENSOR_NUM * ggml_tensor_overhead());
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = true;
 
         params_ctx = ggml_init(params);
-        GGML_ASSERT(params_ctx != NULL);
+        GGML_ASSERT(params_ctx != nullptr);
         if (params_backend != runtime_backend) {
             offload_ctx = ggml_init(params);
-            GGML_ASSERT(offload_ctx != NULL);
+            GGML_ASSERT(offload_ctx != nullptr);
         }
     }
 
     void free_params_ctx() {
-        if (params_ctx != NULL) {
+        if (params_ctx != nullptr) {
             ggml_free(params_ctx);
-            params_ctx = NULL;
+            params_ctx = nullptr;
         }
-        if (offload_ctx != NULL) {
+        if (offload_ctx != nullptr) {
             ggml_free(offload_ctx);
-            offload_ctx = NULL;
+            offload_ctx = nullptr;
         }
     }
 
     void alloc_cache_ctx() {
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(MAX_PARAMS_TENSOR_NUM * ggml_tensor_overhead());
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = true;
 
         cache_ctx = ggml_init(params);
-        GGML_ASSERT(cache_ctx != NULL);
+        GGML_ASSERT(cache_ctx != nullptr);
     }
 
     void free_cache_ctx() {
-        if (cache_ctx != NULL) {
+        if (cache_ctx != nullptr) {
             ggml_free(cache_ctx);
-            cache_ctx = NULL;
+            cache_ctx = nullptr;
         }
     }
 
     void alloc_compute_ctx() {
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(ggml_tensor_overhead() * MAX_GRAPH_SIZE + ggml_graph_overhead());
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = true;
 
         compute_ctx = ggml_init(params);
-        GGML_ASSERT(compute_ctx != NULL);
+        GGML_ASSERT(compute_ctx != nullptr);
     }
 
     void free_compute_ctx() {
-        if (compute_ctx != NULL) {
+        if (compute_ctx != nullptr) {
             ggml_free(compute_ctx);
-            compute_ctx = NULL;
+            compute_ctx = nullptr;
         }
     }
 
@@ -1399,7 +1399,7 @@ protected:
     }
 
     bool alloc_compute_buffer(get_graph_cb_t get_graph) {
-        if (compute_allocr != NULL) {
+        if (compute_allocr != nullptr) {
             return true;
         }
         reset_compute_ctx();
@@ -1424,9 +1424,9 @@ protected:
     }
 
     void free_cache_buffer() {
-        if (cache_buffer != NULL) {
+        if (cache_buffer != nullptr) {
             ggml_backend_buffer_free(cache_buffer);
-            cache_buffer = NULL;
+            cache_buffer = nullptr;
         }
     }
 
@@ -1436,7 +1436,7 @@ protected:
         }
         free_cache_ctx_and_buffer();
         alloc_cache_ctx();
-        GGML_ASSERT(cache_buffer == NULL);
+        GGML_ASSERT(cache_buffer == nullptr);
         std::map<ggml_tensor*, ggml_tensor*> runtime_tensor_to_cache_tensor;
         for (auto kv : cache_tensor_map) {
             auto cache_tensor = ggml_dup_tensor(cache_ctx, kv.second);
@@ -1445,7 +1445,7 @@ protected:
         }
         size_t num_tensors = ggml_tensor_num(cache_ctx);
         cache_buffer       = ggml_backend_alloc_ctx_tensors(cache_ctx, runtime_backend);
-        GGML_ASSERT(cache_buffer != NULL);
+        GGML_ASSERT(cache_buffer != nullptr);
         for (auto kv : runtime_tensor_to_cache_tensor) {
             ggml_backend_tensor_copy(kv.first, kv.second);
         }
@@ -1477,12 +1477,12 @@ protected:
         if (params_on_runtime_backend) {
             return true;
         }
-        GGML_ASSERT(runtime_params_buffer == NULL);
+        GGML_ASSERT(runtime_params_buffer == nullptr);
         int64_t t0         = ggml_time_ms();
         size_t num_tensors = ggml_tensor_num(offload_ctx);
         if (num_tensors == 0) {
-            for (ggml_tensor* t = ggml_get_first_tensor(params_ctx); t != NULL; t = ggml_get_next_tensor(params_ctx, t)) {
-                GGML_ASSERT(t->view_src == NULL);
+            for (ggml_tensor* t = ggml_get_first_tensor(params_ctx); t != nullptr; t = ggml_get_next_tensor(params_ctx, t)) {
+                GGML_ASSERT(t->view_src == nullptr);
                 ggml_dup_tensor(offload_ctx, t);
             }
         }
@@ -1491,7 +1491,7 @@ protected:
 
         runtime_params_buffer = ggml_backend_alloc_ctx_tensors(offload_ctx, runtime_backend);
 
-        if (runtime_params_buffer == NULL) {
+        if (runtime_params_buffer == nullptr) {
             LOG_ERROR("%s alloc runtime params backend buffer failed, num_tensors = %i",
                       get_desc().c_str(),
                       num_tensors);
@@ -1501,7 +1501,7 @@ protected:
         ggml_tensor* t         = ggml_get_first_tensor(params_ctx);
         ggml_tensor* offload_t = ggml_get_first_tensor(offload_ctx);
 
-        while (t != NULL && offload_t != NULL) {
+        while (t != nullptr && offload_t != nullptr) {
             ggml_backend_tensor_copy(t, offload_t);
             std::swap(t->buffer, offload_t->buffer);
             std::swap(t->data, offload_t->data);
@@ -1532,19 +1532,19 @@ protected:
         ggml_tensor* t         = ggml_get_first_tensor(params_ctx);
         ggml_tensor* offload_t = ggml_get_first_tensor(offload_ctx);
 
-        while (t != NULL && offload_t != NULL) {
+        while (t != nullptr && offload_t != nullptr) {
             t->buffer         = offload_t->buffer;
             t->data           = offload_t->data;
-            offload_t->buffer = NULL;
-            offload_t->data   = NULL;
+            offload_t->buffer = nullptr;
+            offload_t->data   = nullptr;
 
             t         = ggml_get_next_tensor(params_ctx, t);
             offload_t = ggml_get_next_tensor(offload_ctx, offload_t);
         }
 
-        if (runtime_params_buffer != NULL) {
+        if (runtime_params_buffer != nullptr) {
             ggml_backend_buffer_free(runtime_params_buffer);
-            runtime_params_buffer = NULL;
+            runtime_params_buffer = nullptr;
         }
         params_on_runtime_backend = false;
     }
@@ -1581,7 +1581,7 @@ public:
     bool alloc_params_buffer() {
         size_t num_tensors = ggml_tensor_num(params_ctx);
         params_buffer      = ggml_backend_alloc_ctx_tensors(params_ctx, params_backend);
-        if (params_buffer == NULL) {
+        if (params_buffer == nullptr) {
             LOG_ERROR("%s alloc params backend buffer failed, num_tensors = %i",
                       get_desc().c_str(),
                       num_tensors);
@@ -1597,14 +1597,14 @@ public:
     }
 
     void free_params_buffer() {
-        if (params_buffer != NULL) {
+        if (params_buffer != nullptr) {
             ggml_backend_buffer_free(params_buffer);
-            params_buffer = NULL;
+            params_buffer = nullptr;
         }
     }
 
     size_t get_params_buffer_size() {
-        if (params_buffer != NULL) {
+        if (params_buffer != nullptr) {
             return ggml_backend_buffer_get_size(params_buffer);
         }
         return 0;
@@ -1616,9 +1616,9 @@ public:
     }
 
     void free_compute_buffer() {
-        if (compute_allocr != NULL) {
+        if (compute_allocr != nullptr) {
             ggml_gallocr_free(compute_allocr);
-            compute_allocr = NULL;
+            compute_allocr = nullptr;
         }
         offload_params_to_params_backend();
     }
@@ -1629,12 +1629,12 @@ public:
     }
 
     struct ggml_tensor* to_backend(struct ggml_tensor* tensor) {
-        GGML_ASSERT(compute_ctx != NULL);
-        if (tensor == NULL) {
-            return NULL;
+        GGML_ASSERT(compute_ctx != nullptr);
+        if (tensor == nullptr) {
+            return nullptr;
         }
         // it's performing a compute, check if backend isn't cpu
-        if (!ggml_backend_is_cpu(runtime_backend) && (tensor->buffer == NULL || ggml_backend_buffer_is_host(tensor->buffer))) {
+        if (!ggml_backend_is_cpu(runtime_backend) && (tensor->buffer == nullptr || ggml_backend_buffer_is_host(tensor->buffer))) {
             // pass input tensors to gpu memory
             auto backend_tensor = ggml_dup_tensor(compute_ctx, tensor);
 
@@ -1650,8 +1650,8 @@ public:
     }
 
     struct ggml_tensor* get_cache_tensor_by_name(const std::string& name) {
-        if (cache_ctx == NULL) {
-            return NULL;
+        if (cache_ctx == nullptr) {
+            return nullptr;
         }
         return ggml_get_tensor(cache_ctx, name.c_str());
     }
@@ -1659,8 +1659,8 @@ public:
     void compute(get_graph_cb_t get_graph,
                  int n_threads,
                  bool free_compute_buffer_immediately = true,
-                 struct ggml_tensor** output          = NULL,
-                 struct ggml_context* output_ctx      = NULL) {
+                 struct ggml_tensor** output          = nullptr,
+                 struct ggml_context* output_ctx      = nullptr) {
         if (!offload_params_to_runtime_backend()) {
             LOG_ERROR("%s offload params to runtime backend failed", get_desc().c_str());
             return;
@@ -1679,12 +1679,12 @@ public:
         ggml_graph_print(gf);
 #endif
         copy_cache_tensors_to_cache_buffer();
-        if (output != NULL) {
+        if (output != nullptr) {
             auto result = ggml_get_tensor(compute_ctx, final_result_name.c_str());
-            if (*output == NULL && output_ctx != NULL) {
+            if (*output == nullptr && output_ctx != nullptr) {
                 *output = ggml_dup_tensor(output_ctx, result);
             }
-            if (*output != NULL) {
+            if (*output != nullptr) {
                 ggml_backend_tensor_get_and_sync(runtime_backend, result, (*output)->data, 0, ggml_nbytes(*output));
             }
         }
@@ -1825,7 +1825,7 @@ public:
 
     struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x) {
         struct ggml_tensor* w = params["weight"];
-        struct ggml_tensor* b = NULL;
+        struct ggml_tensor* b = nullptr;
         if (bias) {
             b = params["bias"];
         }
@@ -1913,7 +1913,7 @@ public:
 
     struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x) {
         struct ggml_tensor* w = params["weight"];
-        struct ggml_tensor* b = NULL;
+        struct ggml_tensor* b = nullptr;
         if (bias) {
             b = params["bias"];
         }
@@ -1964,7 +1964,7 @@ public:
     // result: [N, OC, OD, OH*OW]
     struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x) {
         struct ggml_tensor* w = params["weight"];
-        struct ggml_tensor* b = NULL;
+        struct ggml_tensor* b = nullptr;
         if (bias) {
             b = params["bias"];
         }
@@ -2013,7 +2013,7 @@ public:
 
     struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x) {
         struct ggml_tensor* w = params["weight"];
-        struct ggml_tensor* b = NULL;
+        struct ggml_tensor* b = nullptr;
         if (bias) {
             b = params["bias"];
         }
@@ -2053,8 +2053,8 @@ public:
           bias(bias) {}
 
     struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x) {
-        struct ggml_tensor* w = NULL;
-        struct ggml_tensor* b = NULL;
+        struct ggml_tensor* w = nullptr;
+        struct ggml_tensor* b = nullptr;
 
         if (elementwise_affine) {
             w = params["weight"];
@@ -2093,8 +2093,8 @@ public:
           affine(affine) {}
 
     struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x) {
-        struct ggml_tensor* w = NULL;
-        struct ggml_tensor* b = NULL;
+        struct ggml_tensor* w = nullptr;
+        struct ggml_tensor* b = nullptr;
         if (affine) {
             w = params["weight"];
             b = params["bias"];
@@ -2174,7 +2174,7 @@ public:
         struct ggml_tensor* k = k_proj->forward(ctx, x);
         struct ggml_tensor* v = v_proj->forward(ctx, x);
 
-        x = ggml_nn_attention_ext(ctx, q, k, v, n_head, NULL, mask);  // [N, n_token, embed_dim]
+        x = ggml_nn_attention_ext(ctx, q, k, v, n_head, nullptr, mask);  // [N, n_token, embed_dim]
 
         x = out_proj->forward(ctx, x);  // [N, n_token, embed_dim]
         return x;

--- a/lora.hpp
+++ b/lora.hpp
@@ -98,7 +98,7 @@ struct LoraModel : public GGMLRunner {
     bool load_failed                = false;
     bool applied                    = false;
     std::vector<int> zero_index_vec = {0};
-    ggml_tensor* zero_index         = NULL;
+    ggml_tensor* zero_index         = nullptr;
     enum lora_t type                = REGULAR;
 
     LoraModel(ggml_backend_t backend,
@@ -273,7 +273,7 @@ struct LoraModel : public GGMLRunner {
                 if (is_qkvm_split) {
                     key = key.substr(sizeof("SPLIT_L|") - 1);
                 }
-                struct ggml_tensor* updown = NULL;
+                struct ggml_tensor* updown = nullptr;
                 float scale_value          = 1.0f;
                 std::string full_key       = lora_pre[type] + key;
                 if (is_bias) {
@@ -300,13 +300,13 @@ struct LoraModel : public GGMLRunner {
                     }
                     std::string alpha_name = "";
 
-                    ggml_tensor* hada_1_mid  = NULL;  // tau for tucker decomposition
-                    ggml_tensor* hada_1_up   = NULL;
-                    ggml_tensor* hada_1_down = NULL;
+                    ggml_tensor* hada_1_mid  = nullptr;  // tau for tucker decomposition
+                    ggml_tensor* hada_1_up   = nullptr;
+                    ggml_tensor* hada_1_down = nullptr;
 
-                    ggml_tensor* hada_2_mid  = NULL;  // tau for tucker decomposition
-                    ggml_tensor* hada_2_up   = NULL;
-                    ggml_tensor* hada_2_down = NULL;
+                    ggml_tensor* hada_2_mid  = nullptr;  // tau for tucker decomposition
+                    ggml_tensor* hada_2_up   = nullptr;
+                    ggml_tensor* hada_2_down = nullptr;
 
                     std::string hada_1_mid_name  = "";
                     std::string hada_1_down_name = "";
@@ -354,7 +354,7 @@ struct LoraModel : public GGMLRunner {
                     applied_lora_tensors.insert(hada_2_up_name);
 
                     applied_lora_tensors.insert(alpha_name);
-                    if (hada_1_up == NULL || hada_1_down == NULL || hada_2_up == NULL || hada_2_down == NULL) {
+                    if (hada_1_up == nullptr || hada_1_down == nullptr || hada_2_up == nullptr || hada_2_down == nullptr) {
                         continue;
                     }
 
@@ -380,8 +380,8 @@ struct LoraModel : public GGMLRunner {
 
                     std::string alpha_name = full_key + ".alpha";
 
-                    ggml_tensor* lokr_w1 = NULL;
-                    ggml_tensor* lokr_w2 = NULL;
+                    ggml_tensor* lokr_w1 = nullptr;
+                    ggml_tensor* lokr_w2 = nullptr;
 
                     std::string lokr_w1_name = "";
                     std::string lokr_w2_name = "";
@@ -393,8 +393,8 @@ struct LoraModel : public GGMLRunner {
                         lokr_w1 = to_f32(compute_ctx, lora_tensors[lokr_w1_name]);
                         applied_lora_tensors.insert(lokr_w1_name);
                     } else {
-                        ggml_tensor* down     = NULL;
-                        ggml_tensor* up       = NULL;
+                        ggml_tensor* down     = nullptr;
+                        ggml_tensor* up       = nullptr;
                         std::string down_name = lokr_w1_name + "_b";
                         std::string up_name   = lokr_w1_name + "_a";
                         if (lora_tensors.find(down_name) != lora_tensors.end()) {
@@ -418,8 +418,8 @@ struct LoraModel : public GGMLRunner {
                         lokr_w2 = to_f32(compute_ctx, lora_tensors[lokr_w2_name]);
                         applied_lora_tensors.insert(lokr_w2_name);
                     } else {
-                        ggml_tensor* down     = NULL;
-                        ggml_tensor* up       = NULL;
+                        ggml_tensor* down     = nullptr;
+                        ggml_tensor* up       = nullptr;
                         std::string down_name = lokr_w2_name + "_b";
                         std::string up_name   = lokr_w2_name + "_a";
                         if (lora_tensors.find(down_name) != lora_tensors.end()) {
@@ -446,9 +446,9 @@ struct LoraModel : public GGMLRunner {
 
                 } else {
                     // LoRA mode
-                    ggml_tensor* lora_mid  = NULL;  // tau for tucker decomposition
-                    ggml_tensor* lora_up   = NULL;
-                    ggml_tensor* lora_down = NULL;
+                    ggml_tensor* lora_mid  = nullptr;  // tau for tucker decomposition
+                    ggml_tensor* lora_up   = nullptr;
+                    ggml_tensor* lora_down = nullptr;
 
                     std::string alpha_name         = "";
                     std::string scale_name         = "";
@@ -483,12 +483,12 @@ struct LoraModel : public GGMLRunner {
                             auto split_k_alpha_name = full_key + "k" + suffix + ".alpha";
                             auto split_v_alpha_name = full_key + "v" + suffix + ".alpha";
 
-                            ggml_tensor* lora_q_down = NULL;
-                            ggml_tensor* lora_q_up   = NULL;
-                            ggml_tensor* lora_k_down = NULL;
-                            ggml_tensor* lora_k_up   = NULL;
-                            ggml_tensor* lora_v_down = NULL;
-                            ggml_tensor* lora_v_up   = NULL;
+                            ggml_tensor* lora_q_down = nullptr;
+                            ggml_tensor* lora_q_up   = nullptr;
+                            ggml_tensor* lora_k_down = nullptr;
+                            ggml_tensor* lora_k_up   = nullptr;
+                            ggml_tensor* lora_v_down = nullptr;
+                            ggml_tensor* lora_v_up   = nullptr;
 
                             lora_q_down = to_f32(compute_ctx, lora_tensors[split_q_d_name]);
 
@@ -619,15 +619,15 @@ struct LoraModel : public GGMLRunner {
                             auto split_v_alpha_name = full_key + "attn.to_v" + ".alpha";
                             auto split_m_alpha_name = full_key + "proj_mlp" + ".alpha";
 
-                            ggml_tensor* lora_q_down = NULL;
-                            ggml_tensor* lora_q_up   = NULL;
-                            ggml_tensor* lora_k_down = NULL;
-                            ggml_tensor* lora_k_up   = NULL;
-                            ggml_tensor* lora_v_down = NULL;
-                            ggml_tensor* lora_v_up   = NULL;
+                            ggml_tensor* lora_q_down = nullptr;
+                            ggml_tensor* lora_q_up   = nullptr;
+                            ggml_tensor* lora_k_down = nullptr;
+                            ggml_tensor* lora_k_up   = nullptr;
+                            ggml_tensor* lora_v_down = nullptr;
+                            ggml_tensor* lora_v_up   = nullptr;
 
-                            ggml_tensor* lora_m_down = NULL;
-                            ggml_tensor* lora_m_up   = NULL;
+                            ggml_tensor* lora_m_down = nullptr;
+                            ggml_tensor* lora_m_up   = nullptr;
 
                             lora_q_up = to_f32(compute_ctx, lora_tensors[split_q_u_name]);
 
@@ -795,7 +795,7 @@ struct LoraModel : public GGMLRunner {
                         }
                     }
 
-                    if (lora_up == NULL || lora_down == NULL) {
+                    if (lora_up == nullptr || lora_down == nullptr) {
                         continue;
                     }
                     // calc_scale

--- a/mmdit.hpp
+++ b/mmdit.hpp
@@ -341,7 +341,7 @@ public:
             auto attn_in = modulate(ctx, norm1->forward(ctx, x), shift_msa, scale_msa);
             auto qkv     = attn->pre_attention(ctx, attn_in);
 
-            return {qkv, {NULL, NULL, NULL, NULL, NULL}};
+            return {qkv, {nullptr, nullptr, nullptr, nullptr, nullptr}};
         }
     }
 
@@ -521,7 +521,7 @@ block_mixing(struct ggml_context* ctx,
                                                 context_intermediates[3],
                                                 context_intermediates[4]);
     } else {
-        context = NULL;
+        context = nullptr;
     }
 
     if (x_block->self_attn) {
@@ -802,8 +802,8 @@ public:
     struct ggml_tensor* forward(struct ggml_context* ctx,
                                 struct ggml_tensor* x,
                                 struct ggml_tensor* t,
-                                struct ggml_tensor* y        = NULL,
-                                struct ggml_tensor* context  = NULL,
+                                struct ggml_tensor* y        = nullptr,
+                                struct ggml_tensor* context  = nullptr,
                                 std::vector<int> skip_layers = std::vector<int>()) {
         // Forward pass of DiT.
         // x: (N, C, H, W) tensor of spatial inputs (images or latent representations of images)
@@ -822,14 +822,14 @@ public:
         x                = ggml_add(ctx, patch_embed, pos_embed);  // [N, H*W, hidden_size]
 
         auto c = t_embedder->forward(ctx, t);  // [N, hidden_size]
-        if (y != NULL && adm_in_channels != -1) {
+        if (y != nullptr && adm_in_channels != -1) {
             auto y_embedder = std::dynamic_pointer_cast<VectorEmbedder>(blocks["y_embedder"]);
 
             y = y_embedder->forward(ctx, y);  // [N, hidden_size]
             c = ggml_add(ctx, c, y);
         }
 
-        if (context != NULL) {
+        if (context != nullptr) {
             auto context_embedder = std::dynamic_pointer_cast<Linear>(blocks["context_embedder"]);
 
             context = context_embedder->forward(ctx, context);  // [N, L, D] aka [N, L, 1536]
@@ -890,8 +890,8 @@ struct MMDiTRunner : public GGMLRunner {
                  struct ggml_tensor* timesteps,
                  struct ggml_tensor* context,
                  struct ggml_tensor* y,
-                 struct ggml_tensor** output     = NULL,
-                 struct ggml_context* output_ctx = NULL,
+                 struct ggml_tensor** output     = nullptr,
+                 struct ggml_context* output_ctx = nullptr,
                  std::vector<int> skip_layers    = std::vector<int>()) {
         // x: [N, in_channels, h, w]
         // timesteps: [N, ]
@@ -907,11 +907,11 @@ struct MMDiTRunner : public GGMLRunner {
     void test() {
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(10 * 1024 * 1024);  // 10 MB
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = false;
 
         struct ggml_context* work_ctx = ggml_init(params);
-        GGML_ASSERT(work_ctx != NULL);
+        GGML_ASSERT(work_ctx != nullptr);
 
         {
             // cpu f16: pass
@@ -932,7 +932,7 @@ struct MMDiTRunner : public GGMLRunner {
             ggml_set_f32(y, 0.01f);
             // print_ggml_tensor(y);
 
-            struct ggml_tensor* out = NULL;
+            struct ggml_tensor* out = nullptr;
 
             int t0 = ggml_time_ms();
             compute(8, x, timesteps, context, y, &out, work_ctx);

--- a/model.cpp
+++ b/model.cpp
@@ -885,7 +885,7 @@ void convert_tensor(void* src,
             ggml_fp16_to_fp32_row((ggml_fp16_t*)src, (float*)dst, n);
         } else {
             auto qtype = ggml_get_type_traits(src_type);
-            if (qtype->to_float == NULL) {
+            if (qtype->to_float == nullptr) {
                 throw std::runtime_error(format("type %s unsupported for integer quantization: no dequantization available",
                                                 ggml_type_name(src_type)));
             }
@@ -895,7 +895,7 @@ void convert_tensor(void* src,
         // src_type == GGML_TYPE_F16 => dst_type is quantized
         // src_type is quantized => dst_type == GGML_TYPE_F16 or dst_type is quantized
         auto qtype = ggml_get_type_traits(src_type);
-        if (qtype->to_float == NULL) {
+        if (qtype->to_float == nullptr) {
             throw std::runtime_error(format("type %s unsupported for integer quantization: no dequantization available",
                                             ggml_type_name(src_type)));
         }
@@ -957,7 +957,7 @@ std::map<char, int> unicode_to_byte() {
 
 bool is_zip_file(const std::string& file_path) {
     struct zip_t* zip = zip_open(file_path.c_str(), 0, 'r');
-    if (zip == NULL) {
+    if (zip == nullptr) {
         return false;
     }
     zip_close(zip);
@@ -1053,8 +1053,8 @@ bool ModelLoader::init_from_gguf_file(const std::string& file_path, const std::s
     file_paths_.push_back(file_path);
     size_t file_index = file_paths_.size() - 1;
 
-    gguf_context* ctx_gguf_ = NULL;
-    ggml_context* ctx_meta_ = NULL;
+    gguf_context* ctx_gguf_ = nullptr;
+    ggml_context* ctx_meta_ = nullptr;
 
     ctx_gguf_ = gguf_init_from_file(file_path.c_str(), {true, &ctx_meta_});
     if (!ctx_gguf_) {
@@ -1663,7 +1663,7 @@ bool ModelLoader::init_from_ckpt_file(const std::string& file_path, const std::s
     size_t file_index = file_paths_.size() - 1;
 
     struct zip_t* zip = zip_open(file_path.c_str(), 0, 'r');
-    if (zip == NULL) {
+    if (zip == nullptr) {
         LOG_ERROR("failed to open '%s'", file_path.c_str());
         return false;
     }
@@ -1676,7 +1676,7 @@ bool ModelLoader::init_from_ckpt_file(const std::string& file_path, const std::s
             if (pos != std::string::npos) {
                 std::string dir = name.substr(0, pos);
                 printf("ZIP %d, name = %s, dir = %s \n", i, name.c_str(), dir.c_str());
-                void* pkl_data = NULL;
+                void* pkl_data = nullptr;
                 size_t pkl_size;
                 zip_entry_read(zip, &pkl_data, &pkl_size);
 
@@ -2001,10 +2001,10 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb) {
             }
         }
 
-        struct zip_t* zip = NULL;
+        struct zip_t* zip = nullptr;
         if (is_zip) {
             zip = zip_open(file_path.c_str(), 0, 'r');
-            if (zip == NULL) {
+            if (zip == nullptr) {
                 LOG_ERROR("failed to open zip '%s'", file_path.c_str());
                 return false;
             }
@@ -2014,7 +2014,7 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb) {
         std::vector<uint8_t> convert_buffer;
 
         auto read_data = [&](const TensorStorage& tensor_storage, char* buf, size_t n) {
-            if (zip != NULL) {
+            if (zip != nullptr) {
                 zip_entry_openbyindex(zip, tensor_storage.index_in_zip);
                 size_t entry_size = zip_entry_size(zip);
                 if (entry_size != n) {
@@ -2046,7 +2046,7 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb) {
                 ++tensor_count;
                 continue;
             }
-            ggml_tensor* dst_tensor = NULL;
+            ggml_tensor* dst_tensor = nullptr;
 
             success = on_new_tensor_cb(tensor_storage, &dst_tensor);
             if (!success) {
@@ -2054,14 +2054,14 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb) {
                 break;
             }
 
-            if (dst_tensor == NULL) {
+            if (dst_tensor == nullptr) {
                 ++tensor_count;
                 continue;
             }
 
             size_t nbytes_to_read = tensor_storage.nbytes_to_read();
 
-            if (dst_tensor->buffer == NULL || ggml_backend_buffer_is_host(dst_tensor->buffer)) {
+            if (dst_tensor->buffer == nullptr || ggml_backend_buffer_is_host(dst_tensor->buffer)) {
                 // for the CPU and Metal backend, we can copy directly into the tensor
                 if (tensor_storage.type == dst_tensor->type) {
                     GGML_ASSERT(ggml_nbytes(dst_tensor) == tensor_storage.nbytes());
@@ -2162,7 +2162,7 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb) {
             }
         }
 
-        if (zip != NULL) {
+        if (zip != nullptr) {
             zip_close(zip);
         }
 
@@ -2314,7 +2314,7 @@ bool ModelLoader::save_to_gguf_file(const std::string& file_path, ggml_type type
     mem_size += tensor_storages.size() * ggml_tensor_overhead();
     mem_size += get_params_mem_size(backend, type);
     LOG_INFO("model tensors mem size: %.2fMB", mem_size / 1024.f / 1024.f);
-    ggml_context* ggml_ctx = ggml_init({mem_size, NULL, false});
+    ggml_context* ggml_ctx = ggml_init({mem_size, nullptr, false});
 
     gguf_context* gguf_ctx = gguf_init_empty();
 
@@ -2338,7 +2338,7 @@ bool ModelLoader::save_to_gguf_file(const std::string& file_path, ggml_type type
         }
 
         ggml_tensor* tensor = ggml_new_tensor(ggml_ctx, tensor_type, tensor_storage.n_dims, tensor_storage.ne);
-        if (tensor == NULL) {
+        if (tensor == nullptr) {
             LOG_ERROR("ggml_new_tensor failed");
             return false;
         }
@@ -2371,7 +2371,7 @@ bool ModelLoader::save_to_gguf_file(const std::string& file_path, ggml_type type
 
 int64_t ModelLoader::get_params_mem_size(ggml_backend_t backend, ggml_type type) {
     size_t alignment = 128;
-    if (backend != NULL) {
+    if (backend != nullptr) {
         alignment = ggml_backend_get_alignment(backend);
     }
     int64_t mem_size = 0;
@@ -2401,7 +2401,7 @@ bool convert(const char* input_path, const char* vae_path, const char* output_pa
         return false;
     }
 
-    if (vae_path != NULL && strlen(vae_path) > 0) {
+    if (vae_path != nullptr && strlen(vae_path) > 0) {
         if (!model_loader.init_from_file(vae_path, "vae.")) {
             LOG_ERROR("init model loader from file failed: '%s'", vae_path);
             return false;

--- a/pmid.hpp
+++ b/pmid.hpp
@@ -683,8 +683,8 @@ public:
         struct ggml_tensor* prompt_embeds_d   = to_backend(prompt_embeds);
         struct ggml_tensor* id_embeds_d       = to_backend(id_embeds);
 
-        struct ggml_tensor* left  = NULL;
-        struct ggml_tensor* right = NULL;
+        struct ggml_tensor* left  = nullptr;
+        struct ggml_tensor* right = nullptr;
         for (int i = 0; i < class_tokens_mask.size(); i++) {
             if (class_tokens_mask[i]) {
                 // printf(" 1,");
@@ -739,7 +739,7 @@ public:
                 }
             }
         }
-        struct ggml_tensor* updated_prompt_embeds = NULL;
+        struct ggml_tensor* updated_prompt_embeds = nullptr;
         if (pm_version == PM_VERSION_1)
             updated_prompt_embeds = id_encoder.forward(ctx0,
                                                        id_pixel_values_d,
@@ -845,7 +845,7 @@ struct PhotoMakerIDEmbed : public GGMLRunner {
         pos = tensors.find("pmid.id_embeds");
         if (pos != tensors.end())
             return pos->second;
-        return NULL;
+        return nullptr;
     }
 };
 

--- a/preprocessing.hpp
+++ b/preprocessing.hpp
@@ -7,7 +7,7 @@
 void convolve(struct ggml_tensor* input, struct ggml_tensor* output, struct ggml_tensor* kernel, int padding) {
     struct ggml_init_params params;
     params.mem_size                 = 20 * 1024 * 1024;  // 10
-    params.mem_buffer               = NULL;
+    params.mem_buffer               = nullptr;
     params.no_alloc                 = false;
     struct ggml_context* ctx0       = ggml_init(params);
     struct ggml_tensor* kernel_fp16 = ggml_new_tensor_4d(ctx0, GGML_TYPE_F16, kernel->ne[0], kernel->ne[1], 1, 1);
@@ -165,13 +165,13 @@ void threshold_hystersis(struct ggml_tensor* img, float high_threshold, float lo
 uint8_t* preprocess_canny(uint8_t* img, int width, int height, float high_threshold, float low_threshold, float weak, float strong, bool inverse) {
     struct ggml_init_params params;
     params.mem_size               = static_cast<size_t>(10 * 1024 * 1024);  // 10
-    params.mem_buffer             = NULL;
+    params.mem_buffer             = nullptr;
     params.no_alloc               = false;
     struct ggml_context* work_ctx = ggml_init(params);
 
     if (!work_ctx) {
         LOG_ERROR("ggml_init() failed");
-        return NULL;
+        return nullptr;
     }
 
     float kX[9] = {

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -78,10 +78,10 @@ void calculate_alphas_cumprod(float* alphas_cumprod,
 
 class StableDiffusionGGML {
 public:
-    ggml_backend_t backend             = NULL;  // general backend
-    ggml_backend_t clip_backend        = NULL;
-    ggml_backend_t control_net_backend = NULL;
-    ggml_backend_t vae_backend         = NULL;
+    ggml_backend_t backend             = nullptr;  // general backend
+    ggml_backend_t clip_backend        = nullptr;
+    ggml_backend_t control_net_backend = nullptr;
+    ggml_backend_t vae_backend         = nullptr;
     ggml_type model_wtype              = GGML_TYPE_COUNT;
     ggml_type conditioner_wtype        = GGML_TYPE_COUNT;
     ggml_type diffusion_model_wtype    = GGML_TYPE_COUNT;
@@ -490,7 +490,7 @@ public:
             // first_stage_model->get_param_tensors(tensors, "first_stage_model.");
 
             if (strlen(SAFE_STR(sd_ctx_params->control_net_path)) > 0) {
-                ggml_backend_t controlnet_backend = NULL;
+                ggml_backend_t controlnet_backend = nullptr;
                 if (sd_ctx_params->keep_control_net_on_cpu && !ggml_backend_is_cpu(backend)) {
                     LOG_DEBUG("ControlNet: Using CPU backend");
                     controlnet_backend = ggml_backend_cpu_init();
@@ -546,11 +546,11 @@ public:
 
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(10 * 1024) * 1024;  // 10M
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = false;
         // LOG_DEBUG("mem_size %u ", params.mem_size);
         struct ggml_context* ctx = ggml_init(params);  // for  alphas_cumprod and is_using_v_parameterization check
-        GGML_ASSERT(ctx != NULL);
+        GGML_ASSERT(ctx != nullptr);
         ggml_tensor* alphas_cumprod_tensor = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, TIMESTEPS);
         calculate_alphas_cumprod((float*)alphas_cumprod_tensor->data);
 
@@ -768,14 +768,14 @@ public:
         struct ggml_tensor* timesteps = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, 1);
         ggml_set_f32(timesteps, 999);
 
-        struct ggml_tensor* concat = is_inpaint ? ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, 8, 8, 5, 1) : NULL;
-        if (concat != NULL) {
+        struct ggml_tensor* concat = is_inpaint ? ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, 8, 8, 5, 1) : nullptr;
+        if (concat != nullptr) {
             ggml_set_f32(concat, 0);
         }
 
         int64_t t0              = ggml_time_ms();
         struct ggml_tensor* out = ggml_dup_tensor(work_ctx, x_t);
-        diffusion_model->compute(n_threads, x_t, timesteps, c, concat, NULL, NULL, {}, -1, {}, 0.f, &out);
+        diffusion_model->compute(n_threads, x_t, timesteps, c, concat, nullptr, nullptr, {}, -1, {}, 0.f, &out);
         diffusion_model->free_compute_buffer();
 
         double result = 0.f;
@@ -881,7 +881,7 @@ public:
                             ggml_tensor* prompts_embeds,
                             ggml_tensor* id_embeds,
                             std::vector<bool>& class_tokens_mask) {
-        ggml_tensor* res = NULL;
+        ggml_tensor* res = nullptr;
         pmid_model->compute(n_threads, init_img, prompts_embeds, id_embeds, class_tokens_mask, &res, work_ctx);
         return res;
     }
@@ -891,7 +891,7 @@ public:
                                         bool return_pooled   = true,
                                         int clip_skip        = -1,
                                         bool zero_out_masked = false) {
-        ggml_tensor* output = NULL;
+        ggml_tensor* output = nullptr;
         if (zero_out_masked) {
             if (return_pooled) {
                 output = ggml_new_tensor_1d(work_ctx,
@@ -909,12 +909,12 @@ public:
             sd_image_f32_t image         = sd_image_t_to_sd_image_f32_t(init_image);
             sd_image_f32_t resized_image = clip_preprocess(image, clip_vision->vision_model.image_size);
             free(image.data);
-            image.data = NULL;
+            image.data = nullptr;
 
             ggml_tensor* pixel_values = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, resized_image.width, resized_image.height, 3, 1);
             sd_image_f32_to_tensor(resized_image.data, pixel_values, false);
             free(resized_image.data);
-            resized_image.data = NULL;
+            resized_image.data = nullptr;
 
             // print_ggml_tensor(pixel_values);
             clip_vision->compute(n_threads, pixel_values, return_pooled, clip_skip, &output, work_ctx);
@@ -936,7 +936,7 @@ public:
         struct ggml_tensor* c_crossattn = get_clip_vision_output(work_ctx, init_image, true, -1, zero_out_masked);
 
         // c_concat
-        struct ggml_tensor* c_concat = NULL;
+        struct ggml_tensor* c_concat = nullptr;
         {
             if (zero_out_masked) {
                 c_concat = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, width / 8, height / 8, 4, 1);
@@ -948,10 +948,10 @@ public:
                     sd_image_f32_t image         = sd_image_t_to_sd_image_f32_t(init_image);
                     sd_image_f32_t resized_image = resize_sd_image_f32_t(image, width, height);
                     free(image.data);
-                    image.data = NULL;
+                    image.data = nullptr;
                     sd_image_f32_to_tensor(resized_image.data, init_img, false);
                     free(resized_image.data);
-                    resized_image.data = NULL;
+                    resized_image.data = nullptr;
                 } else {
                     sd_image_to_tensor(init_image.data, init_img);
                 }
@@ -968,7 +968,7 @@ public:
         }
 
         // y
-        struct ggml_tensor* y = NULL;
+        struct ggml_tensor* y = nullptr;
         {
             y                            = ggml_new_tensor_1d(work_ctx, GGML_TYPE_F32, diffusion_model->get_adm_in_channels());
             int out_dim                  = 256;
@@ -987,7 +987,7 @@ public:
         if (diffusion_model->get_desc() == "Wan2.2-TI2V-5B") {
             auto new_timesteps = std::vector<float>(init_latent->ne[2], timesteps[0]);
 
-            if (denoise_mask != NULL) {
+            if (denoise_mask != nullptr) {
                 float value = ggml_tensor_get_f32(denoise_mask, 0, 0, 0, 0);
                 if (value == 0.f) {
                     new_timesteps[0] = 0.f;
@@ -1054,15 +1054,15 @@ public:
 
         struct ggml_tensor* noised_input = ggml_dup_tensor(work_ctx, x);
 
-        bool has_unconditioned = img_cfg_scale != 1.0 && uncond.c_crossattn != NULL;
-        bool has_img_cond      = cfg_scale != img_cfg_scale && img_cond.c_crossattn != NULL;
+        bool has_unconditioned = img_cfg_scale != 1.0 && uncond.c_crossattn != nullptr;
+        bool has_img_cond      = cfg_scale != img_cfg_scale && img_cond.c_crossattn != nullptr;
         bool has_skiplayer     = slg_scale != 0.0 && skip_layers.size() > 0;
 
         // denoise wrapper
         struct ggml_tensor* out_cond     = ggml_dup_tensor(work_ctx, x);
-        struct ggml_tensor* out_uncond   = NULL;
-        struct ggml_tensor* out_skip     = NULL;
-        struct ggml_tensor* out_img_cond = NULL;
+        struct ggml_tensor* out_uncond   = nullptr;
+        struct ggml_tensor* out_skip     = nullptr;
+        struct ggml_tensor* out_img_cond = nullptr;
 
         if (has_unconditioned) {
             out_uncond = ggml_dup_tensor(work_ctx, x);
@@ -1109,7 +1109,7 @@ public:
 
             std::vector<struct ggml_tensor*> controls;
 
-            if (control_hint != NULL) {
+            if (control_hint != nullptr) {
                 control_net->compute(n_threads, noised_input, control_hint, timesteps, cond.c_crossattn, cond.c_vector);
                 controls = control_net->controls;
                 // print_ggml_tensor(controls[12]);
@@ -1145,10 +1145,10 @@ public:
                                               &out_cond);
             }
 
-            float* negative_data = NULL;
+            float* negative_data = nullptr;
             if (has_unconditioned) {
                 // uncond
-                if (control_hint != NULL) {
+                if (control_hint != nullptr) {
                     control_net->compute(n_threads, noised_input, control_hint, timesteps, uncond.c_crossattn, uncond.c_vector);
                     controls = control_net->controls;
                 }
@@ -1167,7 +1167,7 @@ public:
                 negative_data = (float*)out_uncond->data;
             }
 
-            float* img_cond_data = NULL;
+            float* img_cond_data = nullptr;
             if (has_img_cond) {
                 work_diffusion_model->compute(n_threads,
                                               noised_input,
@@ -1186,7 +1186,7 @@ public:
 
             int step_count         = sigmas.size();
             bool is_skiplayer_step = has_skiplayer && step > (int)(guidance.slg.layer_start * step_count) && step < (int)(guidance.slg.layer_end * step_count);
-            float* skip_layer_data = NULL;
+            float* skip_layer_data = nullptr;
             if (is_skiplayer_step) {
                 LOG_DEBUG("Skipping layers at step %d\n", step);
                 // skip layer (same as conditionned)
@@ -1202,7 +1202,7 @@ public:
                                               controls,
                                               control_strength,
                                               &out_skip,
-                                              NULL,
+                                              nullptr,
                                               skip_layers);
                 skip_layer_data = (float*)out_skip->data;
             }
@@ -1291,7 +1291,7 @@ public:
 
     ggml_tensor* encode_first_stage(ggml_context* work_ctx, ggml_tensor* x, bool decode_video = false) {
         int64_t t0          = ggml_time_ms();
-        ggml_tensor* result = NULL;
+        ggml_tensor* result = nullptr;
         if (!use_tiny_autoencoder) {
             process_vae_input_tensor(x);
             first_stage_model->compute(n_threads, x, false, &result, work_ctx);
@@ -1390,7 +1390,7 @@ public:
         int64_t W           = x->ne[0] * 8;
         int64_t H           = x->ne[1] * 8;
         int64_t C           = 3;
-        ggml_tensor* result = NULL;
+        ggml_tensor* result = nullptr;
         if (decode_video) {
             int T = x->ne[2];
             if (sd_version_is_wan(version)) {
@@ -1422,7 +1422,7 @@ public:
             if (vae_tiling && !decode_video) {
                 // split latent in 32x32 tiles and compute in several steps
                 auto on_tiling = [&](ggml_tensor* in, ggml_tensor* out, bool init) {
-                    first_stage_model->compute(n_threads, in, true, &out, NULL);
+                    first_stage_model->compute(n_threads, in, true, &out, nullptr);
                 };
                 sd_tiling(x, result, 8, 32, 0.5f, on_tiling);
             } else {
@@ -1567,7 +1567,7 @@ void sd_ctx_params_init(sd_ctx_params_t* sd_ctx_params) {
 char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {
     char* buf = (char*)malloc(4096);
     if (!buf)
-        return NULL;
+        return nullptr;
     buf[0] = '\0';
 
     snprintf(buf + strlen(buf), 4096 - strlen(buf),
@@ -1645,7 +1645,7 @@ void sd_sample_params_init(sd_sample_params_t* sample_params) {
 char* sd_sample_params_to_str(const sd_sample_params_t* sample_params) {
     char* buf = (char*)malloc(4096);
     if (!buf)
-        return NULL;
+        return nullptr;
     buf[0] = '\0';
 
     snprintf(buf + strlen(buf), 4096 - strlen(buf),
@@ -1693,7 +1693,7 @@ void sd_img_gen_params_init(sd_img_gen_params_t* sd_img_gen_params) {
 char* sd_img_gen_params_to_str(const sd_img_gen_params_t* sd_img_gen_params) {
     char* buf = (char*)malloc(4096);
     if (!buf)
-        return NULL;
+        return nullptr;
     buf[0] = '\0';
 
     char* sample_params_str = sd_sample_params_to_str(&sd_img_gen_params->sample_params);
@@ -1746,33 +1746,33 @@ void sd_vid_gen_params_init(sd_vid_gen_params_t* sd_vid_gen_params) {
 }
 
 struct sd_ctx_t {
-    StableDiffusionGGML* sd = NULL;
+    StableDiffusionGGML* sd = nullptr;
 };
 
 sd_ctx_t* new_sd_ctx(const sd_ctx_params_t* sd_ctx_params) {
     sd_ctx_t* sd_ctx = (sd_ctx_t*)malloc(sizeof(sd_ctx_t));
-    if (sd_ctx == NULL) {
-        return NULL;
+    if (sd_ctx == nullptr) {
+        return nullptr;
     }
 
     sd_ctx->sd = new StableDiffusionGGML();
-    if (sd_ctx->sd == NULL) {
-        return NULL;
+    if (sd_ctx->sd == nullptr) {
+        return nullptr;
     }
 
     if (!sd_ctx->sd->init(sd_ctx_params)) {
         delete sd_ctx->sd;
-        sd_ctx->sd = NULL;
+        sd_ctx->sd = nullptr;
         free(sd_ctx);
-        return NULL;
+        return nullptr;
     }
     return sd_ctx;
 }
 
 void free_sd_ctx(sd_ctx_t* sd_ctx) {
-    if (sd_ctx->sd != NULL) {
+    if (sd_ctx->sd != nullptr) {
         delete sd_ctx->sd;
-        sd_ctx->sd = NULL;
+        sd_ctx->sd = nullptr;
     }
     free(sd_ctx);
 }
@@ -1797,13 +1797,13 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
                                     bool normalize_input,
                                     std::string input_id_images_path,
                                     std::vector<ggml_tensor*> ref_latents,
-                                    ggml_tensor* concat_latent = NULL,
-                                    ggml_tensor* denoise_mask  = NULL) {
+                                    ggml_tensor* concat_latent = nullptr,
+                                    ggml_tensor* denoise_mask  = nullptr) {
     if (seed < 0) {
         // Generally, when using the provided command line, the seed is always >0.
         // However, to prevent potential issues if 'stable-diffusion.cpp' is invoked as a library
         // by a third party with a seed <0, let's incorporate randomization here.
-        srand((int)time(NULL));
+        srand((int)time(nullptr));
         seed = rand();
     }
 
@@ -1820,7 +1820,7 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
 
     // Photo Maker
     std::string prompt_text_only;
-    ggml_tensor* init_img = NULL;
+    ggml_tensor* init_img = nullptr;
     SDCondition id_cond;
     std::vector<bool> class_tokens_mask;
     if (sd_ctx->sd->stacked_id) {
@@ -1846,19 +1846,19 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
                     continue;
                 }
                 uint8_t* input_image_buffer = stbi_load(img_file.c_str(), &width, &height, &c, 3);
-                if (input_image_buffer == NULL) {
+                if (input_image_buffer == nullptr) {
                     LOG_ERROR("PhotoMaker load image from '%s' failed", img_file.c_str());
                     continue;
                 } else {
                     LOG_INFO("PhotoMaker loaded image from '%s'", img_file.c_str());
                 }
-                sd_image_t* input_image = NULL;
+                sd_image_t* input_image = nullptr;
                 input_image             = new sd_image_t{(uint32_t)width,
                                              (uint32_t)height,
                                              3,
                                              input_image_buffer};
                 input_image             = preprocess_id_image(input_image);
-                if (input_image == NULL) {
+                if (input_image == nullptr) {
                     LOG_ERROR("preprocess input id image from '%s' failed", img_file.c_str());
                     continue;
                 }
@@ -1880,7 +1880,7 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
                 if (normalize_input)
                     sd_mul_images_to_tensor(init_image->data, init_img, i, mean, std);
                 else
-                    sd_mul_images_to_tensor(init_image->data, init_img, i, NULL, NULL);
+                    sd_mul_images_to_tensor(init_image->data, init_img, i, nullptr, nullptr);
             }
             int64_t t0                    = ggml_time_ms();
             auto cond_tup                 = sd_ctx->sd->cond_stage_model->get_learned_condition_with_trigger(work_ctx,
@@ -1892,7 +1892,7 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
                                                                                                              sd_ctx->sd->diffusion_model->get_adm_in_channels());
             id_cond                       = std::get<0>(cond_tup);
             class_tokens_mask             = std::get<1>(cond_tup);  //
-            struct ggml_tensor* id_embeds = NULL;
+            struct ggml_tensor* id_embeds = nullptr;
             if (pmv2) {
                 // id_embeds = sd_ctx->sd->pmid_id_embeds->get();
                 id_embeds = load_tensor_from_file(work_ctx, path_join(input_id_images_path, "id_embeds.bin"));
@@ -1957,8 +1957,8 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
     }
 
     // Control net hint
-    struct ggml_tensor* image_hint = NULL;
-    if (control_image.data != NULL) {
+    struct ggml_tensor* image_hint = nullptr;
+    if (control_image.data != nullptr) {
         image_hint = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, width, height, 3, 1);
         sd_image_to_tensor(control_image.data, image_hint);
     }
@@ -1999,23 +1999,23 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
                 }
             }
         }
-        if (concat_latent == NULL) {
+        if (concat_latent == nullptr) {
             concat_latent = empty_latent;
         }
         cond.c_concat   = concat_latent;
         uncond.c_concat = empty_latent;
-        denoise_mask    = NULL;
+        denoise_mask    = nullptr;
     } else if (sd_version_is_unet_edit(sd_ctx->sd->version)) {
         auto empty_latent = ggml_dup_tensor(work_ctx, init_latent);
         ggml_set_f32(empty_latent, 0);
         uncond.c_concat = empty_latent;
-        if (concat_latent == NULL) {
+        if (concat_latent == nullptr) {
             concat_latent = empty_latent;
         }
         cond.c_concat = ref_latents[0];
     }
     SDCondition img_cond;
-    if (uncond.c_crossattn != NULL &&
+    if (uncond.c_crossattn != nullptr &&
         (sd_version_is_inpaint_or_unet_edit(sd_ctx->sd->version) && guidance.txt_cfg != guidance.img_cfg)) {
         img_cond = SDCondition(uncond.c_crossattn, uncond.c_vector, cond.c_concat);
     }
@@ -2074,7 +2074,7 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
         t1                      = ggml_time_ms();
         struct ggml_tensor* img = sd_ctx->sd->decode_first_stage(work_ctx, final_latents[i] /* x_0 */);
         // print_ggml_tensor(img);
-        if (img != NULL) {
+        if (img != nullptr) {
             decoded_images.push_back(img);
         }
         int64_t t2 = ggml_time_ms();
@@ -2087,9 +2087,9 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
         sd_ctx->sd->first_stage_model->free_params_buffer();
     }
     sd_image_t* result_images = (sd_image_t*)calloc(batch_count, sizeof(sd_image_t));
-    if (result_images == NULL) {
+    if (result_images == nullptr) {
         ggml_free(work_ctx);
-        return NULL;
+        return nullptr;
     }
 
     for (size_t i = 0; i < decoded_images.size(); i++) {
@@ -2151,18 +2151,18 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
                       model_version_to_str[sd_ctx->sd->version],
                       width,
                       height);
-            return NULL;
+            return nullptr;
         }
     } else if (width % 64 || height % 64) {
         LOG_ERROR("Image dimensions must be must be a multiple of 64 on each axis for %s models. (Got %dx%d)",
                   model_version_to_str[sd_ctx->sd->version],
                   width,
                   height);
-        return NULL;
+        return nullptr;
     }
     LOG_DEBUG("generate_image %dx%d", width, height);
-    if (sd_ctx == NULL || sd_img_gen_params == NULL) {
-        return NULL;
+    if (sd_ctx == nullptr || sd_img_gen_params == nullptr) {
+        return nullptr;
     }
 
     struct ggml_init_params params;
@@ -2179,19 +2179,19 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
     params.mem_size += width * height * 3 * sizeof(float) * 3;
     params.mem_size += width * height * 3 * sizeof(float) * 3 * sd_img_gen_params->ref_images_count;
     params.mem_size *= sd_img_gen_params->batch_count;
-    params.mem_buffer = NULL;
+    params.mem_buffer = nullptr;
     params.no_alloc   = false;
     // LOG_DEBUG("mem_size %u ", params.mem_size);
 
     struct ggml_context* work_ctx = ggml_init(params);
     if (!work_ctx) {
         LOG_ERROR("ggml_init() failed");
-        return NULL;
+        return nullptr;
     }
 
     int64_t seed = sd_img_gen_params->seed;
     if (seed < 0) {
-        srand((int)time(NULL));
+        srand((int)time(nullptr));
         seed = rand();
     }
     sd_ctx->sd->rng->manual_seed(seed);
@@ -2203,9 +2203,9 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
     sd_ctx->sd->init_scheduler(sd_img_gen_params->sample_params.scheduler);
     std::vector<float> sigmas = sd_ctx->sd->denoiser->get_sigmas(sample_steps);
 
-    ggml_tensor* init_latent   = NULL;
-    ggml_tensor* concat_latent = NULL;
-    ggml_tensor* denoise_mask  = NULL;
+    ggml_tensor* init_latent   = nullptr;
+    ggml_tensor* concat_latent = nullptr;
+    ggml_tensor* denoise_mask  = nullptr;
     if (sd_img_gen_params->init_image.data) {
         LOG_INFO("IMG2IMG");
 
@@ -2230,7 +2230,7 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
             }
             ggml_tensor* masked_img = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, width, height, 3, 1);
             sd_apply_mask(init_img, mask_img, masked_img);
-            ggml_tensor* masked_latent = NULL;
+            ggml_tensor* masked_latent = nullptr;
             if (!sd_ctx->sd->use_tiny_autoencoder) {
                 ggml_tensor* moments = sd_ctx->sd->encode_first_stage(work_ctx, masked_img);
                 masked_latent        = sd_ctx->sd->get_first_stage_encoding(work_ctx, moments);
@@ -2314,7 +2314,7 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
                                               1);
         sd_image_to_tensor(sd_img_gen_params->ref_images[i].data, img);
 
-        ggml_tensor* latent = NULL;
+        ggml_tensor* latent = nullptr;
         if (sd_ctx->sd->use_tiny_autoencoder) {
             latent = sd_ctx->sd->encode_first_stage(work_ctx, img);
         } else if (sd_ctx->sd->version == VERSION_SD1_PIX2PIX) {
@@ -2334,7 +2334,7 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
         ref_latents.push_back(latent);
     }
 
-    if (sd_img_gen_params->init_image.data != NULL || sd_img_gen_params->ref_images_count > 0) {
+    if (sd_img_gen_params->init_image.data != nullptr || sd_img_gen_params->ref_images_count > 0) {
         size_t t1 = ggml_time_ms();
         LOG_INFO("encode_first_stage completed, taking %.2fs", (t1 - t0) * 1.0f / 1000);
     }
@@ -2370,8 +2370,8 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* sd_img_g
 }
 
 SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* sd_vid_gen_params, int* num_frames_out) {
-    if (sd_ctx == NULL || sd_vid_gen_params == NULL) {
-        return NULL;
+    if (sd_ctx == nullptr || sd_vid_gen_params == nullptr) {
+        return nullptr;
     }
 
     std::string prompt          = SAFE_STR(sd_vid_gen_params->prompt);
@@ -2414,19 +2414,19 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
     struct ggml_init_params params;
     params.mem_size = static_cast<size_t>(200 * 1024) * 1024;  // 200 MB
     params.mem_size += width * height * frames * 3 * sizeof(float) * 2;
-    params.mem_buffer = NULL;
+    params.mem_buffer = nullptr;
     params.no_alloc   = false;
     // LOG_DEBUG("mem_size %u ", params.mem_size);
 
     struct ggml_context* work_ctx = ggml_init(params);
     if (!work_ctx) {
         LOG_ERROR("ggml_init() failed");
-        return NULL;
+        return nullptr;
     }
 
     int64_t seed = sd_vid_gen_params->seed;
     if (seed < 0) {
-        seed = (int)time(NULL);
+        seed = (int)time(nullptr);
     }
 
     sd_ctx->sd->rng->manual_seed(seed);
@@ -2436,10 +2436,10 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
     // Apply lora
     prompt = sd_ctx->sd->apply_loras_from_prompt(prompt);
 
-    ggml_tensor* init_latent        = NULL;
-    ggml_tensor* clip_vision_output = NULL;
-    ggml_tensor* concat_latent      = NULL;
-    ggml_tensor* denoise_mask       = NULL;
+    ggml_tensor* init_latent        = nullptr;
+    ggml_tensor* clip_vision_output = nullptr;
+    ggml_tensor* concat_latent      = nullptr;
+    ggml_tensor* denoise_mask       = nullptr;
     if (sd_ctx->sd->diffusion_model->get_desc() == "Wan2.1-I2V-14B" ||
         sd_ctx->sd->diffusion_model->get_desc() == "Wan2.2-I2V-14B" ||
         sd_ctx->sd->diffusion_model->get_desc() == "Wan2.1-FLF2V-14B") {
@@ -2454,7 +2454,7 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
             }
 
             if (sd_ctx->sd->diffusion_model->get_desc() == "Wan2.1-FLF2V-14B") {
-                ggml_tensor* end_image_clip_vision_output = NULL;
+                ggml_tensor* end_image_clip_vision_output = nullptr;
                 if (sd_vid_gen_params->end_image.data) {
                     end_image_clip_vision_output = sd_ctx->sd->get_clip_vision_output(work_ctx, sd_vid_gen_params->end_image, false, -2);
                 } else {
@@ -2553,7 +2553,7 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
         LOG_INFO("encode_first_stage completed, taking %" PRId64 " ms", t2 - t1);
     }
 
-    if (init_latent == NULL) {
+    if (init_latent == nullptr) {
         init_latent = generate_init_latent(sd_ctx, work_ctx, width, height, frames, true);
     }
 
@@ -2621,7 +2621,7 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
                                  cond,
                                  uncond,
                                  {},
-                                 NULL,
+                                 nullptr,
                                  0,
                                  sd_vid_gen_params->high_noise_sample_params.guidance,
                                  sd_vid_gen_params->high_noise_sample_params.eta,
@@ -2637,7 +2637,7 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
         if (sd_ctx->sd->free_params_immediately) {
             sd_ctx->sd->high_noise_diffusion_model->free_params_buffer();
         }
-        noise = NULL;
+        noise = nullptr;
     }
 
     // Sample
@@ -2653,7 +2653,7 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
                                           cond,
                                           uncond,
                                           {},
-                                          NULL,
+                                          nullptr,
                                           0,
                                           sd_vid_gen_params->sample_params.guidance,
                                           sd_vid_gen_params->sample_params.eta,
@@ -2681,9 +2681,9 @@ SD_API sd_image_t* generate_video(sd_ctx_t* sd_ctx, const sd_vid_gen_params_t* s
     }
 
     sd_image_t* result_images = (sd_image_t*)calloc(vid->ne[2], sizeof(sd_image_t));
-    if (result_images == NULL) {
+    if (result_images == nullptr) {
         ggml_free(work_ctx);
-        return NULL;
+        return nullptr;
     }
     *num_frames_out = vid->ne[2];
 

--- a/t5.hpp
+++ b/t5.hpp
@@ -579,9 +579,9 @@ public:
     // x: [N, n_token, model_dim]
     std::pair<struct ggml_tensor*, struct ggml_tensor*> forward(struct ggml_context* ctx,
                                                                 struct ggml_tensor* x,
-                                                                struct ggml_tensor* past_bias                = NULL,
-                                                                struct ggml_tensor* mask                     = NULL,
-                                                                struct ggml_tensor* relative_position_bucket = NULL) {
+                                                                struct ggml_tensor* past_bias                = nullptr,
+                                                                struct ggml_tensor* mask                     = nullptr,
+                                                                struct ggml_tensor* relative_position_bucket = nullptr) {
         auto q_proj   = std::dynamic_pointer_cast<Linear>(blocks["q"]);
         auto k_proj   = std::dynamic_pointer_cast<Linear>(blocks["k"]);
         auto v_proj   = std::dynamic_pointer_cast<Linear>(blocks["v"]);
@@ -594,11 +594,11 @@ public:
         auto k = k_proj->forward(ctx, x);
         auto v = v_proj->forward(ctx, x);
 
-        if (using_relative_attention_bias && relative_position_bucket != NULL) {
+        if (using_relative_attention_bias && relative_position_bucket != nullptr) {
             past_bias = compute_bias(ctx, relative_position_bucket);
         }
-        if (past_bias != NULL) {
-            if (mask != NULL) {
+        if (past_bias != nullptr) {
+            if (mask != nullptr) {
                 mask = ggml_repeat(ctx, mask, past_bias);
                 mask = ggml_add(ctx, mask, past_bias);
             } else {
@@ -628,9 +628,9 @@ public:
 
     std::pair<struct ggml_tensor*, struct ggml_tensor*> forward(struct ggml_context* ctx,
                                                                 struct ggml_tensor* x,
-                                                                struct ggml_tensor* past_bias                = NULL,
-                                                                struct ggml_tensor* mask                     = NULL,
-                                                                struct ggml_tensor* relative_position_bucket = NULL) {
+                                                                struct ggml_tensor* past_bias                = nullptr,
+                                                                struct ggml_tensor* mask                     = nullptr,
+                                                                struct ggml_tensor* relative_position_bucket = nullptr) {
         // x: [N, n_token, model_dim]
         auto SelfAttention = std::dynamic_pointer_cast<T5Attention>(blocks["SelfAttention"]);
         auto layer_norm    = std::dynamic_pointer_cast<T5LayerNorm>(blocks["layer_norm"]);
@@ -654,9 +654,9 @@ public:
 
     std::pair<struct ggml_tensor*, struct ggml_tensor*> forward(struct ggml_context* ctx,
                                                                 struct ggml_tensor* x,
-                                                                struct ggml_tensor* past_bias                = NULL,
-                                                                struct ggml_tensor* mask                     = NULL,
-                                                                struct ggml_tensor* relative_position_bucket = NULL) {
+                                                                struct ggml_tensor* past_bias                = nullptr,
+                                                                struct ggml_tensor* mask                     = nullptr,
+                                                                struct ggml_tensor* relative_position_bucket = nullptr) {
         // x: [N, n_token, model_dim]
         auto layer_0 = std::dynamic_pointer_cast<T5LayerSelfAttention>(blocks["layer.0"]);
         auto layer_1 = std::dynamic_pointer_cast<T5LayerFF>(blocks["layer.1"]);
@@ -689,9 +689,9 @@ public:
 
     struct ggml_tensor* forward(struct ggml_context* ctx,
                                 struct ggml_tensor* x,
-                                struct ggml_tensor* past_bias                = NULL,
-                                struct ggml_tensor* attention_mask           = NULL,
-                                struct ggml_tensor* relative_position_bucket = NULL) {
+                                struct ggml_tensor* past_bias                = nullptr,
+                                struct ggml_tensor* attention_mask           = nullptr,
+                                struct ggml_tensor* relative_position_bucket = nullptr) {
         // x: [N, n_token, model_dim]
         for (int i = 0; i < num_layers; i++) {
             auto block = std::dynamic_pointer_cast<T5Block>(blocks["block." + std::to_string(i)]);
@@ -736,9 +736,9 @@ public:
 
     struct ggml_tensor* forward(struct ggml_context* ctx,
                                 struct ggml_tensor* input_ids,
-                                struct ggml_tensor* past_bias                = NULL,
-                                struct ggml_tensor* attention_mask           = NULL,
-                                struct ggml_tensor* relative_position_bucket = NULL) {
+                                struct ggml_tensor* past_bias                = nullptr,
+                                struct ggml_tensor* attention_mask           = nullptr,
+                                struct ggml_tensor* relative_position_bucket = nullptr) {
         // input_ids: [N, n_token]
 
         auto shared  = std::dynamic_pointer_cast<Embedding>(blocks["shared"]);
@@ -780,16 +780,16 @@ struct T5Runner : public GGMLRunner {
     struct ggml_tensor* forward(struct ggml_context* ctx,
                                 struct ggml_tensor* input_ids,
                                 struct ggml_tensor* relative_position_bucket,
-                                struct ggml_tensor* attention_mask = NULL) {
+                                struct ggml_tensor* attention_mask = nullptr) {
         size_t N       = input_ids->ne[1];
         size_t n_token = input_ids->ne[0];
 
-        auto hidden_states = model.forward(ctx, input_ids, NULL, attention_mask, relative_position_bucket);  // [N, n_token, model_dim]
+        auto hidden_states = model.forward(ctx, input_ids, nullptr, attention_mask, relative_position_bucket);  // [N, n_token, model_dim]
         return hidden_states;
     }
 
     struct ggml_cgraph* build_graph(struct ggml_tensor* input_ids,
-                                    struct ggml_tensor* attention_mask = NULL) {
+                                    struct ggml_tensor* attention_mask = nullptr) {
         struct ggml_cgraph* gf = ggml_new_graph(compute_ctx);
 
         input_ids      = to_backend(input_ids);
@@ -821,7 +821,7 @@ struct T5Runner : public GGMLRunner {
                  struct ggml_tensor* input_ids,
                  struct ggml_tensor* attention_mask,
                  ggml_tensor** output,
-                 ggml_context* output_ctx = NULL) {
+                 ggml_context* output_ctx = nullptr) {
         auto get_graph = [&]() -> struct ggml_cgraph* {
             return build_graph(input_ids, attention_mask);
         };
@@ -960,11 +960,11 @@ struct T5Embedder {
     void test() {
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(10 * 1024 * 1024);  // 10 MB
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = false;
 
         struct ggml_context* work_ctx = ggml_init(params);
-        GGML_ASSERT(work_ctx != NULL);
+        GGML_ASSERT(work_ctx != nullptr);
 
         {
             std::string text("a lovely cat");
@@ -979,7 +979,7 @@ struct T5Embedder {
             printf("\n");
             auto input_ids          = vector_to_ggml_tensor_i32(work_ctx, tokens);
             auto attention_mask     = vector_to_ggml_tensor(work_ctx, masks);
-            struct ggml_tensor* out = NULL;
+            struct ggml_tensor* out = nullptr;
 
             int t0 = ggml_time_ms();
             model.compute(8, input_ids, attention_mask, &out, work_ctx);

--- a/tae.hpp
+++ b/tae.hpp
@@ -261,7 +261,7 @@ struct TinyAutoEncoder : public GGMLRunner {
                  struct ggml_tensor* z,
                  bool decode_graph,
                  struct ggml_tensor** output,
-                 struct ggml_context* output_ctx = NULL) {
+                 struct ggml_context* output_ctx = nullptr) {
         auto get_graph = [&]() -> struct ggml_cgraph* {
             return build_graph(z, decode_graph);
         };

--- a/unet.hpp
+++ b/unet.hpp
@@ -381,8 +381,8 @@ public:
                                 struct ggml_tensor* x,
                                 struct ggml_tensor* timesteps,
                                 struct ggml_tensor* context,
-                                struct ggml_tensor* c_concat              = NULL,
-                                struct ggml_tensor* y                     = NULL,
+                                struct ggml_tensor* c_concat              = nullptr,
+                                struct ggml_tensor* y                     = nullptr,
                                 int num_video_frames                      = -1,
                                 std::vector<struct ggml_tensor*> controls = {},
                                 float control_strength                    = 0.f) {
@@ -392,20 +392,20 @@ public:
         // c_concat: [N, in_channels, h, w] or [1, in_channels, h, w]
         // y: [N, adm_in_channels] or [1, adm_in_channels]
         // return: [N, out_channels, h, w]
-        if (context != NULL) {
+        if (context != nullptr) {
             if (context->ne[2] != x->ne[3]) {
                 context = ggml_repeat(ctx, context, ggml_new_tensor_3d(ctx, GGML_TYPE_F32, context->ne[0], context->ne[1], x->ne[3]));
             }
         }
 
-        if (c_concat != NULL) {
+        if (c_concat != nullptr) {
             if (c_concat->ne[3] != x->ne[3]) {
                 c_concat = ggml_repeat(ctx, c_concat, x);
             }
             x = ggml_concat(ctx, x, c_concat, 2);
         }
 
-        if (y != NULL) {
+        if (y != nullptr) {
             if (y->ne[1] != x->ne[3]) {
                 y = ggml_repeat(ctx, y, ggml_new_tensor_2d(ctx, GGML_TYPE_F32, y->ne[0], x->ne[3]));
             }
@@ -425,7 +425,7 @@ public:
         emb      = time_embed_2->forward(ctx, emb);  // [N, time_embed_dim]
 
         // SDXL/SVD
-        if (y != NULL) {
+        if (y != nullptr) {
             auto label_embed_0 = std::dynamic_pointer_cast<Linear>(blocks["label_emb.0.0"]);
             auto label_embed_2 = std::dynamic_pointer_cast<Linear>(blocks["label_emb.0.2"]);
 
@@ -570,8 +570,8 @@ struct UNetModelRunner : public GGMLRunner {
     struct ggml_cgraph* build_graph(struct ggml_tensor* x,
                                     struct ggml_tensor* timesteps,
                                     struct ggml_tensor* context,
-                                    struct ggml_tensor* c_concat              = NULL,
-                                    struct ggml_tensor* y                     = NULL,
+                                    struct ggml_tensor* c_concat              = nullptr,
+                                    struct ggml_tensor* y                     = nullptr,
                                     int num_video_frames                      = -1,
                                     std::vector<struct ggml_tensor*> controls = {},
                                     float control_strength                    = 0.f) {
@@ -615,8 +615,8 @@ struct UNetModelRunner : public GGMLRunner {
                  int num_video_frames                      = -1,
                  std::vector<struct ggml_tensor*> controls = {},
                  float control_strength                    = 0.f,
-                 struct ggml_tensor** output               = NULL,
-                 struct ggml_context* output_ctx           = NULL) {
+                 struct ggml_tensor** output               = nullptr,
+                 struct ggml_context* output_ctx           = nullptr) {
         // x: [N, in_channels, h, w]
         // timesteps: [N, ]
         // context: [N, max_position, hidden_size]([N, 77, 768]) or [1, max_position, hidden_size]
@@ -632,11 +632,11 @@ struct UNetModelRunner : public GGMLRunner {
     void test() {
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(10 * 1024 * 1024);  // 10 MB
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = false;
 
         struct ggml_context* work_ctx = ggml_init(params);
-        GGML_ASSERT(work_ctx != NULL);
+        GGML_ASSERT(work_ctx != nullptr);
 
         {
             // CPU, num_video_frames = 1, x{num_video_frames, 8, 8, 8}: Pass
@@ -659,10 +659,10 @@ struct UNetModelRunner : public GGMLRunner {
             ggml_set_f32(y, 0.5f);
             // print_ggml_tensor(y);
 
-            struct ggml_tensor* out = NULL;
+            struct ggml_tensor* out = nullptr;
 
             int t0 = ggml_time_ms();
-            compute(8, x, timesteps, context, NULL, y, num_video_frames, {}, 0.f, &out, work_ctx);
+            compute(8, x, timesteps, context, nullptr, y, num_video_frames, {}, 0.f, &out, work_ctx);
             int t1 = ggml_time_ms();
 
             print_ggml_tensor(out);

--- a/upscaler.cpp
+++ b/upscaler.cpp
@@ -4,7 +4,7 @@
 #include "stable-diffusion.h"
 
 struct UpscalerGGML {
-    ggml_backend_t backend    = NULL;  // general backend
+    ggml_backend_t backend    = nullptr;  // general backend
     ggml_type model_data_type = GGML_TYPE_F16;
     std::shared_ptr<ESRGAN> esrgan_upscaler;
     std::string esrgan_path;
@@ -62,7 +62,7 @@ struct UpscalerGGML {
 
     sd_image_t upscale(sd_image_t input_image, uint32_t upscale_factor) {
         // upscale_factor, unused for RealESRGAN_x4plus_anime_6B.pth
-        sd_image_t upscaled_image = {0, 0, 0, NULL};
+        sd_image_t upscaled_image = {0, 0, 0, nullptr};
         int output_width          = (int)input_image.width * esrgan_upscaler->scale;
         int output_height         = (int)input_image.height * esrgan_upscaler->scale;
         LOG_INFO("upscaling from (%i x %i) to (%i x %i)",
@@ -71,7 +71,7 @@ struct UpscalerGGML {
         struct ggml_init_params params;
         params.mem_size = output_width * output_height * 3 * sizeof(float) * 2;
         params.mem_size += 2 * ggml_tensor_overhead();
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = false;
 
         // draft context
@@ -107,7 +107,7 @@ struct UpscalerGGML {
 };
 
 struct upscaler_ctx_t {
-    UpscalerGGML* upscaler = NULL;
+    UpscalerGGML* upscaler = nullptr;
 };
 
 upscaler_ctx_t* new_upscaler_ctx(const char* esrgan_path_c_str,
@@ -115,21 +115,21 @@ upscaler_ctx_t* new_upscaler_ctx(const char* esrgan_path_c_str,
                                  bool direct,
                                  int n_threads) {
     upscaler_ctx_t* upscaler_ctx = (upscaler_ctx_t*)malloc(sizeof(upscaler_ctx_t));
-    if (upscaler_ctx == NULL) {
-        return NULL;
+    if (upscaler_ctx == nullptr) {
+        return nullptr;
     }
     std::string esrgan_path(esrgan_path_c_str);
 
     upscaler_ctx->upscaler = new UpscalerGGML(n_threads, direct);
-    if (upscaler_ctx->upscaler == NULL) {
-        return NULL;
+    if (upscaler_ctx->upscaler == nullptr) {
+        return nullptr;
     }
 
     if (!upscaler_ctx->upscaler->load_from_file(esrgan_path, offload_params_to_cpu)) {
         delete upscaler_ctx->upscaler;
-        upscaler_ctx->upscaler = NULL;
+        upscaler_ctx->upscaler = nullptr;
         free(upscaler_ctx);
-        return NULL;
+        return nullptr;
     }
     return upscaler_ctx;
 }
@@ -139,9 +139,9 @@ sd_image_t upscale(upscaler_ctx_t* upscaler_ctx, sd_image_t input_image, uint32_
 }
 
 void free_upscaler_ctx(upscaler_ctx_t* upscaler_ctx) {
-    if (upscaler_ctx->upscaler != NULL) {
+    if (upscaler_ctx->upscaler != nullptr) {
         delete upscaler_ctx->upscaler;
-        upscaler_ctx->upscaler = NULL;
+        upscaler_ctx->upscaler = nullptr;
     }
     free(upscaler_ctx);
 }

--- a/util.cpp
+++ b/util.cpp
@@ -64,7 +64,7 @@ std::string format(const char* fmt, ...) {
     va_list ap2;
     va_start(ap, fmt);
     va_copy(ap2, ap);
-    int size = vsnprintf(NULL, 0, fmt, ap);
+    int size = vsnprintf(nullptr, 0, fmt, ap);
     std::vector<char> buf(size + 1);
     int size2 = vsnprintf(buf.data(), size + 1, fmt, ap2);
     va_end(ap2);
@@ -240,11 +240,11 @@ int32_t get_num_physical_cores() {
 #elif defined(__APPLE__) && defined(__MACH__)
     int32_t num_physical_cores;
     size_t len = sizeof(num_physical_cores);
-    int result = sysctlbyname("hw.perflevel0.physicalcpu", &num_physical_cores, &len, NULL, 0);
+    int result = sysctlbyname("hw.perflevel0.physicalcpu", &num_physical_cores, &len, nullptr, 0);
     if (result == 0) {
         return num_physical_cores;
     }
-    result = sysctlbyname("hw.physicalcpu", &num_physical_cores, &len, NULL, 0);
+    result = sysctlbyname("hw.physicalcpu", &num_physical_cores, &len, nullptr, 0);
     if (result == 0) {
         return num_physical_cores;
     }
@@ -255,8 +255,8 @@ int32_t get_num_physical_cores() {
     return n_threads > 0 ? (n_threads <= 4 ? n_threads : n_threads / 2) : 4;
 }
 
-static sd_progress_cb_t sd_progress_cb = NULL;
-void* sd_progress_cb_data              = NULL;
+static sd_progress_cb_t sd_progress_cb = nullptr;
+void* sd_progress_cb_data              = nullptr;
 
 std::u32string utf8_to_utf32(const std::string& utf8_str) {
     std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> converter;
@@ -321,7 +321,7 @@ std::vector<std::string> split_string(const std::string& str, char delimiter) {
 sd_image_t* preprocess_id_image(sd_image_t* img) {
     int shortest_edge   = 224;
     int size            = shortest_edge;
-    sd_image_t* resized = NULL;
+    sd_image_t* resized = nullptr;
     uint32_t w          = img->width;
     uint32_t h          = img->height;
     uint32_t c          = img->channel;
@@ -399,8 +399,8 @@ std::string trim(const std::string& s) {
     return rtrim(ltrim(s));
 }
 
-static sd_log_cb_t sd_log_cb = NULL;
-void* sd_log_cb_data         = NULL;
+static sd_log_cb_t sd_log_cb = nullptr;
+void* sd_log_cb_data         = nullptr;
 
 #define LOG_BUFFER_SIZE 1024
 

--- a/vae.hpp
+++ b/vae.hpp
@@ -582,7 +582,7 @@ struct AutoEncoderKL : public VAE {
                  struct ggml_tensor* z,
                  bool decode_graph,
                  struct ggml_tensor** output,
-                 struct ggml_context* output_ctx = NULL) {
+                 struct ggml_context* output_ctx = nullptr) {
         auto get_graph = [&]() -> struct ggml_cgraph* {
             return build_graph(z, decode_graph);
         };
@@ -594,11 +594,11 @@ struct AutoEncoderKL : public VAE {
     void test() {
         struct ggml_init_params params;
         params.mem_size   = static_cast<size_t>(10 * 1024 * 1024);  // 10 MB
-        params.mem_buffer = NULL;
+        params.mem_buffer = nullptr;
         params.no_alloc   = false;
 
         struct ggml_context* work_ctx = ggml_init(params);
-        GGML_ASSERT(work_ctx != NULL);
+        GGML_ASSERT(work_ctx != nullptr);
 
         {
             // CPU, x{1, 3, 64, 64}: Pass
@@ -608,7 +608,7 @@ struct AutoEncoderKL : public VAE {
             auto x = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, 64, 64, 3, 2);
             ggml_set_f32(x, 0.5f);
             print_ggml_tensor(x);
-            struct ggml_tensor* out = NULL;
+            struct ggml_tensor* out = nullptr;
 
             int t0 = ggml_time_ms();
             compute(8, x, false, &out, work_ctx);
@@ -626,7 +626,7 @@ struct AutoEncoderKL : public VAE {
             auto z = ggml_new_tensor_4d(work_ctx, GGML_TYPE_F32, 8, 8, 4, 1);
             ggml_set_f32(z, 0.5f);
             print_ggml_tensor(z);
-            struct ggml_tensor* out = NULL;
+            struct ggml_tensor* out = nullptr;
 
             int t0 = ggml_time_ms();
             compute(8, z, true, &out, work_ctx);

--- a/wan.hpp
+++ b/wan.hpp
@@ -52,11 +52,11 @@ namespace WAN {
               dilation(dilation),
               bias(bias) {}
 
-        struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x, struct ggml_tensor* cache_x = NULL) {
+        struct ggml_tensor* forward(struct ggml_context* ctx, struct ggml_tensor* x, struct ggml_tensor* cache_x = nullptr) {
             // x: [N*IC, ID, IH, IW]
             // result: x: [N*OC, ID, IH, IW]
             struct ggml_tensor* w = params["weight"];
-            struct ggml_tensor* b = NULL;
+            struct ggml_tensor* b = nullptr;
             if (bias) {
                 b = params["bias"];
             }
@@ -68,7 +68,7 @@ namespace WAN {
             int lp2 = 2 * std::get<0>(padding);
             int rp2 = 0;
 
-            if (cache_x != NULL && lp2 > 0) {
+            if (cache_x != nullptr && lp2 > 0) {
                 x = ggml_concat(ctx, cache_x, x, 2);
                 lp2 -= (int)cache_x->ne[2];
             }
@@ -159,12 +159,12 @@ namespace WAN {
                     int idx = feat_idx;
                     feat_idx += 1;
                     if (chunk_idx == 0) {
-                        // feat_cache[idx] == NULL, pass
+                        // feat_cache[idx] == nullptr, pass
                     } else {
                         auto time_conv = std::dynamic_pointer_cast<CausalConv3d>(blocks["time_conv"]);
 
                         auto cache_x = ggml_slice(ctx, x, 2, -CACHE_T, x->ne[2]);
-                        if (cache_x->ne[2] < 2 && feat_cache[idx] != NULL) {  // chunk_idx >= 2
+                        if (cache_x->ne[2] < 2 && feat_cache[idx] != nullptr) {  // chunk_idx >= 2
                             // cache last frame of last two chunk
                             cache_x = ggml_concat(ctx,
                                                   ggml_slice(ctx, feat_cache[idx], 2, -1, feat_cache[idx]->ne[2]),
@@ -209,7 +209,7 @@ namespace WAN {
             if (mode == "downsample3d") {
                 if (feat_cache.size() > 0) {
                     int idx = feat_idx;
-                    if (feat_cache[idx] == NULL) {
+                    if (feat_cache[idx] == nullptr) {
                         feat_cache[idx] = x;
                         feat_idx += 1;
                     } else {
@@ -373,7 +373,7 @@ namespace WAN {
                     if (feat_cache.size() > 0) {
                         int idx      = feat_idx;
                         auto cache_x = ggml_slice(ctx, x, 2, -CACHE_T, x->ne[2]);
-                        if (cache_x->ne[2] < 2 && feat_cache[idx] != NULL) {
+                        if (cache_x->ne[2] < 2 && feat_cache[idx] != nullptr) {
                             // cache last frame of last two chunk
                             cache_x = ggml_concat(ctx,
                                                   ggml_slice(ctx, feat_cache[idx], 2, -1, feat_cache[idx]->ne[2]),
@@ -566,7 +566,7 @@ namespace WAN {
 
             x = ggml_nn_attention(ctx, q, k, v, false);  // [t, h * w, c]
             // v      = ggml_cont(ctx, ggml_torch_permute(ctx, v, 1, 0, 2, 3));  // [t, h * w, c]
-            // x = ggml_nn_attention_ext(ctx, q, k, v, q->ne[2], NULL, false, false, true);
+            // x = ggml_nn_attention_ext(ctx, q, k, v, q->ne[2], nullptr, false, false, true);
 
             x = ggml_nn_cont(ctx, ggml_permute(ctx, x, 1, 0, 2, 3));  // [t, c, h * w]
             x = ggml_reshape_4d(ctx, x, w, h, c, n);                  // [t, c, h, w]
@@ -672,7 +672,7 @@ namespace WAN {
             if (feat_cache.size() > 0) {
                 int idx      = feat_idx;
                 auto cache_x = ggml_slice(ctx, x, 2, -CACHE_T, x->ne[2]);
-                if (cache_x->ne[2] < 2 && feat_cache[idx] != NULL) {
+                if (cache_x->ne[2] < 2 && feat_cache[idx] != nullptr) {
                     // cache last frame of last two chunk
                     cache_x = ggml_concat(ctx,
                                           ggml_slice(ctx, feat_cache[idx], 2, -1, feat_cache[idx]->ne[2]),
@@ -724,7 +724,7 @@ namespace WAN {
             if (feat_cache.size() > 0) {
                 int idx      = feat_idx;
                 auto cache_x = ggml_slice(ctx, x, 2, -CACHE_T, x->ne[2]);
-                if (cache_x->ne[2] < 2 && feat_cache[idx] != NULL) {
+                if (cache_x->ne[2] < 2 && feat_cache[idx] != nullptr) {
                     // cache last frame of last two chunk
                     cache_x = ggml_concat(ctx,
                                           ggml_slice(ctx, feat_cache[idx], 2, -1, feat_cache[idx]->ne[2]),
@@ -843,7 +843,7 @@ namespace WAN {
             if (feat_cache.size() > 0) {
                 int idx      = feat_idx;
                 auto cache_x = ggml_slice(ctx, x, 2, -CACHE_T, x->ne[2]);
-                if (cache_x->ne[2] < 2 && feat_cache[idx] != NULL) {
+                if (cache_x->ne[2] < 2 && feat_cache[idx] != nullptr) {
                     // cache last frame of last two chunk
                     cache_x = ggml_concat(ctx,
                                           ggml_slice(ctx, feat_cache[idx], 2, -1, feat_cache[idx]->ne[2]),
@@ -895,7 +895,7 @@ namespace WAN {
             if (feat_cache.size() > 0) {
                 int idx      = feat_idx;
                 auto cache_x = ggml_slice(ctx, x, 2, -CACHE_T, x->ne[2]);
-                if (cache_x->ne[2] < 2 && feat_cache[idx] != NULL) {
+                if (cache_x->ne[2] < 2 && feat_cache[idx] != nullptr) {
                     // cache last frame of last two chunk
                     cache_x = ggml_concat(ctx,
                                           ggml_slice(ctx, feat_cache[idx], 2, -1, feat_cache[idx]->ne[2]),
@@ -935,9 +935,9 @@ namespace WAN {
 
         void clear_cache() {
             _conv_idx     = 0;
-            _feat_map     = std::vector<struct ggml_tensor*>(_conv_num, NULL);
+            _feat_map     = std::vector<struct ggml_tensor*>(_conv_num, nullptr);
             _enc_conv_idx = 0;
-            _enc_feat_map = std::vector<struct ggml_tensor*>(_enc_conv_num, NULL);
+            _enc_feat_map = std::vector<struct ggml_tensor*>(_enc_conv_num, nullptr);
         }
 
     public:
@@ -1152,7 +1152,7 @@ namespace WAN {
 
             for (int64_t feat_idx = 0; feat_idx < ae._feat_map.size(); feat_idx++) {
                 ggml_tensor* feat_cache = ae._feat_map[feat_idx];
-                if (feat_cache != NULL) {
+                if (feat_cache != nullptr) {
                     cache("feat_idx:" + std::to_string(feat_idx), feat_cache);
                     ggml_build_forward_expand(gf, feat_cache);
                 }
@@ -1167,7 +1167,7 @@ namespace WAN {
                      struct ggml_tensor* z,
                      bool decode_graph,
                      struct ggml_tensor** output,
-                     struct ggml_context* output_ctx = NULL) {
+                     struct ggml_context* output_ctx = nullptr) {
             if (true) {
                 auto get_graph = [&]() -> struct ggml_cgraph* {
                     return build_graph(z, decode_graph);
@@ -1180,7 +1180,7 @@ namespace WAN {
                 auto get_graph = [&]() -> struct ggml_cgraph* {
                     return build_graph_partial(z, decode_graph, i);
                 };
-                struct ggml_tensor* out = NULL;
+                struct ggml_tensor* out = nullptr;
                 GGMLRunner::compute(get_graph, n_threads, true, &out, output_ctx);
                 ae.clear_cache();
                 if (t == 1) {
@@ -1220,11 +1220,11 @@ namespace WAN {
         void test() {
             struct ggml_init_params params;
             params.mem_size   = static_cast<size_t>(1000 * 1024 * 1024);  // 10 MB
-            params.mem_buffer = NULL;
+            params.mem_buffer = nullptr;
             params.no_alloc   = false;
 
             struct ggml_context* work_ctx = ggml_init(params);
-            GGML_ASSERT(work_ctx != NULL);
+            GGML_ASSERT(work_ctx != nullptr);
 
             if (true) {
                 // cpu f32, pass
@@ -1235,7 +1235,7 @@ namespace WAN {
                 ggml_set_f32(z, 0.5f);
                 z = load_tensor_from_file(work_ctx, "wan_vae_z.bin");
                 print_ggml_tensor(z);
-                struct ggml_tensor* out = NULL;
+                struct ggml_tensor* out = nullptr;
 
                 int64_t t0 = ggml_time_ms();
                 compute(8, z, true, &out, work_ctx);
@@ -1308,7 +1308,7 @@ namespace WAN {
         virtual struct ggml_tensor* forward(struct ggml_context* ctx,
                                             struct ggml_tensor* x,
                                             struct ggml_tensor* pe,
-                                            struct ggml_tensor* mask = NULL) {
+                                            struct ggml_tensor* mask = nullptr) {
             // x: [N, n_token, dim]
             // pe: [n_token, d_head/2, 2, 2]
             // return [N, n_token, dim]
@@ -1385,7 +1385,7 @@ namespace WAN {
             k      = norm_k->forward(ctx, k);
             auto v = v_proj->forward(ctx, context);  // [N, n_context, dim]
 
-            x = ggml_nn_attention_ext(ctx, q, k, v, num_heads, NULL, false, false, flash_attn);  // [N, n_token, dim]
+            x = ggml_nn_attention_ext(ctx, q, k, v, num_heads, nullptr, false, false, flash_attn);  // [N, n_token, dim]
 
             x = o_proj->forward(ctx, x);  // [N, n_token, dim]
             return x;
@@ -1451,8 +1451,8 @@ namespace WAN {
             k_img      = norm_k_img->forward(ctx, k_img);
             auto v_img = v_img_proj->forward(ctx, context_img);  // [N, context_img_len, dim]
 
-            auto img_x = ggml_nn_attention_ext(ctx, q, k_img, v_img, num_heads, NULL, false, false, flash_attn);  // [N, n_token, dim]
-            x          = ggml_nn_attention_ext(ctx, q, k, v, num_heads, NULL, false, false, flash_attn);          // [N, n_token, dim]
+            auto img_x = ggml_nn_attention_ext(ctx, q, k_img, v_img, num_heads, nullptr, false, false, flash_attn);  // [N, n_token, dim]
+            x          = ggml_nn_attention_ext(ctx, q, k, v, num_heads, nullptr, false, false, flash_attn);          // [N, n_token, dim]
 
             x = ggml_add(ctx, x, img_x);
 
@@ -1789,7 +1789,7 @@ namespace WAN {
                                          struct ggml_tensor* timestep,
                                          struct ggml_tensor* context,
                                          struct ggml_tensor* pe,
-                                         struct ggml_tensor* clip_fea = NULL,
+                                         struct ggml_tensor* clip_fea = nullptr,
                                          int64_t N                    = 1) {
             // x: [N*C, T, H, W], C => in_dim
             // timestep: [N,] or [T]
@@ -1830,7 +1830,7 @@ namespace WAN {
             context = text_embedding_2->forward(ctx, context);  // [N, context_txt_len, dim]
 
             int64_t context_img_len = 0;
-            if (clip_fea != NULL) {
+            if (clip_fea != nullptr) {
                 if (params.model_type == "i2v") {
                     auto img_emb     = std::dynamic_pointer_cast<MLPProj>(blocks["img_emb"]);
                     auto context_img = img_emb->forward(ctx, clip_fea);            // [N, context_img_len, dim]
@@ -1855,8 +1855,8 @@ namespace WAN {
                                     struct ggml_tensor* timestep,
                                     struct ggml_tensor* context,
                                     struct ggml_tensor* pe,
-                                    struct ggml_tensor* clip_fea        = NULL,
-                                    struct ggml_tensor* time_dim_concat = NULL,
+                                    struct ggml_tensor* clip_fea        = nullptr,
+                                    struct ggml_tensor* time_dim_concat = nullptr,
                                     int64_t N                           = 1) {
             // Forward pass of DiT.
             // x: [N*C, T, H, W]
@@ -1879,7 +1879,7 @@ namespace WAN {
             int64_t h_len = ((H + (std::get<1>(params.patch_size) / 2)) / std::get<1>(params.patch_size));
             int64_t w_len = ((W + (std::get<2>(params.patch_size) / 2)) / std::get<2>(params.patch_size));
 
-            if (time_dim_concat != NULL) {
+            if (time_dim_concat != nullptr) {
                 time_dim_concat = pad_to_patch_size(ctx, time_dim_concat);
                 x               = ggml_concat(ctx, x, time_dim_concat, 2);  // [N*C, (T+pad_t) + (T2+pad_t2), H + pad_h, W + pad_w]
                 t_len           = ((x->ne[2] + (std::get<0>(params.patch_size) / 2)) / std::get<0>(params.patch_size));
@@ -2006,9 +2006,9 @@ namespace WAN {
         struct ggml_cgraph* build_graph(struct ggml_tensor* x,
                                         struct ggml_tensor* timesteps,
                                         struct ggml_tensor* context,
-                                        struct ggml_tensor* clip_fea        = NULL,
-                                        struct ggml_tensor* c_concat        = NULL,
-                                        struct ggml_tensor* time_dim_concat = NULL) {
+                                        struct ggml_tensor* clip_fea        = nullptr,
+                                        struct ggml_tensor* c_concat        = nullptr,
+                                        struct ggml_tensor* time_dim_concat = nullptr) {
             struct ggml_cgraph* gf = ggml_new_graph_custom(compute_ctx, WAN_GRAPH_SIZE, false);
 
             x               = to_backend(x);
@@ -2032,10 +2032,10 @@ namespace WAN {
             auto pe = ggml_new_tensor_4d(compute_ctx, GGML_TYPE_F32, 2, 2, wan_params.axes_dim_sum / 2, pos_len);
             // pe->data = pe_vec.data();
             // print_ggml_tensor(pe);
-            // pe->data = NULL;
+            // pe->data = nullptr;
             set_backend_tensor_data(pe, pe_vec.data());
 
-            if (c_concat != NULL) {
+            if (c_concat != nullptr) {
                 x = ggml_concat(compute_ctx, x, c_concat, 3);
             }
 
@@ -2056,11 +2056,11 @@ namespace WAN {
                      struct ggml_tensor* x,
                      struct ggml_tensor* timesteps,
                      struct ggml_tensor* context,
-                     struct ggml_tensor* clip_fea        = NULL,
-                     struct ggml_tensor* c_concat        = NULL,
-                     struct ggml_tensor* time_dim_concat = NULL,
-                     struct ggml_tensor** output         = NULL,
-                     struct ggml_context* output_ctx     = NULL) {
+                     struct ggml_tensor* clip_fea        = nullptr,
+                     struct ggml_tensor* c_concat        = nullptr,
+                     struct ggml_tensor* time_dim_concat = nullptr,
+                     struct ggml_tensor** output         = nullptr,
+                     struct ggml_context* output_ctx     = nullptr) {
             auto get_graph = [&]() -> struct ggml_cgraph* {
                 return build_graph(x, timesteps, context, clip_fea, c_concat, time_dim_concat);
             };
@@ -2071,11 +2071,11 @@ namespace WAN {
         void test() {
             struct ggml_init_params params;
             params.mem_size   = static_cast<size_t>(200 * 1024 * 1024);  // 200 MB
-            params.mem_buffer = NULL;
+            params.mem_buffer = nullptr;
             params.no_alloc   = false;
 
             struct ggml_context* work_ctx = ggml_init(params);
-            GGML_ASSERT(work_ctx != NULL);
+            GGML_ASSERT(work_ctx != nullptr);
 
             {
                 // cpu f16: pass
@@ -2097,10 +2097,10 @@ namespace WAN {
                 // auto clip_fea = load_tensor_from_file(work_ctx, "wan_dit_clip_fea.bin");
                 // print_ggml_tensor(clip_fea);
 
-                struct ggml_tensor* out = NULL;
+                struct ggml_tensor* out = nullptr;
 
                 int t0 = ggml_time_ms();
-                compute(8, x, timesteps, context, NULL, NULL, NULL, &out, work_ctx);
+                compute(8, x, timesteps, context, nullptr, nullptr, nullptr, &out, work_ctx);
                 int t1 = ggml_time_ms();
 
                 print_ggml_tensor(out);


### PR DESCRIPTION
Converted the usage of  `NULL` to use the new C++11 `nullptr` keyword. See Clang-Tidy reference https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-nullptr.html