### PR TITLE
feat: in-place SDXL VAE conv scaling

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -984,7 +984,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_conv_2d(struct ggml_context* ctx,
                                                       bool direct = false,
                                                       float scale = 1.f) {
     if (scale != 1.f) {
-        x = ggml_scale(ctx, x, scale);
+        x = ggml_scale_inplace(ctx, x, scale);
     }
     if (direct) {
         x = ggml_conv_2d_direct(ctx, w, x, s0, s1, p0, p1, d0, d1);
@@ -992,7 +992,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_nn_conv_2d(struct ggml_context* ctx,
         x = ggml_conv_2d(ctx, w, x, s0, s1, p0, p1, d0, d1);
     }
     if (scale != 1.f) {
-        x = ggml_scale(ctx, x, 1.f / scale);
+        x = ggml_scale_inplace(ctx, x, 1.f / scale);
     }
     if (b != NULL) {
         b = ggml_reshape_4d(ctx, b, 1, 1, b->ne[0], 1);


### PR DESCRIPTION
No idea if this is really OK, since the resulting images look a little bit different in details, and the memory savings look surprisingly high, but this is for a 1024x1024 image, no `vae-conv-direct`:

before:
```
[INFO ] stable-diffusion.cpp:2386 - decoding 1 latents
[DEBUG] ggml_extend.hpp:1579 - vae compute buffer size: 7680.25 MB(VRAM)
[DEBUG] stable-diffusion.cpp:1677 - computing vae decode graph completed, taking 5.98s
[INFO ] stable-diffusion.cpp:2396 - latent 1 decoded, taking 5.98s
[INFO ] stable-diffusion.cpp:2400 - decode_first_stage completed, taking 5.98s
```

after:
```
[INFO ] stable-diffusion.cpp:2386 - decoding 1 latents
[DEBUG] ggml_extend.hpp:1579 - vae compute buffer size: 6656.25 MB(VRAM)
[DEBUG] stable-diffusion.cpp:1677 - computing vae decode graph completed, taking 5.99s
[INFO ] stable-diffusion.cpp:2396 - latent 1 decoded, taking 6.00s
[INFO ] stable-diffusion.cpp:2400 - decode_first_stage completed, taking 6.00s
```
