### PR TITLE
fix: make tiled VAE reuse the compute buffer

### DIFF
--- a/vae.hpp
+++ b/vae.hpp
@@ -588,7 +588,7 @@ struct AutoEncoderKL : public VAE {
         };
         // ggml_set_f32(z, 0.5f);
         // print_ggml_tensor(z);
-        GGMLRunner::compute(get_graph, n_threads, true, output, output_ctx);
+        GGMLRunner::compute(get_graph, n_threads, false, output, output_ctx);
     }
 
     void test() {


### PR DESCRIPTION
The compute buffer was being freed and allocated again between each tile.

Note that both the encode and decode paths already call `free_compute_buffer()` explicitly right after the `compute()` calls.