### PR TITLE
fix: avoid crash on multithreaded model conversion

### DIFF
--- a/model.cpp
+++ b/model.cpp
@@ -2427,7 +2427,12 @@ bool ModelLoader::save_to_gguf_file(const std::string& file_path, ggml_type type
 
     auto tensor_type_rules = parse_tensor_type_rules(tensor_type_rules_str);
 
+    std::mutex mux_conversion;
+
     auto on_new_tensor_cb = [&](const TensorStorage& tensor_storage, ggml_tensor** dst_tensor) -> bool {
+
+        std::lock_guard<std::mutex> lock(mux_conversion);
+
         const std::string& name = tensor_storage.name;
         ggml_type tensor_type   = tensor_storage.type;
         ggml_type dst_type      = type;


### PR DESCRIPTION
Since 55c2e05d98752fa7236c18a7352ec421f5e345ab / #790  , model conversion easily crashes, unless `--threads 1` is used.

This mutex _seems_ to fix the issue for me, but I didn't look for other possible race conditions.

