### PR TITLE
fix: better progress display for second-order samplers

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1089,11 +1089,12 @@ public:
         }
         struct ggml_tensor* denoised = ggml_dup_tensor(work_ctx, x);
 
+        int64_t t0 = ggml_time_us();
+
         auto denoise = [&](ggml_tensor* input, float sigma, int step) -> ggml_tensor* {
-            if (step == 1) {
+            if (step == 1 || step == -1) {
                 pretty_progress(0, (int)steps, 0);
             }
-            int64_t t0 = ggml_time_us();
 
             std::vector<float> scaling = denoiser->get_scalings(sigma);
             GGML_ASSERT(scaling.size() == 3);
@@ -1223,8 +1224,9 @@ public:
                 vec_denoised[i] = latent_result * c_out + vec_input[i] * c_skip;
             }
             int64_t t1 = ggml_time_us();
-            if (step > 0) {
-                pretty_progress(step, (int)steps, (t1 - t0) / 1000000.f);
+            if (step != 0) {
+                int showstep = std::abs(step);
+                pretty_progress(showstep, (int)steps, (t1 - t0) / 1000000.f / showstep);
                 // LOG_INFO("step %d sampling completed taking %.2fs", step, (t1 - t0) * 1.0f / 1000000);
             }
             if (denoise_mask != nullptr) {


### PR DESCRIPTION
Second-order samplers call the model twice per step, except for the last iteration. Since the progress is updated only for each second call, the last step is never shown.

The timing information is also misleading, since it's displaying the number of full steps, but measuring only the last half. Comparing to a first-order sampler, the progress shows the same timing for each iteration, and the same number of steps, but takes almost twice as long.

So, change the display to show average time per step, which should give a better idea of the expected time until completion, and update the progress display after all model calls.