### PR TITLE
add support for Qwen Image Pruning

### DIFF
--- a/qwen_image.hpp
+++ b/qwen_image.hpp
@@ -492,6 +492,22 @@ namespace Qwen {
                         bool flash_attn                     = false)
             : GGMLRunner(backend, offload_params_to_cpu) {
             qwen_image_params.flash_attn = flash_attn;
+
+            int model_layers = 60;
+            int num_layers = 1;
+            for (int layer = model_layers; layer > num_layers; layer--) {
+                for (auto pair : tensor_types) {
+                    if (pair.first.find("model.diffusion_model.transformer_blocks." + std::to_string(layer-1) + ".attn.add_k_proj.bias") != std::string::npos) {
+                        num_layers = layer;
+                        break;
+                    }
+                }
+            }
+            if (num_layers < model_layers) {
+                LOG_INFO("Qwen Image: some layers missing, assuming pruned model");
+            }
+
+            qwen_image_params.num_layers = num_layers;
             qwen_image                   = QwenImageModel(qwen_image_params);
             qwen_image.init(params_ctx, tensor_types, prefix);
         }


### PR DESCRIPTION
For #851 . Allow the model loading logic to tolerate missing layers, which is enough to run the 12B Pruning variant:

https://huggingface.co/OPPOer/Qwen-Image-Pruning

Tested with the Q4_K_M quant from https://huggingface.co/wsbagnsv1/Qwen-Image-Pruning-GGUF :

<img width="192" height="192" alt="teste_1759693079" src="https://github.com/user-attachments/assets/bdaed587-29f9-4f51-a303-9161fd01c776" />

