### PR TITLE
Some headers from C library were deprecated in C++ and are no longer welcome in C++ codebases

### DIFF
--- a/examples/cli/avi_writer.h
+++ b/examples/cli/avi_writer.h
@@ -1,10 +1,10 @@
 #ifndef __AVI_WRITER_H__
 #define __AVI_WRITER_H__
 
-#include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include "stable-diffusion.h"
 

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -1,6 +1,6 @@
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
 #include <functional>
 #include <iostream>
 #include <map>

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -1,9 +1,9 @@
 #ifndef __GGML_EXTEND_HPP__
 #define __GGML_EXTEND_HPP__
 
-#include <assert.h>
-#include <inttypes.h>
-#include <stdarg.h>
+#include <cassert>
+#include <cinttypes>
+#include <cstdarg>
 #include <algorithm>
 #include <cstring>
 #include <fstream>

--- a/model.cpp
+++ b/model.cpp
@@ -1,4 +1,4 @@
-#include <stdarg.h>
+#include <cstdarg>
 #include <fstream>
 #include <regex>
 #include <set>

--- a/t5.hpp
+++ b/t5.hpp
@@ -1,7 +1,7 @@
 #ifndef __T5_HPP__
 #define __T5_HPP__
 
-#include <float.h>
+#include <cfloat>
 #include <limits>
 #include <map>
 #include <memory>

--- a/util.cpp
+++ b/util.cpp
@@ -1,5 +1,5 @@
 #include "util.h"
-#include <stdarg.h>
+#include <cstdarg>
 #include <algorithm>
 #include <cmath>
 #include <codecvt>


### PR DESCRIPTION
This PR replaces C standard library headers with their C++ alternatives. See Clang-Tidy reference https://clang.llvm.org/extra/clang-tidy/checks/modernize/deprecated-headers.html