### PR TITLE
Fix dockerfile libgomp1 dependency + improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,7 @@ ARG UBUNTU_VERSION=22.04
 
 FROM ubuntu:$UBUNTU_VERSION AS build
 
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends build-essential git cmake && \
-    apt-get clean
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git cmake
 
 WORKDIR /sd.cpp
 


### PR DESCRIPTION
Fixes an issue with stable-diffusion needing `libgomp.so.1` but not present during runtime.

```
/sd: error while loading shared libraries: libgomp.so.1: cannot open shared object file: No such file or directory
```

- Introduces cmake parallel build
- No install recommends for the build stage to prevent any extra packages from being installed in the build stage

Build time (on my machine, no caching) `docker build --no-cache -t sd .`:
- Without improvements: **96.0s**
- With improvements: **59.4s**