### PR TITLE
Renaming the header guard to avoid ambiguity and potential conflicts with other codebases

### DIFF
--- a/clip.hpp
+++ b/clip.hpp
@@ -1,5 +1,5 @@
-#ifndef __CLIP_HPP__
-#define __CLIP_HPP__
+#ifndef SD_CLIP_HPP
+#define SD_CLIP_HPP
 
 #include "ggml_extend.hpp"
 #include "model.h"
@@ -959,4 +959,4 @@ struct CLIPTextModelRunner : public GGMLRunner {
     }
 };
 
-#endif  // __CLIP_HPP__
+#endif  // SD_CLIP_HPP

--- a/common.hpp
+++ b/common.hpp
@@ -1,5 +1,5 @@
-#ifndef __COMMON_HPP__
-#define __COMMON_HPP__
+#ifndef SD_COMMON_HPP
+#define SD_COMMON_HPP
 
 #include "ggml_extend.hpp"
 
@@ -520,4 +520,4 @@ public:
     }
 };
 
-#endif  // __COMMON_HPP__
+#endif  // SD_COMMON_HPP

--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -1,5 +1,5 @@
-#ifndef __CONDITIONER_HPP__
-#define __CONDITIONER_HPP__
+#ifndef SD_CONDITIONER_HPP
+#define SD_CONDITIONER_HPP
 
 #include "clip.hpp"
 #include "t5.hpp"
@@ -1437,4 +1437,4 @@ struct T5CLIPEmbedder : public Conditioner {
     }
 };
 
-#endif
+#endif  // SD_CONDITIONER_HPP

--- a/control.hpp
+++ b/control.hpp
@@ -1,5 +1,5 @@
-#ifndef __CONTROL_HPP__
-#define __CONTROL_HPP__
+#ifndef SD_CONTROL_HPP
+#define SD_CONTROL_HPP
 
 #include "common.hpp"
 #include "ggml_extend.hpp"
@@ -467,4 +467,4 @@ struct ControlNet : public GGMLRunner {
     }
 };
 
-#endif  // __CONTROL_HPP__
+#endif  // SD_CONTROL_HPP

--- a/denoiser.hpp
+++ b/denoiser.hpp
@@ -1,5 +1,5 @@
-#ifndef __DENOISER_HPP__
-#define __DENOISER_HPP__
+#ifndef SD_DENOISER_HPP
+#define SD_DENOISER_HPP
 
 #include "ggml_extend.hpp"
 #include "gits_noise.inl"
@@ -1401,4 +1401,4 @@ static void sample_k_diffusion(sample_method_t method,
     }
 }
 
-#endif  // __DENOISER_HPP__
+#endif  // SD_DENOISER_HPP

--- a/diffusion_model.hpp
+++ b/diffusion_model.hpp
@@ -1,5 +1,5 @@
-#ifndef __DIFFUSION_MODEL_H__
-#define __DIFFUSION_MODEL_H__
+#ifndef SD_DIFFUSION_MODEL_HPP
+#define SD_DIFFUSION_MODEL_HPP
 
 #include "flux.hpp"
 #include "mmdit.hpp"
@@ -260,4 +260,4 @@ struct WanModel : public DiffusionModel {
     }
 };
 
-#endif
+#endif  // SD_DIFFUSION_MODEL_HPP

--- a/esrgan.hpp
+++ b/esrgan.hpp
@@ -1,5 +1,5 @@
-#ifndef __ESRGAN_HPP__
-#define __ESRGAN_HPP__
+#ifndef SD_ESRGAN_HPP
+#define SD_ESRGAN_HPP
 
 #include "ggml_extend.hpp"
 #include "model.h"
@@ -207,4 +207,4 @@ struct ESRGAN : public GGMLRunner {
     }
 };
 
-#endif  // __ESRGAN_HPP__
+#endif  // SD_ESRGAN_HPP

--- a/examples/cli/avi_writer.h
+++ b/examples/cli/avi_writer.h
@@ -1,5 +1,5 @@
-#ifndef __AVI_WRITER_H__
-#define __AVI_WRITER_H__
+#ifndef SD_AVI_WRITER_H
+#define SD_AVI_WRITER_H
 
 #include <stdint.h>
 #include <stdio.h>
@@ -214,4 +214,4 @@ int create_mjpg_avi_from_sd_images(const char* filename, sd_image_t* images, int
     return 0;
 }
 
-#endif  // __AVI_WRITER_H__
+#endif  // SD_AVI_WRITER_H

--- a/flux.hpp
+++ b/flux.hpp
@@ -1,5 +1,5 @@
-#ifndef __FLUX_HPP__
-#define __FLUX_HPP__
+#ifndef SD_FLUX_HPP
+#define SD_FLUX_HPP
 
 #include <vector>
 
@@ -1115,4 +1115,4 @@ namespace Flux {
 
 }  // namespace Flux
 
-#endif  // __FLUX_HPP__
+#endif  // SD_FLUX_HPP

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -1,5 +1,5 @@
-#ifndef __GGML_EXTEND_HPP__
-#define __GGML_EXTEND_HPP__
+#ifndef SD_GGML_EXTEND_HPP
+#define SD_GGML_EXTEND_HPP
 
 #include <assert.h>
 #include <inttypes.h>
@@ -2181,4 +2181,4 @@ public:
     }
 };
 
-#endif  // __GGML_EXTEND__HPP__
+#endif  // SD_GGML_EXTEND_HPP

--- a/gguf_reader.hpp
+++ b/gguf_reader.hpp
@@ -1,5 +1,5 @@
-#ifndef __GGUF_READER_HPP__
-#define __GGUF_READER_HPP__
+#ifndef SD_GGUF_READER_HPP
+#define SD_GGUF_READER_HPP
 
 #include <cstdint>
 #include <fstream>
@@ -228,4 +228,4 @@ public:
     size_t data_offset() const { return data_offset_; }
 };
 
-#endif  // __GGUF_READER_HPP__
+#endif  // SD_GGUF_READER_HPP

--- a/lora.hpp
+++ b/lora.hpp
@@ -1,5 +1,5 @@
-#ifndef __LORA_HPP__
-#define __LORA_HPP__
+#ifndef SD_LORA_HPP
+#define SD_LORA_HPP
 
 #include "ggml_extend.hpp"
 
@@ -880,4 +880,4 @@ struct LoraModel : public GGMLRunner {
     }
 };
 
-#endif  // __LORA_HPP__
+#endif  // SD_LORA_HPP

--- a/ltxv.hpp
+++ b/ltxv.hpp
@@ -1,5 +1,5 @@
-#ifndef __LTXV_HPP__
-#define __LTXV_HPP__
+#ifndef SD_LTXV_HPP
+#define SD_LTXV_HPP
 
 #include "common.hpp"
 #include "ggml_extend.hpp"
@@ -71,4 +71,4 @@ namespace LTXV {
 
 };
 
-#endif
+#endif  // SD_LTXV_HPP

--- a/mmdit.hpp
+++ b/mmdit.hpp
@@ -1,5 +1,5 @@
-#ifndef __MMDIT_HPP__
-#define __MMDIT_HPP__
+#ifndef SD_MMDIT_HPP
+#define SD_MMDIT_HPP
 
 #include "ggml_extend.hpp"
 #include "model.h"
@@ -974,4 +974,4 @@ struct MMDiTRunner : public GGMLRunner {
     }
 };
 
-#endif
+#endif  // SD_MMDIT_HPP

--- a/model.h
+++ b/model.h
@@ -1,5 +1,5 @@
-#ifndef __MODEL_H__
-#define __MODEL_H__
+#ifndef SD_MODEL_H
+#define SD_MODEL_H
 
 #include <functional>
 #include <map>
@@ -261,4 +261,4 @@ public:
     static std::string load_umt5_tokenizer_json();
 };
 
-#endif  // __MODEL_H__
+#endif  // SD_MODEL_H

--- a/pmid.hpp
+++ b/pmid.hpp
@@ -1,5 +1,5 @@
-#ifndef __PMI_HPP__
-#define __PMI_HPP__
+#ifndef SD_PMI_HPP
+#define SD_PMI_HPP
 
 #include "ggml_extend.hpp"
 
@@ -849,4 +849,4 @@ struct PhotoMakerIDEmbed : public GGMLRunner {
     }
 };
 
-#endif  // __PMI_HPP__
+#endif  // SD_PMI_HPP

--- a/preprocessing.hpp
+++ b/preprocessing.hpp
@@ -1,5 +1,5 @@
-#ifndef __PREPROCESSING_HPP__
-#define __PREPROCESSING_HPP__
+#ifndef SD_PREPROCESSING_HPP
+#define SD_PREPROCESSING_HPP
 
 #include "ggml_extend.hpp"
 #define M_PI_ 3.14159265358979323846
@@ -224,4 +224,4 @@ uint8_t* preprocess_canny(uint8_t* img, int width, int height, float high_thresh
     return output;
 }
 
-#endif  // __PREPROCESSING_HPP__
+#endif  // SD_PREPROCESSING_HPP

--- a/rng.hpp
+++ b/rng.hpp
@@ -1,5 +1,5 @@
-#ifndef __RNG_H__
-#define __RNG_H__
+#ifndef SD_RNG_HPP
+#define SD_RNG_HPP
 
 #include <random>
 #include <vector>
@@ -32,4 +32,4 @@ public:
     }
 };
 
-#endif  // __RNG_H__
+#endif  // SD_RNG_HPP

--- a/rng_philox.hpp
+++ b/rng_philox.hpp
@@ -1,5 +1,5 @@
-#ifndef __RNG_PHILOX_H__
-#define __RNG_PHILOX_H__
+#ifndef SD_RNG_PHILOX_HPP
+#define SD_RNG_PHILOX_HPP
 
 #include <cmath>
 #include <vector>
@@ -122,4 +122,4 @@ public:
     }
 };
 
-#endif  // __RNG_PHILOX_H__
+#endif  // SD_RNG_PHILOX_HPP

--- a/rope.hpp
+++ b/rope.hpp
@@ -1,5 +1,5 @@
-#ifndef __ROPE_HPP__
-#define __ROPE_HPP__
+#ifndef SD_ROPE_HPP
+#define SD_ROPE_HPP
 
 #include <vector>
 #include "ggml_extend.hpp"
@@ -249,4 +249,4 @@ struct Rope {
     }
 };  // struct Rope
 
-#endif  // __ROPE_HPP__
+#endif  // SD_ROPE_HPP

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -1,5 +1,5 @@
-#ifndef __STABLE_DIFFUSION_H__
-#define __STABLE_DIFFUSION_H__
+#ifndef SD_STABLE_DIFFUSION_H
+#define SD_STABLE_DIFFUSION_H
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 #ifndef SD_BUILD_SHARED_LIB
@@ -278,4 +278,4 @@ SD_API uint8_t* preprocess_canny(uint8_t* img,
 }
 #endif
 
-#endif  // __STABLE_DIFFUSION_H__
+#endif  // SD_STABLE_DIFFUSION_H

--- a/t5.hpp
+++ b/t5.hpp
@@ -1,5 +1,5 @@
-#ifndef __T5_HPP__
-#define __T5_HPP__
+#ifndef SD_T5_HPP
+#define SD_T5_HPP
 
 #include <float.h>
 #include <limits>
@@ -1032,4 +1032,4 @@ struct T5Embedder {
     }
 };
 
-#endif  // __T5_HPP__
+#endif  // SD_T5_HPP

--- a/tae.hpp
+++ b/tae.hpp
@@ -1,5 +1,5 @@
-#ifndef __TAE_HPP__
-#define __TAE_HPP__
+#ifndef SD_TAE_HPP
+#define SD_TAE_HPP
 
 #include "ggml_extend.hpp"
 
@@ -270,4 +270,4 @@ struct TinyAutoEncoder : public GGMLRunner {
     }
 };
 
-#endif  // __TAE_HPP__
+#endif  // SD_TAE_HPP

--- a/unet.hpp
+++ b/unet.hpp
@@ -1,5 +1,5 @@
-#ifndef __UNET_HPP__
-#define __UNET_HPP__
+#ifndef SD_UNET_HPP
+#define SD_UNET_HPP
 
 #include "common.hpp"
 #include "ggml_extend.hpp"
@@ -671,4 +671,4 @@ struct UNetModelRunner : public GGMLRunner {
     }
 };
 
-#endif  // __UNET_HPP__
+#endif  // SD_UNET_HPP

--- a/util.h
+++ b/util.h
@@ -1,5 +1,5 @@
-#ifndef __UTIL_H__
-#define __UTIL_H__
+#ifndef SD_UTIL_H
+#define SD_UTIL_H
 
 #include <cstdint>
 #include <string>
@@ -63,4 +63,5 @@ std::vector<std::pair<std::string, float>> parse_prompt_attention(const std::str
 #define LOG_INFO(format, ...) log_printf(SD_LOG_INFO, __FILE__, __LINE__, format, ##__VA_ARGS__)
 #define LOG_WARN(format, ...) log_printf(SD_LOG_WARN, __FILE__, __LINE__, format, ##__VA_ARGS__)
 #define LOG_ERROR(format, ...) log_printf(SD_LOG_ERROR, __FILE__, __LINE__, format, ##__VA_ARGS__)
-#endif  // __UTIL_H__
+
+#endif  // SD_UTIL_H

--- a/vae.hpp
+++ b/vae.hpp
@@ -1,5 +1,5 @@
-#ifndef __VAE_HPP__
-#define __VAE_HPP__
+#ifndef SD_VAE_HPP
+#define SD_VAE_HPP
 
 #include "common.hpp"
 #include "ggml_extend.hpp"
@@ -638,4 +638,4 @@ struct AutoEncoderKL : public VAE {
     };
 };
 
-#endif
+#endif  // SD_VAE_HPP

--- a/wan.hpp
+++ b/wan.hpp
@@ -1,5 +1,5 @@
-#ifndef __WAN_HPP__
-#define __WAN_HPP__
+#ifndef SD_WAN_HPP
+#define SD_WAN_HPP
 
 #include <map>
 
@@ -2154,4 +2154,4 @@ namespace WAN {
 
 }  // namespace WAN
 
-#endif  // __WAN_HPP__
+#endif  // SD_WAN_HPP


### PR DESCRIPTION
Renaming header guard to `SD_xxx` to avoid conflicts. Clang-Tidy reference https://clang.llvm.org/extra/clang-tidy/checks/llvm/header-guard.html