### PR TITLE
Feature add DyPE support (experimental)

### DIFF
--- a/flux.hpp
+++ b/flux.hpp
@@ -1276,19 +1276,27 @@ namespace Flux {
                 ref_latents[i] = to_backend(ref_latents[i]);
             }
 
-            // get use_yarn and use_dype from env for now (TODO: add args)
-            bool use_yarn      = false;
-            bool use_dype      = false;
-            char* use_yarn_env = getenv("USE_YARN");
-            if (use_yarn_env != nullptr) {
-                if (strcmp(use_yarn_env, "OFF") != 0) {
+            // get use_yarn, use_ntk and use_dype from env for now (TODO: add args)
+            // Env value could be one of yarn, dy_yarn, ntk or dy_ntk, (anything else means disabled)
+            const char* env_value = getenv("FLUX_ROPE");
+            bool use_yarn = false;
+            bool use_dype = false;
+            bool use_ntk  = false; 
+            if (env_value != nullptr) {
+                if (strcmp(env_value, "YARN") == 0) {
+                    LOG_DEBUG("Using YARN RoPE");
                     use_yarn = true;
-                    char* use_dype_env = getenv("USE_DYPE");
-                    if (use_dype_env != nullptr) {
-                        if (strcmp(use_dype_env, "OFF") != 0) {
-                            use_dype = true;
-                        }
-                    }
+                } else if (strcmp(env_value, "DY_YARN") == 0) {
+                    LOG_DEBUG("Using DY YARN RoPE");
+                    use_yarn = true;
+                    use_dype = true;
+                } else if (strcmp(env_value, "NTK") == 0) {
+                    LOG_DEBUG("Using NTK RoPE");
+                    use_ntk = true;
+                } else if (strcmp(env_value, "DY_NTK") == 0) {
+                    LOG_DEBUG("Using DY NTK RoPE");
+                    use_ntk  = true;
+                    use_dype = true;
                 }
             }
 
@@ -1303,6 +1311,7 @@ namespace Flux {
                                             flux_params.axes_dim,
                                             use_yarn,
                                             use_dype,
+                                            use_ntk,
                                             current_timestep);
             int pos_len = pe_vec.size() / flux_params.axes_dim_sum / 2;
             // LOG_DEBUG("pos_len %d", pos_len);


### PR DESCRIPTION
https://github.com/guyyariv/DyPE/tree/master

Flux only for now, I don't have enough VRAM to test it at very high resolutions (seems to be working at 1536x1536 resolution, but it should be tested at up to 4096x4096 to be completely sure it's working as intended) 

Use env vraiables to enable it:
- `FLUX_ROPE` = `DY_YARN`, `DY_NTK`, `YARN`, or `NTK` (any other value will use standard RoPE)
- `FLUX_DYPE_BASE_RESOLUTION` (defaults to `1024` which should be best for base Flux, ~~maybe use `512` for Chroma? (untested yet)~~ `768` seems to work for Chroma, for some reason `512` didn't perform well at all in my testing, maybe use `1024` too) 

Example:

`.\build\bin\sd.exe --diffusion-model  ..\ComfyUI\models\unet\Flux\dev\flux1-dev-Q3_k.gguf --t5xxl ..\ComfyUI\models\clip\t5\t5xxl_q8_0.gguf  --clip_l ..\ComfyUI\models\clip\clip_l\clip_l.safetensors --vae ..\ComfyUI\models\vae\flux\ae.safetensors  -p "a lovely cat holding a sign says 'Flux cpp'" --cfg-scale 1 --sampling-method euler  -W 1536 -H 1536 --vae-tiling --vae-tile-size 64`
 
 (base resolution 1024) 
| default RoPE | DY_YARN | DY_NTK | YARN | NTK |
| --- | --- | --- | --- | --- |
|<img width="1536" height="1536" alt="output" src="https://github.com/user-attachments/assets/bca3f980-f3bb-433f-8a48-da2fff385b55" /> | <img width="1536" height="1536" alt="output" src="https://github.com/user-attachments/assets/6f91ca46-c5af-4507-b96c-fa5d82cc785d" /> | <img width="1536" height="1536" alt="output" src="https://github.com/user-attachments/assets/979b8a6f-dba0-484b-b2ba-3134a81b4730" /> | <img width="1536" height="1536" alt="output" src="https://github.com/user-attachments/assets/b88509c0-d0af-490a-a316-8c3a1a5d8214" /> | <img width="1536" height="1536" alt="output" src="https://github.com/user-attachments/assets/38643c5e-9aa4-4392-b6c8-df6954a6e3f1" /> |