### PR TITLE
refactor: optimize the logic for name conversion and the processing of the LoRA model

### DIFF
--- a/conditioner.hpp
+++ b/conditioner.hpp
@@ -111,7 +111,7 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
     bool load_embedding(std::string embd_name, std::string embd_path, std::vector<int32_t>& bpe_tokens) {
         // the order matters
         ModelLoader model_loader;
-        if (!model_loader.init_from_file(embd_path)) {
+        if (!model_loader.init_from_file_and_convert_name(embd_path)) {
             LOG_ERROR("embedding '%s' failed", embd_name.c_str());
             return false;
         }

--- a/control.hpp
+++ b/control.hpp
@@ -442,7 +442,7 @@ struct ControlNet : public GGMLRunner {
         std::set<std::string> ignore_tensors;
 
         ModelLoader model_loader;
-        if (!model_loader.init_from_file(file_path)) {
+        if (!model_loader.init_from_file_and_convert_name(file_path)) {
             LOG_ERROR("init control net model loader from file failed: '%s'", file_path.c_str());
             return false;
         }

--- a/esrgan.hpp
+++ b/esrgan.hpp
@@ -169,7 +169,7 @@ struct ESRGAN : public GGMLRunner {
         LOG_INFO("loading esrgan from '%s'", file_path.c_str());
 
         ModelLoader model_loader;
-        if (!model_loader.init_from_file(file_path)) {
+        if (!model_loader.init_from_file_and_convert_name(file_path)) {
             LOG_ERROR("init esrgan model loader from file failed: '%s'", file_path.c_str());
             return false;
         }

--- a/flux.hpp
+++ b/flux.hpp
@@ -1398,7 +1398,7 @@ namespace Flux {
             ggml_type model_data_type = GGML_TYPE_Q8_0;
 
             ModelLoader model_loader;
-            if (!model_loader.init_from_file(file_path, "model.diffusion_model.")) {
+            if (!model_loader.init_from_file_and_convert_name(file_path, "model.diffusion_model.")) {
                 LOG_ERROR("init model loader from file failed: '%s'", file_path.c_str());
                 return;
             }

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -1568,8 +1568,10 @@ protected:
     struct ggml_cgraph* get_compute_graph(get_graph_cb_t get_graph) {
         prepare_build_in_tensor_before();
         struct ggml_cgraph* gf = get_graph();
-        auto result            = ggml_graph_node(gf, -1);
-        ggml_set_name(result, final_result_name.c_str());
+        if (ggml_graph_n_nodes(gf) > 0) {
+            auto result = ggml_graph_node(gf, -1);
+            ggml_set_name(result, final_result_name.c_str());
+        }
         prepare_build_in_tensor_after(gf);
         return gf;
     }

--- a/mmdit.hpp
+++ b/mmdit.hpp
@@ -961,7 +961,7 @@ struct MMDiTRunner : public GGMLRunner {
             mmdit->get_param_tensors(tensors, "model.diffusion_model");
 
             ModelLoader model_loader;
-            if (!model_loader.init_from_file(file_path)) {
+            if (!model_loader.init_from_file_and_convert_name(file_path)) {
                 LOG_ERROR("init model loader from file failed: '%s'", file_path.c_str());
                 return;
             }

--- a/model.cpp
+++ b/model.cpp
@@ -25,6 +25,7 @@
 #include "ggml-cpu.h"
 #include "ggml.h"
 
+#include "name_conversion.h"
 #include "stable-diffusion.h"
 
 #ifdef SD_USE_METAL
@@ -75,15 +76,6 @@ uint16_t read_short(uint8_t* buffer) {
 
 /*================================================= Preprocess ==================================================*/
 
-std::string self_attn_names[] = {
-    "self_attn.q_proj.weight",
-    "self_attn.k_proj.weight",
-    "self_attn.v_proj.weight",
-    "self_attn.q_proj.bias",
-    "self_attn.k_proj.bias",
-    "self_attn.v_proj.bias",
-};
-
 const char* unused_tensors[] = {
     "betas",
     "alphas_cumprod_prev",
@@ -97,9 +89,9 @@ const char* unused_tensors[] = {
     "posterior_mean_coef1",
     "posterior_mean_coef2",
     "cond_stage_model.transformer.text_model.embeddings.position_ids",
+    "cond_stage_model.1.model.text_model.embeddings.position_ids",
     "cond_stage_model.transformer.vision_model.embeddings.position_ids",
     "cond_stage_model.model.logit_scale",
-    "cond_stage_model.model.text_projection",
     "conditioner.embedders.0.transformer.text_model.embeddings.position_ids",
     "conditioner.embedders.0.model.logit_scale",
     "conditioner.embedders.1.model.logit_scale",
@@ -110,6 +102,7 @@ const char* unused_tensors[] = {
     "model_ema.diffusion_model",
     "embedding_manager",
     "denoiser.sigmas",
+    "edm_vpred.sigma_max",
     "text_encoders.t5xxl.transformer.encoder.embed_tokens.weight",  // only used during training
     "text_encoders.qwen2vl.output.weight",
     "text_encoders.qwen2vl.lm_head.",
@@ -122,622 +115,6 @@ bool is_unused_tensor(std::string name) {
         }
     }
     return false;
-}
-
-std::unordered_map<std::string, std::string> open_clip_to_hf_clip_model = {
-    {"model.ln_final.bias", "transformer.text_model.final_layer_norm.bias"},
-    {"model.ln_final.weight", "transformer.text_model.final_layer_norm.weight"},
-    {"model.positional_embedding", "transformer.text_model.embeddings.position_embedding.weight"},
-    {"model.token_embedding.weight", "transformer.text_model.embeddings.token_embedding.weight"},
-    {"model.text_projection", "transformer.text_model.text_projection"},
-    {"model.visual.class_embedding", "transformer.vision_model.embeddings.class_embedding"},
-    {"model.visual.conv1.weight", "transformer.vision_model.embeddings.patch_embedding.weight"},
-    {"model.visual.ln_post.bias", "transformer.vision_model.post_layernorm.bias"},
-    {"model.visual.ln_post.weight", "transformer.vision_model.post_layernorm.weight"},
-    {"model.visual.ln_pre.bias", "transformer.vision_model.pre_layernorm.bias"},
-    {"model.visual.ln_pre.weight", "transformer.vision_model.pre_layernorm.weight"},
-    {"model.visual.positional_embedding", "transformer.vision_model.embeddings.position_embedding.weight"},
-    {"model.visual.proj", "transformer.visual_projection.weight"},
-};
-
-std::unordered_map<std::string, std::string> open_clip_to_hf_clip_resblock = {
-    {"attn.in_proj_bias", "self_attn.in_proj.bias"},
-    {"attn.in_proj_weight", "self_attn.in_proj.weight"},
-    {"attn.out_proj.bias", "self_attn.out_proj.bias"},
-    {"attn.out_proj.weight", "self_attn.out_proj.weight"},
-    {"ln_1.bias", "layer_norm1.bias"},
-    {"ln_1.weight", "layer_norm1.weight"},
-    {"ln_2.bias", "layer_norm2.bias"},
-    {"ln_2.weight", "layer_norm2.weight"},
-    {"mlp.c_fc.bias", "mlp.fc1.bias"},
-    {"mlp.c_fc.weight", "mlp.fc1.weight"},
-    {"mlp.c_proj.bias", "mlp.fc2.bias"},
-    {"mlp.c_proj.weight", "mlp.fc2.weight"},
-};
-
-std::unordered_map<std::string, std::string> cond_model_name_map = {
-    {"transformer.vision_model.pre_layrnorm.weight", "transformer.vision_model.pre_layernorm.weight"},
-    {"transformer.vision_model.pre_layrnorm.bias", "transformer.vision_model.pre_layernorm.bias"},
-};
-
-std::unordered_map<std::string, std::string> vae_decoder_name_map = {
-    {"first_stage_model.decoder.mid.attn_1.to_k.bias", "first_stage_model.decoder.mid.attn_1.k.bias"},
-    {"first_stage_model.decoder.mid.attn_1.to_k.weight", "first_stage_model.decoder.mid.attn_1.k.weight"},
-    {"first_stage_model.decoder.mid.attn_1.to_out.0.bias", "first_stage_model.decoder.mid.attn_1.proj_out.bias"},
-    {"first_stage_model.decoder.mid.attn_1.to_out.0.weight", "first_stage_model.decoder.mid.attn_1.proj_out.weight"},
-    {"first_stage_model.decoder.mid.attn_1.to_q.bias", "first_stage_model.decoder.mid.attn_1.q.bias"},
-    {"first_stage_model.decoder.mid.attn_1.to_q.weight", "first_stage_model.decoder.mid.attn_1.q.weight"},
-    {"first_stage_model.decoder.mid.attn_1.to_v.bias", "first_stage_model.decoder.mid.attn_1.v.bias"},
-    {"first_stage_model.decoder.mid.attn_1.to_v.weight", "first_stage_model.decoder.mid.attn_1.v.weight"},
-};
-
-std::unordered_map<std::string, std::string> pmid_v2_name_map = {
-    {"pmid.qformer_perceiver.perceiver_resampler.layers.0.1.1.weight",
-     "pmid.qformer_perceiver.perceiver_resampler.layers.0.1.1.fc1.weight"},
-    {"pmid.qformer_perceiver.perceiver_resampler.layers.0.1.3.weight",
-     "pmid.qformer_perceiver.perceiver_resampler.layers.0.1.1.fc2.weight"},
-    {"pmid.qformer_perceiver.perceiver_resampler.layers.1.1.1.weight",
-     "pmid.qformer_perceiver.perceiver_resampler.layers.1.1.1.fc1.weight"},
-    {"pmid.qformer_perceiver.perceiver_resampler.layers.1.1.3.weight",
-     "pmid.qformer_perceiver.perceiver_resampler.layers.1.1.1.fc2.weight"},
-    {"pmid.qformer_perceiver.perceiver_resampler.layers.2.1.1.weight",
-     "pmid.qformer_perceiver.perceiver_resampler.layers.2.1.1.fc1.weight"},
-    {"pmid.qformer_perceiver.perceiver_resampler.layers.2.1.3.weight",
-     "pmid.qformer_perceiver.perceiver_resampler.layers.2.1.1.fc2.weight"},
-    {"pmid.qformer_perceiver.perceiver_resampler.layers.3.1.1.weight",
-     "pmid.qformer_perceiver.perceiver_resampler.layers.3.1.1.fc1.weight"},
-    {"pmid.qformer_perceiver.perceiver_resampler.layers.3.1.3.weight",
-     "pmid.qformer_perceiver.perceiver_resampler.layers.3.1.1.fc2.weight"},
-    {"pmid.qformer_perceiver.token_proj.0.bias",
-     "pmid.qformer_perceiver.token_proj.fc1.bias"},
-    {"pmid.qformer_perceiver.token_proj.2.bias",
-     "pmid.qformer_perceiver.token_proj.fc2.bias"},
-    {"pmid.qformer_perceiver.token_proj.0.weight",
-     "pmid.qformer_perceiver.token_proj.fc1.weight"},
-    {"pmid.qformer_perceiver.token_proj.2.weight",
-     "pmid.qformer_perceiver.token_proj.fc2.weight"},
-};
-
-std::unordered_map<std::string, std::string> qwenvl_name_map{
-    {"token_embd.", "model.embed_tokens."},
-    {"blk.", "model.layers."},
-    {"attn_q.", "self_attn.q_proj."},
-    {"attn_k.", "self_attn.k_proj."},
-    {"attn_v.", "self_attn.v_proj."},
-    {"attn_output.", "self_attn.o_proj."},
-    {"attn_norm.", "input_layernorm."},
-    {"ffn_down.", "mlp.down_proj."},
-    {"ffn_gate.", "mlp.gate_proj."},
-    {"ffn_up.", "mlp.up_proj."},
-    {"ffn_norm.", "post_attention_layernorm."},
-    {"output_norm.", "model.norm."},
-};
-
-std::unordered_map<std::string, std::string> qwenvl_vision_name_map{
-    {"mm.", "merger.mlp."},
-    {"v.post_ln.", "merger.ln_q."},
-    {"v.patch_embd.weight", "patch_embed.proj.0.weight"},
-    {"patch_embed.proj.0.weight.1", "patch_embed.proj.1.weight"},
-    {"v.patch_embd.weight.1", "patch_embed.proj.1.weight"},
-    {"v.blk.", "blocks."},
-    {"attn_q.", "attn.q_proj."},
-    {"attn_k.", "attn.k_proj."},
-    {"attn_v.", "attn.v_proj."},
-    {"attn_out.", "attn.proj."},
-    {"ffn_down.", "mlp.down_proj."},
-    {"ffn_gate.", "mlp.gate_proj."},
-    {"ffn_up.", "mlp.up_proj."},
-    {"ln1.", "norm1."},
-    {"ln2.", "norm2."},
-};
-
-std::string convert_cond_model_name(const std::string& name) {
-    std::string new_name = name;
-    std::string prefix;
-    if (contains(new_name, ".enc.")) {
-        // llama.cpp naming convention for T5
-        size_t pos = new_name.find(".enc.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 5, ".encoder.");
-        }
-        pos = new_name.find("blk.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 4, "block.");
-        }
-        pos = new_name.find("output_norm.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 12, "final_layer_norm.");
-        }
-        pos = new_name.find("attn_k.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 7, "layer.0.SelfAttention.k.");
-        }
-        pos = new_name.find("attn_v.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 7, "layer.0.SelfAttention.v.");
-        }
-        pos = new_name.find("attn_o.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 7, "layer.0.SelfAttention.o.");
-        }
-        pos = new_name.find("attn_q.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 7, "layer.0.SelfAttention.q.");
-        }
-        pos = new_name.find("attn_norm.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 10, "layer.0.layer_norm.");
-        }
-        pos = new_name.find("ffn_norm.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 9, "layer.1.layer_norm.");
-        }
-        pos = new_name.find("ffn_up.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 7, "layer.1.DenseReluDense.wi_1.");
-        }
-        pos = new_name.find("ffn_down.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 9, "layer.1.DenseReluDense.wo.");
-        }
-        pos = new_name.find("ffn_gate.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 9, "layer.1.DenseReluDense.wi_0.");
-        }
-        pos = new_name.find("attn_rel_b.");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, 11, "layer.0.SelfAttention.relative_attention_bias.");
-        }
-    } else if (contains(name, "qwen2vl")) {
-        if (contains(name, "qwen2vl.visual")) {
-            for (auto kv : qwenvl_vision_name_map) {
-                size_t pos = new_name.find(kv.first);
-                if (pos != std::string::npos) {
-                    new_name.replace(pos, kv.first.size(), kv.second);
-                }
-            }
-        } else {
-            for (auto kv : qwenvl_name_map) {
-                size_t pos = new_name.find(kv.first);
-                if (pos != std::string::npos) {
-                    new_name.replace(pos, kv.first.size(), kv.second);
-                }
-            }
-        }
-    } else if (name == "text_encoders.t5xxl.transformer.token_embd.weight") {
-        new_name = "text_encoders.t5xxl.transformer.shared.weight";
-    }
-
-    if (starts_with(new_name, "conditioner.embedders.0.open_clip.")) {
-        prefix   = "cond_stage_model.";
-        new_name = new_name.substr(strlen("conditioner.embedders.0.open_clip."));
-    } else if (starts_with(new_name, "conditioner.embedders.0.")) {
-        prefix   = "cond_stage_model.";
-        new_name = new_name.substr(strlen("conditioner.embedders.0."));
-    } else if (starts_with(new_name, "conditioner.embedders.1.")) {
-        prefix   = "cond_stage_model.1.";
-        new_name = new_name.substr(strlen("conditioner.embedders.0."));
-    } else if (starts_with(new_name, "cond_stage_model.")) {
-        prefix   = "cond_stage_model.";
-        new_name = new_name.substr(strlen("cond_stage_model."));
-    } else if (ends_with(new_name, "vision_model.visual_projection.weight")) {
-        prefix   = new_name.substr(0, new_name.size() - strlen("vision_model.visual_projection.weight"));
-        new_name = prefix + "visual_projection.weight";
-        return new_name;
-    } else if (ends_with(new_name, "transformer.text_projection.weight")) {
-        prefix   = new_name.substr(0, new_name.size() - strlen("transformer.text_projection.weight"));
-        new_name = prefix + "transformer.text_model.text_projection";
-        return new_name;
-    } else {
-        return new_name;
-    }
-
-    if (new_name == "model.text_projection.weight") {
-        new_name = "transformer.text_model.text_projection";
-    }
-
-    if (open_clip_to_hf_clip_model.find(new_name) != open_clip_to_hf_clip_model.end()) {
-        new_name = open_clip_to_hf_clip_model[new_name];
-    }
-
-    if (cond_model_name_map.find(new_name) != cond_model_name_map.end()) {
-        new_name = cond_model_name_map[new_name];
-    }
-
-    std::string open_clip_resblock_prefix = "model.transformer.resblocks.";
-    std::string hf_clip_resblock_prefix   = "transformer.text_model.encoder.layers.";
-
-    auto replace_suffix = [&]() {
-        if (new_name.find(open_clip_resblock_prefix) == 0) {
-            std::string remain = new_name.substr(open_clip_resblock_prefix.length());
-            std::string idx    = remain.substr(0, remain.find("."));
-            std::string suffix = remain.substr(idx.length() + 1);
-
-            if (open_clip_to_hf_clip_resblock.find(suffix) != open_clip_to_hf_clip_resblock.end()) {
-                std::string new_suffix = open_clip_to_hf_clip_resblock[suffix];
-                new_name               = hf_clip_resblock_prefix + idx + "." + new_suffix;
-            }
-        }
-    };
-
-    replace_suffix();
-
-    open_clip_resblock_prefix = "model.visual.transformer.resblocks.";
-    hf_clip_resblock_prefix   = "transformer.vision_model.encoder.layers.";
-
-    replace_suffix();
-
-    return prefix + new_name;
-}
-
-std::string convert_vae_decoder_name(const std::string& name) {
-    if (vae_decoder_name_map.find(name) != vae_decoder_name_map.end()) {
-        return vae_decoder_name_map[name];
-    }
-    return name;
-}
-
-std::string convert_pmid_v2_name(const std::string& name) {
-    if (pmid_v2_name_map.find(name) != pmid_v2_name_map.end()) {
-        return pmid_v2_name_map[name];
-    }
-    return name;
-}
-
-/* If not a SDXL LoRA the unet" prefix will have already been replaced by this
- * point and "te2" and "te1" don't seem to appear in non-SDXL only "te_" */
-std::string convert_sdxl_lora_name(std::string tensor_name) {
-    const std::pair<std::string, std::string> sdxl_lora_name_lookup[] = {
-        {"unet", "model_diffusion_model"},
-        {"te2", "cond_stage_model_1_transformer"},
-        {"te1", "cond_stage_model_transformer"},
-        {"text_encoder_2", "cond_stage_model_1_transformer"},
-        {"text_encoder", "cond_stage_model_transformer"},
-    };
-    for (auto& pair_i : sdxl_lora_name_lookup) {
-        if (tensor_name.compare(0, pair_i.first.length(), pair_i.first) == 0) {
-            tensor_name = std::regex_replace(tensor_name, std::regex(pair_i.first), pair_i.second);
-            break;
-        }
-    }
-    return tensor_name;
-}
-
-std::unordered_map<std::string, std::unordered_map<std::string, std::string>> suffix_conversion_underline = {
-    {
-        "attentions",
-        {
-            {"to_k", "k"},
-            {"to_q", "q"},
-            {"to_v", "v"},
-            {"to_out_0", "proj_out"},
-            {"group_norm", "norm"},
-            {"key", "k"},
-            {"query", "q"},
-            {"value", "v"},
-            {"proj_attn", "proj_out"},
-        },
-    },
-    {
-        "resnets",
-        {
-            {"conv1", "in_layers_2"},
-            {"conv2", "out_layers_3"},
-            {"norm1", "in_layers_0"},
-            {"norm2", "out_layers_0"},
-            {"time_emb_proj", "emb_layers_1"},
-            {"conv_shortcut", "skip_connection"},
-        },
-    },
-};
-
-std::unordered_map<std::string, std::unordered_map<std::string, std::string>> suffix_conversion_dot = {
-    {
-        "attentions",
-        {
-            {"to_k", "k"},
-            {"to_q", "q"},
-            {"to_v", "v"},
-            {"to_out.0", "proj_out"},
-            {"group_norm", "norm"},
-            {"key", "k"},
-            {"query", "q"},
-            {"value", "v"},
-            {"proj_attn", "proj_out"},
-        },
-    },
-    {
-        "resnets",
-        {
-            {"conv1", "in_layers.2"},
-            {"conv2", "out_layers.3"},
-            {"norm1", "in_layers.0"},
-            {"norm2", "out_layers.0"},
-            {"time_emb_proj", "emb_layers.1"},
-            {"conv_shortcut", "skip_connection"},
-        },
-    },
-};
-
-std::string convert_diffusers_name_to_compvis(std::string key, char seq) {
-    std::vector<std::string> m;
-
-    auto match = [](std::vector<std::string>& match_list, const std::regex& regex, const std::string& key) {
-        auto r = std::smatch{};
-        if (!std::regex_match(key, r, regex)) {
-            return false;
-        }
-
-        match_list.clear();
-        for (size_t i = 1; i < r.size(); ++i) {
-            match_list.push_back(r.str(i));
-        }
-        return true;
-    };
-
-    std::unordered_map<std::string, std::unordered_map<std::string, std::string>> suffix_conversion;
-    if (seq == '_') {
-        suffix_conversion = suffix_conversion_underline;
-    } else {
-        suffix_conversion = suffix_conversion_dot;
-    }
-
-    auto get_converted_suffix = [&suffix_conversion](const std::string& outer_key, const std::string& inner_key) {
-        auto outer_iter = suffix_conversion.find(outer_key);
-        if (outer_iter != suffix_conversion.end()) {
-            auto inner_iter = outer_iter->second.find(inner_key);
-            if (inner_iter != outer_iter->second.end()) {
-                return inner_iter->second;
-            }
-        }
-        return inner_key;
-    };
-
-    // convert attn to out
-    if (ends_with(key, "to_out")) {
-        key += format("%c0", seq);
-    }
-
-    // unet
-    if (match(m, std::regex(format("unet%cconv_in(.*)", seq)), key)) {
-        return format("model%cdiffusion_model%cinput_blocks%c0%c0", seq, seq, seq, seq) + m[0];
-    }
-
-    if (match(m, std::regex(format("unet%cconv%cout(.*)", seq, seq)), key)) {
-        return format("model%cdiffusion_model%cout%c2", seq, seq, seq) + m[0];
-    }
-
-    if (match(m, std::regex(format("unet%cconv_norm_out(.*)", seq)), key)) {
-        return format("model%cdiffusion_model%cout%c0", seq, seq, seq) + m[0];
-    }
-
-    if (match(m, std::regex(format("unet%ctime_embedding%clinear_(\\d+)(.*)", seq, seq)), key)) {
-        return format("model%cdiffusion_model%ctime_embed%c", seq, seq, seq) + std::to_string(std::stoi(m[0]) * 2 - 2) + m[1];
-    }
-
-    if (match(m, std::regex(format("unet%cadd_embedding%clinear_(\\d+)(.*)", seq, seq)), key)) {
-        return format("model%cdiffusion_model%clabel_emb%c0%c", seq, seq, seq, seq) + std::to_string(std::stoi(m[0]) * 2 - 2) + m[1];
-    }
-
-    if (match(m, std::regex(format("unet%cdown_blocks%c(\\d+)%c(attentions|resnets)%c(\\d+)%c(.+)", seq, seq, seq, seq, seq)), key)) {
-        std::string suffix = get_converted_suffix(m[1], m[3]);
-        // LOG_DEBUG("%s %s %s %s", m[0].c_str(), m[1].c_str(), m[2].c_str(), m[3].c_str());
-        return format("model%cdiffusion_model%cinput_blocks%c", seq, seq, seq) + std::to_string(1 + std::stoi(m[0]) * 3 + std::stoi(m[2])) + seq +
-               (m[1] == "attentions" ? "1" : "0") + seq + suffix;
-    }
-
-    if (match(m, std::regex(format("unet%cmid_block%c(attentions|resnets)%c(\\d+)%c(.+)", seq, seq, seq, seq)), key)) {
-        std::string suffix = get_converted_suffix(m[0], m[2]);
-        return format("model%cdiffusion_model%cmiddle_block%c", seq, seq, seq) + (m[0] == "attentions" ? "1" : std::to_string(std::stoi(m[1]) * 2)) +
-               seq + suffix;
-    }
-
-    if (match(m, std::regex(format("unet%cup_blocks%c(\\d+)%c(attentions|resnets)%c(\\d+)%c(.+)", seq, seq, seq, seq, seq)), key)) {
-        std::string suffix = get_converted_suffix(m[1], m[3]);
-        return format("model%cdiffusion_model%coutput_blocks%c", seq, seq, seq) + std::to_string(std::stoi(m[0]) * 3 + std::stoi(m[2])) + seq +
-               (m[1] == "attentions" ? "1" : "0") + seq + suffix;
-    }
-
-    if (match(m, std::regex(format("unet%cdown_blocks%c(\\d+)%cdownsamplers%c0%cconv", seq, seq, seq, seq, seq)), key)) {
-        return format("model%cdiffusion_model%cinput_blocks%c", seq, seq, seq) + std::to_string(3 + std::stoi(m[0]) * 3) + seq + "0" + seq + "op";
-    }
-
-    if (match(m, std::regex(format("unet%cup_blocks%c(\\d+)%cupsamplers%c0%cconv", seq, seq, seq, seq, seq)), key)) {
-        return format("model%cdiffusion_model%coutput_blocks%c", seq, seq, seq) + std::to_string(2 + std::stoi(m[0]) * 3) + seq +
-               (std::stoi(m[0]) > 0 ? "2" : "1") + seq + "conv";
-    }
-
-    // clip
-    if (match(m, std::regex(format("te%ctext_model%cencoder%clayers%c(\\d+)%c(.+)", seq, seq, seq, seq, seq)), key)) {
-        return format("cond_stage_model%ctransformer%ctext_model%cencoder%clayers%c", seq, seq, seq, seq, seq) + m[0] + seq + m[1];
-    }
-
-    if (match(m, std::regex(format("te%ctext_model(.*)", seq)), key)) {
-        return format("cond_stage_model%ctransformer%ctext_model", seq, seq) + m[0];
-    }
-
-    // clip-g
-    if (match(m, std::regex(format("te%c1%ctext_model%cencoder%clayers%c(\\d+)%c(.+)", seq, seq, seq, seq, seq, seq)), key)) {
-        return format("cond_stage_model%c1%ctransformer%ctext_model%cencoder%clayers%c", seq, seq, seq, seq, seq, seq) + m[0] + seq + m[1];
-    }
-
-    if (match(m, std::regex(format("te%c1%ctext_model(.*)", seq, seq)), key)) {
-        return format("cond_stage_model%c1%ctransformer%ctext_model", seq, seq, seq) + m[0];
-    }
-
-    if (match(m, std::regex(format("te%c1%ctext_projection", seq, seq)), key)) {
-        return format("cond_stage_model%c1%ctransformer%ctext_model%ctext_projection", seq, seq, seq, seq);
-    }
-
-    // vae
-    if (match(m, std::regex(format("vae%c(.*)%cconv_norm_out(.*)", seq, seq)), key)) {
-        return format("first_stage_model%c%s%cnorm_out%s", seq, m[0].c_str(), seq, m[1].c_str());
-    }
-
-    if (match(m, std::regex(format("vae%c(.*)%cmid_block%c(attentions|resnets)%c(\\d+)%c(.+)", seq, seq, seq, seq, seq)), key)) {
-        std::string suffix;
-        std::string block_name;
-        if (m[1] == "attentions") {
-            block_name = "attn";
-            suffix     = get_converted_suffix(m[1], m[3]);
-        } else {
-            block_name = "block";
-            suffix     = m[3];
-        }
-        return format("first_stage_model%c%s%cmid%c%s_%d%c%s",
-                      seq, m[0].c_str(), seq, seq, block_name.c_str(), std::stoi(m[2]) + 1, seq, suffix.c_str());
-    }
-
-    if (match(m, std::regex(format("vae%c(.*)%cup_blocks%c(\\d+)%cresnets%c(\\d+)%c(.+)", seq, seq, seq, seq, seq, seq)), key)) {
-        std::string suffix = m[3];
-        if (suffix == "conv_shortcut") {
-            suffix = "nin_shortcut";
-        }
-        return format("first_stage_model%c%s%cup%c%d%cblock%c%s%c%s",
-                      seq, m[0].c_str(), seq, seq, 3 - std::stoi(m[1]), seq, seq, m[2].c_str(), seq, suffix.c_str());
-    }
-
-    if (match(m, std::regex(format("vae%c(.*)%cdown_blocks%c(\\d+)%cdownsamplers%c0%cconv", seq, seq, seq, seq, seq, seq)), key)) {
-        return format("first_stage_model%c%s%cdown%c%d%cdownsample%cconv",
-                      seq, m[0].c_str(), seq, seq, std::stoi(m[1]), seq, seq);
-    }
-
-    if (match(m, std::regex(format("vae%c(.*)%cdown_blocks%c(\\d+)%cresnets%c(\\d+)%c(.+)", seq, seq, seq, seq, seq, seq)), key)) {
-        std::string suffix = m[3];
-        if (suffix == "conv_shortcut") {
-            suffix = "nin_shortcut";
-        }
-        return format("first_stage_model%c%s%cdown%c%d%cblock%c%s%c%s",
-                      seq, m[0].c_str(), seq, seq, std::stoi(m[1]), seq, seq, m[2].c_str(), seq, suffix.c_str());
-    }
-
-    if (match(m, std::regex(format("vae%c(.*)%cup_blocks%c(\\d+)%cupsamplers%c0%cconv", seq, seq, seq, seq, seq, seq)), key)) {
-        return format("first_stage_model%c%s%cup%c%d%cupsample%cconv",
-                      seq, m[0].c_str(), seq, seq, 3 - std::stoi(m[1]), seq, seq);
-    }
-
-    if (match(m, std::regex(format("vae%c(.*)", seq)), key)) {
-        return format("first_stage_model%c", seq) + m[0];
-    }
-
-    return key;
-}
-
-std::string convert_tensor_name(std::string name) {
-    if (starts_with(name, "diffusion_model")) {
-        name = "model." + name;
-    }
-    if (starts_with(name, "model.diffusion_model.up_blocks.0.attentions.0.")) {
-        name.replace(0, sizeof("model.diffusion_model.up_blocks.0.attentions.0.") - 1,
-                     "model.diffusion_model.output_blocks.0.1.");
-    }
-    if (starts_with(name, "model.diffusion_model.up_blocks.0.attentions.1.")) {
-        name.replace(0, sizeof("model.diffusion_model.up_blocks.0.attentions.1.") - 1,
-                     "model.diffusion_model.output_blocks.1.1.");
-    }
-    // size_t pos = name.find("lora_A");
-    // if (pos != std::string::npos) {
-    //     name.replace(pos, strlen("lora_A"), "lora_up");
-    // }
-    // pos = name.find("lora_B");
-    // if (pos != std::string::npos) {
-    //     name.replace(pos, strlen("lora_B"), "lora_down");
-    // }
-    std::string new_name = name;
-    if (starts_with(name, "cond_stage_model.") ||
-        starts_with(name, "conditioner.embedders.") ||
-        starts_with(name, "text_encoders.") ||
-        ends_with(name, ".vision_model.visual_projection.weight") ||
-        starts_with(name, "qwen2vl")) {
-        new_name = convert_cond_model_name(name);
-    } else if (starts_with(name, "first_stage_model.decoder")) {
-        new_name = convert_vae_decoder_name(name);
-    } else if (starts_with(name, "pmid.qformer_perceiver")) {
-        new_name = convert_pmid_v2_name(name);
-    } else if (starts_with(name, "control_model.")) {  // for controlnet pth models
-        size_t pos = name.find('.');
-        if (pos != std::string::npos) {
-            new_name = name.substr(pos + 1);
-        }
-    } else if (starts_with(name, "lora_")) {  // for lora
-        size_t pos = name.find('.');
-        if (pos != std::string::npos) {
-            std::string name_without_network_parts = name.substr(5, pos - 5);
-            std::string network_part               = name.substr(pos + 1);
-
-            // LOG_DEBUG("%s %s", name_without_network_parts.c_str(), network_part.c_str());
-            std::string new_key = convert_diffusers_name_to_compvis(name_without_network_parts, '_');
-            /* For dealing with the new SDXL LoRA tensor naming convention */
-            new_key = convert_sdxl_lora_name(new_key);
-
-            if (new_key.empty()) {
-                new_name = name;
-            } else {
-                new_name = "lora." + new_key + "." + network_part;
-            }
-        } else {
-            new_name = name;
-        }
-    } else if (ends_with(name, ".diff") || ends_with(name, ".diff_b")) {
-        new_name = "lora." + name;
-    } else if (contains(name, "lora_up") || contains(name, "lora_down") ||
-               contains(name, "lora.up") || contains(name, "lora.down") ||
-               contains(name, "lora_linear") || ends_with(name, ".alpha")) {
-        size_t pos = new_name.find(".processor");
-        if (pos != std::string::npos) {
-            new_name.replace(pos, strlen(".processor"), "");
-        }
-        // if (starts_with(new_name, "transformer.transformer_blocks") || starts_with(new_name, "transformer.single_transformer_blocks")) {
-        //     new_name = "model.diffusion_model." + new_name;
-        // }
-        if (ends_with(name, ".alpha")) {
-            pos = new_name.rfind("alpha");
-        } else {
-            pos = new_name.rfind("lora");
-        }
-        if (pos != std::string::npos) {
-            std::string name_without_network_parts = new_name.substr(0, pos - 1);
-            std::string network_part               = new_name.substr(pos);
-            // LOG_DEBUG("%s %s", name_without_network_parts.c_str(), network_part.c_str());
-            std::string new_key = convert_diffusers_name_to_compvis(name_without_network_parts, '.');
-            new_key             = convert_sdxl_lora_name(new_key);
-            replace_all_chars(new_key, '.', '_');
-            size_t npos = network_part.rfind("_linear_layer");
-            if (npos != std::string::npos) {
-                network_part.replace(npos, strlen("_linear_layer"), "");
-            }
-            if (starts_with(network_part, "lora.")) {
-                network_part = "lora_" + network_part.substr(5);
-            }
-            if (new_key.size() > 0) {
-                new_name = "lora." + new_key + "." + network_part;
-            }
-            // LOG_DEBUG("new name: %s", new_name.c_str());
-        }
-    } else if (starts_with(name, "unet") || starts_with(name, "vae") || starts_with(name, "te")) {  // for diffuser
-        size_t pos = name.find_last_of('.');
-        if (pos != std::string::npos) {
-            std::string name_without_network_parts = name.substr(0, pos);
-            std::string network_part               = name.substr(pos + 1);
-            // LOG_DEBUG("%s %s", name_without_network_parts.c_str(), network_part.c_str());
-            std::string new_key = convert_diffusers_name_to_compvis(name_without_network_parts, '.');
-            if (new_key.empty()) {
-                new_name = name;
-            } else if (new_key == "cond_stage_model.1.transformer.text_model.text_projection") {
-                new_name = new_key;
-            } else {
-                new_name = new_key + "." + network_part;
-            }
-        } else {
-            new_name = name;
-        }
-    } else {
-        new_name = name;
-    }
-    // if (new_name != name) {
-    //     LOG_DEBUG("%s => %s", name.c_str(), new_name.c_str());
-    // }
-    return new_name;
 }
 
 float bf16_to_f32(uint16_t bfloat16) {
@@ -916,9 +293,7 @@ void convert_tensor(void* src,
 /*================================================= ModelLoader ==================================================*/
 
 void ModelLoader::add_tensor_storage(const TensorStorage& tensor_storage) {
-    TensorStorage copy            = tensor_storage;
-    copy.name                     = convert_tensor_name(copy.name);
-    tensor_storage_map[copy.name] = std::move(copy);
+    tensor_storage_map[tensor_storage.name] = tensor_storage;
 }
 
 bool is_zip_file(const std::string& file_path) {
@@ -1010,6 +385,31 @@ bool ModelLoader::init_from_file(const std::string& file_path, const std::string
         LOG_WARN("unknown format %s", file_path.c_str());
         return false;
     }
+}
+
+void ModelLoader::convert_tensors_name() {
+    SDVersion version = (version_ == VERSION_COUNT) ? get_sd_version() : version_;
+    String2TensorStorage new_map;
+
+    for (auto& [_, tensor_storage] : tensor_storage_map) {
+        auto new_name = convert_tensor_name(tensor_storage.name, version);
+        // LOG_DEBUG("%s -> %s", tensor_storage.name.c_str(), new_name.c_str());
+        tensor_storage.name = new_name;
+        new_map[new_name]   = std::move(tensor_storage);
+    }
+
+    tensor_storage_map.swap(new_map);
+}
+
+bool ModelLoader::init_from_file_and_convert_name(const std::string& file_path, const std::string& prefix, SDVersion version) {
+    if (version_ == VERSION_COUNT && version != VERSION_COUNT) {
+        version_ = version;
+    }
+    if (!init_from_file(file_path, prefix)) {
+        return false;
+    }
+    convert_tensors_name();
+    return true;
 }
 
 /*================================================= GGUFModelLoader ==================================================*/
@@ -1258,32 +658,6 @@ bool ModelLoader::init_from_diffusers_file(const std::string& file_path, const s
 
     if (!init_from_safetensors_file(unet_path, "unet.")) {
         return false;
-    }
-    for (auto& [name, tensor_storage] : tensor_storage_map) {
-        if (name.find("add_embedding") != std::string::npos || name.find("label_emb") != std::string::npos) {
-            // probably SDXL
-            LOG_DEBUG("Fixing name for SDXL output blocks.2.2");
-            String2TensorStorage new_tensor_storage_map;
-
-            for (auto& [name, tensor_storage] : tensor_storage_map) {
-                int len  = 34;
-                auto pos = tensor_storage.name.find("unet.up_blocks.0.upsamplers.0.conv");
-                if (pos == std::string::npos) {
-                    len = 44;
-                    pos = tensor_storage.name.find("model.diffusion_model.output_blocks.2.1.conv");
-                }
-                if (pos != std::string::npos) {
-                    std::string new_name = "model.diffusion_model.output_blocks.2.2.conv" + name.substr(len);
-                    LOG_DEBUG("NEW NAME: %s", new_name.c_str());
-                    tensor_storage.name              = new_name;
-                    new_tensor_storage_map[new_name] = tensor_storage;
-                } else {
-                    new_tensor_storage_map[name] = tensor_storage;
-                }
-            }
-            tensor_storage_map = new_tensor_storage_map;
-            break;
-        }
     }
 
     if (!init_from_safetensors_file(vae_path, "vae.")) {
@@ -1922,7 +1296,7 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb, int n_thread
     int64_t start_time = ggml_time_ms();
 
     std::vector<TensorStorage> processed_tensor_storages;
-    for (auto& [name, tensor_storage] : tensor_storage_map) {
+    for (const auto& [name, tensor_storage] : tensor_storage_map) {
         if (is_unused_tensor(tensor_storage.name)) {
             continue;
         }
@@ -2391,6 +1765,7 @@ bool convert(const char* input_path, const char* vae_path, const char* output_pa
             return false;
         }
     }
+    model_loader.convert_tensors_name();
     bool success = model_loader.save_to_gguf_file(output_path, (ggml_type)output_type, tensor_type_rules);
     return success;
 }

--- a/model.h
+++ b/model.h
@@ -15,6 +15,7 @@
 #include "ggml.h"
 #include "gguf.h"
 #include "json.hpp"
+#include "ordered_map.hpp"
 #include "zip.h"
 
 #define SD_MAX_DIMS 5
@@ -107,7 +108,11 @@ static inline bool sd_version_is_qwen_image(SDVersion version) {
 }
 
 static inline bool sd_version_is_inpaint(SDVersion version) {
-    if (version == VERSION_SD1_INPAINT || version == VERSION_SD2_INPAINT || version == VERSION_SDXL_INPAINT || version == VERSION_FLUX_FILL || version == VERSION_FLEX_2) {
+    if (version == VERSION_SD1_INPAINT ||
+        version == VERSION_SD2_INPAINT ||
+        version == VERSION_SDXL_INPAINT ||
+        version == VERSION_FLUX_FILL ||
+        version == VERSION_FLEX_2) {
         return true;
     }
     return false;
@@ -252,10 +257,11 @@ struct TensorStorage {
 
 typedef std::function<bool(const TensorStorage&, ggml_tensor**)> on_new_tensor_cb_t;
 
-typedef std::map<std::string, TensorStorage> String2TensorStorage;
+typedef OrderedMap<std::string, TensorStorage> String2TensorStorage;
 
 class ModelLoader {
 protected:
+    SDVersion version_ = VERSION_COUNT;
     std::vector<std::string> file_paths_;
     String2TensorStorage tensor_storage_map;
 
@@ -275,6 +281,10 @@ protected:
 
 public:
     bool init_from_file(const std::string& file_path, const std::string& prefix = "");
+    void convert_tensors_name();
+    bool init_from_file_and_convert_name(const std::string& file_path,
+                                         const std::string& prefix = "",
+                                         SDVersion version         = VERSION_COUNT);
     SDVersion get_sd_version();
     std::map<ggml_type, uint32_t> get_wtype_stat();
     std::map<ggml_type, uint32_t> get_conditioner_wtype_stat();

--- a/name_conversion.cpp
+++ b/name_conversion.cpp
@@ -1,0 +1,1028 @@
+#include <unordered_map>
+#include <unordered_set>
+
+#include "name_conversion.h"
+#include "util.h"
+
+void replace_with_name_map(std::string& name, const std::vector<std::pair<std::string, std::string>>& name_map) {
+    for (auto kv : name_map) {
+        size_t pos = name.find(kv.first);
+        if (pos != std::string::npos) {
+            name.replace(pos, kv.first.size(), kv.second);
+        }
+    }
+}
+
+void replace_with_prefix_map(std::string& name, const std::vector<std::pair<std::string, std::string>>& prefix_map) {
+    for (const auto& [old_prefix, new_prefix] : prefix_map) {
+        if (starts_with(name, old_prefix)) {
+            name = new_prefix + name.substr(old_prefix.size());
+            break;
+        }
+    }
+}
+
+void replace_with_prefix_map(std::string& name, const std::unordered_map<std::string, std::string>& prefix_map) {
+    for (const auto& [old_prefix, new_prefix] : prefix_map) {
+        if (starts_with(name, old_prefix)) {
+            name = new_prefix + name.substr(old_prefix.size());
+            break;
+        }
+    }
+}
+
+std::string convert_open_clip_to_hf_clip_name(std::string name) {
+    static std::unordered_map<std::string, std::string> open_clip_to_hf_clip_model = {
+        {"model.ln_final.bias", "transformer.text_model.final_layer_norm.bias"},
+        {"model.ln_final.weight", "transformer.text_model.final_layer_norm.weight"},
+        {"model.positional_embedding", "transformer.text_model.embeddings.position_embedding.weight"},
+        {"model.token_embedding.weight", "transformer.text_model.embeddings.token_embedding.weight"},
+        {"model.text_projection", "transformer.text_model.text_projection"},
+        {"model.visual.class_embedding", "transformer.vision_model.embeddings.class_embedding"},
+        {"model.visual.conv1.weight", "transformer.vision_model.embeddings.patch_embedding.weight"},
+        {"model.visual.ln_post.bias", "transformer.vision_model.post_layernorm.bias"},
+        {"model.visual.ln_post.weight", "transformer.vision_model.post_layernorm.weight"},
+        {"model.visual.ln_pre.bias", "transformer.vision_model.pre_layernorm.bias"},
+        {"model.visual.ln_pre.weight", "transformer.vision_model.pre_layernorm.weight"},
+        {"model.visual.positional_embedding", "transformer.vision_model.embeddings.position_embedding.weight"},
+        {"model.visual.proj", "transformer.visual_projection.weight"},
+    };
+
+    static std::unordered_map<std::string, std::string> open_clip_to_hf_clip_resblock = {
+        {"attn.in_proj_bias", "self_attn.in_proj.bias"},
+        {"attn.in_proj_weight", "self_attn.in_proj.weight"},
+        {"attn.out_proj.bias", "self_attn.out_proj.bias"},
+        {"attn.out_proj.weight", "self_attn.out_proj.weight"},
+        {"ln_1.bias", "layer_norm1.bias"},
+        {"ln_1.weight", "layer_norm1.weight"},
+        {"ln_2.bias", "layer_norm2.bias"},
+        {"ln_2.weight", "layer_norm2.weight"},
+        {"mlp.c_fc.bias", "mlp.fc1.bias"},
+        {"mlp.c_fc.weight", "mlp.fc1.weight"},
+        {"mlp.c_proj.bias", "mlp.fc2.bias"},
+        {"mlp.c_proj.weight", "mlp.fc2.weight"},
+    };
+
+    static std::unordered_map<std::string, std::string> cond_model_name_map = {
+        {"transformer.vision_model.pre_layrnorm.weight", "transformer.vision_model.pre_layernorm.weight"},
+        {"transformer.vision_model.pre_layrnorm.bias", "transformer.vision_model.pre_layernorm.bias"},
+    };
+
+    if (open_clip_to_hf_clip_model.find(name) != open_clip_to_hf_clip_model.end()) {
+        name = open_clip_to_hf_clip_model[name];
+    }
+
+    if (cond_model_name_map.find(name) != cond_model_name_map.end()) {
+        name = cond_model_name_map[name];
+    }
+
+    std::string open_clip_resblock_prefix = "model.transformer.resblocks.";
+    std::string hf_clip_resblock_prefix   = "transformer.text_model.encoder.layers.";
+
+    auto replace_suffix = [&]() {
+        if (name.find(open_clip_resblock_prefix) == 0) {
+            std::string remain = name.substr(open_clip_resblock_prefix.length());
+            std::string idx    = remain.substr(0, remain.find("."));
+            std::string suffix = remain.substr(idx.length() + 1);
+
+            if (open_clip_to_hf_clip_resblock.find(suffix) != open_clip_to_hf_clip_resblock.end()) {
+                std::string new_suffix = open_clip_to_hf_clip_resblock[suffix];
+                name                   = hf_clip_resblock_prefix + idx + "." + new_suffix;
+            }
+        }
+    };
+
+    replace_suffix();
+
+    open_clip_resblock_prefix = "model.visual.transformer.resblocks.";
+    hf_clip_resblock_prefix   = "transformer.vision_model.encoder.layers.";
+
+    replace_suffix();
+
+    return name;
+}
+
+std::string convert_cond_stage_model_name(std::string name, std::string prefix) {
+    static const std::vector<std::pair<std::string, std::string>> clip_name_map{
+        {"transformer.text_projection.weight", "transformer.text_model.text_projection"},
+        {"model.text_projection.weight", "transformer.text_model.text_projection"},
+        {"vision_model.visual_projection.weight", "visual_projection.weight"},
+    };
+
+    // llama.cpp to original
+    static const std::vector<std::pair<std::string, std::string>> t5_name_map{
+        {"enc.", "encoder."},
+        {"blk.", "block."},
+        {"output_norm.", "final_layer_norm."},
+        {"attn_q.", "layer.0.SelfAttention.q."},
+        {"attn_k.", "layer.0.SelfAttention.k."},
+        {"attn_v.", "layer.0.SelfAttention.v."},
+        {"attn_o.", "layer.0.SelfAttention.o."},
+        {"attn_norm.", "layer.0.layer_norm."},
+        {"ffn_norm.", "layer.1.layer_norm."},
+        {"ffn_up.", "layer.1.DenseReluDense.wi_1."},
+        {"ffn_down.", "layer.1.DenseReluDense.wo."},
+        {"ffn_gate.", "layer.1.DenseReluDense.wi_0."},
+        {"attn_rel_b.", "layer.0.SelfAttention.relative_attention_bias."},
+        {"token_embd.", "shared."},
+    };
+
+    static const std::vector<std::pair<std::string, std::string>> qwenvl_name_map{
+        {"token_embd.", "model.embed_tokens."},
+        {"blk.", "model.layers."},
+        {"attn_q.", "self_attn.q_proj."},
+        {"attn_k.", "self_attn.k_proj."},
+        {"attn_v.", "self_attn.v_proj."},
+        {"attn_output.", "self_attn.o_proj."},
+        {"attn_norm.", "input_layernorm."},
+        {"ffn_down.", "mlp.down_proj."},
+        {"ffn_gate.", "mlp.gate_proj."},
+        {"ffn_up.", "mlp.up_proj."},
+        {"ffn_norm.", "post_attention_layernorm."},
+        {"output_norm.", "model.norm."},
+    };
+
+    static const std::vector<std::pair<std::string, std::string>> qwenvl_vision_name_map{
+        {"mm.", "merger.mlp."},
+        {"v.post_ln.", "merger.ln_q."},
+        {"v.patch_embd.weight", "patch_embed.proj.0.weight"},
+        {"patch_embed.proj.0.weight.1", "patch_embed.proj.1.weight"},
+        {"v.patch_embd.weight.1", "patch_embed.proj.1.weight"},
+        {"v.blk.", "blocks."},
+        {"attn_q.", "attn.q_proj."},
+        {"attn_k.", "attn.k_proj."},
+        {"attn_v.", "attn.v_proj."},
+        {"attn_out.", "attn.proj."},
+        {"ffn_down.", "mlp.down_proj."},
+        {"ffn_gate.", "mlp.gate_proj."},
+        {"ffn_up.", "mlp.up_proj."},
+        {"ln1.", "norm1."},
+        {"ln2.", "norm2."},
+    };
+    if (contains(name, "t5xxl")) {
+        replace_with_name_map(name, t5_name_map);
+    } else if (contains(name, "qwen2vl")) {
+        if (contains(name, "qwen2vl.visual")) {
+            replace_with_name_map(name, qwenvl_vision_name_map);
+        } else {
+            replace_with_name_map(name, qwenvl_name_map);
+        }
+    } else {
+        name = convert_open_clip_to_hf_clip_name(name);
+        replace_with_name_map(name, clip_name_map);
+    }
+    return name;
+}
+
+// ref: https://github.com/huggingface/diffusers/blob/main/scripts/convert_diffusers_to_original_stable_diffusion.py
+std::string convert_diffusers_unet_to_original_sd1(std::string name) {
+    // (stable-diffusion, HF Diffusers)
+    static const std::vector<std::pair<std::string, std::string>> unet_conversion_map = {
+        {"time_embed.0.weight", "time_embedding.linear_1.weight"},
+        {"time_embed.0.bias", "time_embedding.linear_1.bias"},
+        {"time_embed.2.weight", "time_embedding.linear_2.weight"},
+        {"time_embed.2.bias", "time_embedding.linear_2.bias"},
+        {"input_blocks.0.0.weight", "conv_in.weight"},
+        {"input_blocks.0.0.bias", "conv_in.bias"},
+        {"out.0.weight", "conv_norm_out.weight"},
+        {"out.0.bias", "conv_norm_out.bias"},
+        {"out.2.weight", "conv_out.weight"},
+        {"out.2.bias", "conv_out.bias"},
+    };
+
+    static const std::vector<std::pair<std::string, std::string>> unet_conversion_map_resnet = {
+        {"in_layers.0", "norm1"},
+        {"in_layers.2", "conv1"},
+        {"out_layers.0", "norm2"},
+        {"out_layers.3", "conv2"},
+        {"emb_layers.1", "time_emb_proj"},
+        {"skip_connection", "conv_shortcut"},
+    };
+
+    static std::vector<std::pair<std::string, std::string>> unet_conversion_map_layer;
+    if (unet_conversion_map_layer.empty()) {
+        for (int i = 0; i < 4; ++i) {
+            // down_blocks
+            for (int j = 0; j < 2; ++j) {
+                std::string hf_down_res_prefix = "down_blocks." + std::to_string(i) + ".resnets." + std::to_string(j) + ".";
+                std::string sd_down_res_prefix = "input_blocks." + std::to_string(3 * i + j + 1) + ".0.";
+                unet_conversion_map_layer.emplace_back(sd_down_res_prefix, hf_down_res_prefix);
+
+                if (i < 3) {
+                    std::string hf_down_atn_prefix = "down_blocks." + std::to_string(i) + ".attentions." + std::to_string(j) + ".";
+                    std::string sd_down_atn_prefix = "input_blocks." + std::to_string(3 * i + j + 1) + ".1.";
+                    unet_conversion_map_layer.emplace_back(sd_down_atn_prefix, hf_down_atn_prefix);
+                }
+            }
+
+            // up_blocks
+            for (int j = 0; j < 3; ++j) {
+                std::string hf_up_res_prefix = "up_blocks." + std::to_string(i) + ".resnets." + std::to_string(j) + ".";
+                std::string sd_up_res_prefix = "output_blocks." + std::to_string(3 * i + j) + ".0.";
+                unet_conversion_map_layer.emplace_back(sd_up_res_prefix, hf_up_res_prefix);
+
+                if (/*i > 0*/ true) {  // for tiny unet
+                    std::string hf_up_atn_prefix = "up_blocks." + std::to_string(i) + ".attentions." + std::to_string(j) + ".";
+                    std::string sd_up_atn_prefix = "output_blocks." + std::to_string(3 * i + j) + ".1.";
+                    unet_conversion_map_layer.emplace_back(sd_up_atn_prefix, hf_up_atn_prefix);
+                }
+            }
+
+            if (i < 3) {
+                std::string hf_downsample_prefix = "down_blocks." + std::to_string(i) + ".downsamplers.0.conv.";
+                std::string sd_downsample_prefix = "input_blocks." + std::to_string(3 * (i + 1)) + ".0.op.";
+                unet_conversion_map_layer.emplace_back(sd_downsample_prefix, hf_downsample_prefix);
+
+                std::string hf_upsample_prefix = "up_blocks." + std::to_string(i) + ".upsamplers.0.";
+                std::string sd_upsample_prefix = "output_blocks." + std::to_string(3 * i + 2) + "." + std::to_string(i == 0 ? 1 : 2) + ".";
+                unet_conversion_map_layer.emplace_back(sd_upsample_prefix, hf_upsample_prefix);
+            }
+        }
+
+        // mid block
+        unet_conversion_map_layer.emplace_back("middle_block.1.", "mid_block.attentions.0.");
+        for (int j = 0; j < 2; ++j) {
+            std::string hf_mid_res_prefix = "mid_block.resnets." + std::to_string(j) + ".";
+            std::string sd_mid_res_prefix = "middle_block." + std::to_string(2 * j) + ".";
+            unet_conversion_map_layer.emplace_back(sd_mid_res_prefix, hf_mid_res_prefix);
+        }
+    }
+
+    std::string result = name;
+
+    for (const auto& p : unet_conversion_map) {
+        if (result == p.second) {
+            result = p.first;
+            return result;
+        }
+    }
+
+    if (contains(result, "resnets")) {
+        for (const auto& p : unet_conversion_map_resnet) {
+            size_t pos = result.find(p.second);
+            if (pos != std::string::npos) {
+                result.replace(pos, p.second.size(), p.first);
+            }
+        }
+    }
+
+    for (const auto& p : unet_conversion_map_layer) {
+        size_t pos = result.find(p.second);
+        if (pos != std::string::npos) {
+            result.replace(pos, p.second.size(), p.first);
+        }
+    }
+
+    return result;
+}
+
+// ref: https://github.com/huggingface/diffusers/blob/main/scripts/convert_diffusers_to_original_sdxl.py
+
+std::string convert_diffusers_unet_to_original_sdxl(std::string name) {
+    // (stable-diffusion, HF Diffusers)
+    static const std::vector<std::pair<std::string, std::string>> unet_conversion_map = {
+        {"time_embed.0.weight", "time_embedding.linear_1.weight"},
+        {"time_embed.0.bias", "time_embedding.linear_1.bias"},
+        {"time_embed.2.weight", "time_embedding.linear_2.weight"},
+        {"time_embed.2.bias", "time_embedding.linear_2.bias"},
+        {"input_blocks.0.0.weight", "conv_in.weight"},
+        {"input_blocks.0.0.bias", "conv_in.bias"},
+        {"out.0.weight", "conv_norm_out.weight"},
+        {"out.0.bias", "conv_norm_out.bias"},
+        {"out.2.weight", "conv_out.weight"},
+        {"out.2.bias", "conv_out.bias"},
+
+        // --- SDXL add_embedding mappings ---
+        {"label_emb.0.0.weight", "add_embedding.linear_1.weight"},
+        {"label_emb.0.0.bias", "add_embedding.linear_1.bias"},
+        {"label_emb.0.2.weight", "add_embedding.linear_2.weight"},
+        {"label_emb.0.2.bias", "add_embedding.linear_2.bias"},
+    };
+
+    static const std::vector<std::pair<std::string, std::string>> unet_conversion_map_resnet = {
+        {"in_layers.0", "norm1"},
+        {"in_layers.2", "conv1"},
+        {"out_layers.0", "norm2"},
+        {"out_layers.3", "conv2"},
+        {"emb_layers.1", "time_emb_proj"},
+        {"skip_connection", "conv_shortcut"},
+    };
+
+    static std::vector<std::pair<std::string, std::string>> unet_conversion_map_layer;
+    if (unet_conversion_map_layer.empty()) {
+        for (int i = 0; i < 3; ++i) {
+            // --- down_blocks ---
+            for (int j = 0; j < 2; ++j) {
+                std::string hf_down_res_prefix = "down_blocks." + std::to_string(i) + ".resnets." + std::to_string(j) + ".";
+                std::string sd_down_res_prefix = "input_blocks." + std::to_string(3 * i + j + 1) + ".0.";
+                unet_conversion_map_layer.emplace_back(sd_down_res_prefix, hf_down_res_prefix);
+
+                if (i > 0) {
+                    std::string hf_down_atn_prefix = "down_blocks." + std::to_string(i) + ".attentions." + std::to_string(j) + ".";
+                    std::string sd_down_atn_prefix = "input_blocks." + std::to_string(3 * i + j + 1) + ".1.";
+                    unet_conversion_map_layer.emplace_back(sd_down_atn_prefix, hf_down_atn_prefix);
+                }
+            }
+
+            // --- up_blocks ---
+            for (int j = 0; j < 4; ++j) {
+                std::string hf_up_res_prefix = "up_blocks." + std::to_string(i) + ".resnets." + std::to_string(j) + ".";
+                std::string sd_up_res_prefix = "output_blocks." + std::to_string(3 * i + j) + ".0.";
+                unet_conversion_map_layer.emplace_back(sd_up_res_prefix, hf_up_res_prefix);
+
+                if (i < 2) {
+                    std::string hf_up_atn_prefix = "up_blocks." + std::to_string(i) + ".attentions." + std::to_string(j) + ".";
+                    std::string sd_up_atn_prefix = "output_blocks." + std::to_string(3 * i + j) + ".1.";
+                    unet_conversion_map_layer.emplace_back(sd_up_atn_prefix, hf_up_atn_prefix);
+                }
+            }
+
+            if (i < 3) {
+                std::string hf_downsample_prefix = "down_blocks." + std::to_string(i) + ".downsamplers.0.conv.";
+                std::string sd_downsample_prefix = "input_blocks." + std::to_string(3 * (i + 1)) + ".0.op.";
+                unet_conversion_map_layer.emplace_back(sd_downsample_prefix, hf_downsample_prefix);
+
+                std::string hf_upsample_prefix = "up_blocks." + std::to_string(i) + ".upsamplers.0.";
+                std::string sd_upsample_prefix =
+                    "output_blocks." + std::to_string(3 * i + 2) + "." + std::to_string(i == 0 ? 1 : 2) + ".";
+                unet_conversion_map_layer.emplace_back(sd_upsample_prefix, hf_upsample_prefix);
+            }
+        }
+
+        unet_conversion_map_layer.emplace_back("output_blocks.2.2.conv.", "output_blocks.2.1.conv.");
+
+        // mid block
+        unet_conversion_map_layer.emplace_back("middle_block.1.", "mid_block.attentions.0.");
+        for (int j = 0; j < 2; ++j) {
+            std::string hf_mid_res_prefix = "mid_block.resnets." + std::to_string(j) + ".";
+            std::string sd_mid_res_prefix = "middle_block." + std::to_string(2 * j) + ".";
+            unet_conversion_map_layer.emplace_back(sd_mid_res_prefix, hf_mid_res_prefix);
+        }
+    }
+
+    std::string result = name;
+
+    for (const auto& p : unet_conversion_map) {
+        if (result == p.second) {
+            result = p.first;
+            return result;
+        }
+    }
+
+    if (contains(result, "resnets")) {
+        for (const auto& p : unet_conversion_map_resnet) {
+            size_t pos = result.find(p.second);
+            if (pos != std::string::npos) {
+                result.replace(pos, p.second.size(), p.first);
+            }
+        }
+    }
+
+    for (const auto& p : unet_conversion_map_layer) {
+        size_t pos = result.find(p.second);
+        if (pos != std::string::npos) {
+            result.replace(pos, p.second.size(), p.first);
+        }
+    }
+
+    static const std::vector<std::pair<std::string, std::string>> name_map{
+        {"to_out.weight", "to_out.0.weight"},
+        {"to_out.bias", "to_out.0.bias"},
+    };
+    replace_with_name_map(result, name_map);
+
+    return result;
+}
+
+std::string convert_diffusers_dit_to_original_sd3(std::string name) {
+    int num_layers = 38;
+    static std::unordered_map<std::string, std::string> sd3_name_map;
+
+    if (sd3_name_map.empty()) {
+        // --- time_text_embed ---
+        sd3_name_map["time_text_embed.timestep_embedder.linear_1.weight"] = "t_embedder.mlp.0.weight";
+        sd3_name_map["time_text_embed.timestep_embedder.linear_1.bias"]   = "t_embedder.mlp.0.bias";
+        sd3_name_map["time_text_embed.timestep_embedder.linear_2.weight"] = "t_embedder.mlp.2.weight";
+        sd3_name_map["time_text_embed.timestep_embedder.linear_2.bias"]   = "t_embedder.mlp.2.bias";
+
+        sd3_name_map["time_text_embed.text_embedder.linear_1.weight"] = "y_embedder.mlp.0.weight";
+        sd3_name_map["time_text_embed.text_embedder.linear_1.bias"]   = "y_embedder.mlp.0.bias";
+        sd3_name_map["time_text_embed.text_embedder.linear_2.weight"] = "y_embedder.mlp.2.weight";
+        sd3_name_map["time_text_embed.text_embedder.linear_2.bias"]   = "y_embedder.mlp.2.bias";
+
+        sd3_name_map["pos_embed.pos_embed"]   = "pos_embed";
+        sd3_name_map["pos_embed.proj.weight"] = "x_embedder.proj.weight";
+        sd3_name_map["pos_embed.proj.bias"]   = "x_embedder.proj.bias";
+
+        // --- transformer blocks ---
+        for (int i = 0; i < num_layers; ++i) {
+            std::string block_prefix = "transformer_blocks." + std::to_string(i) + ".";
+            std::string dst_prefix   = "joint_blocks." + std::to_string(i) + ".";
+
+            sd3_name_map[block_prefix + "norm1.linear.weight"]         = dst_prefix + "x_block.adaLN_modulation.1.weight";
+            sd3_name_map[block_prefix + "norm1.linear.bias"]           = dst_prefix + "x_block.adaLN_modulation.1.bias";
+            sd3_name_map[block_prefix + "norm1_context.linear.weight"] = dst_prefix + "context_block.adaLN_modulation.1.weight";
+            sd3_name_map[block_prefix + "norm1_context.linear.bias"]   = dst_prefix + "context_block.adaLN_modulation.1.bias";
+
+            // attn
+            sd3_name_map[block_prefix + "attn.to_q.weight"] = dst_prefix + "x_block.attn.qkv.weight";
+            sd3_name_map[block_prefix + "attn.to_q.bias"]   = dst_prefix + "x_block.attn.qkv.bias";
+            sd3_name_map[block_prefix + "attn.to_k.weight"] = dst_prefix + "x_block.attn.qkv.weight.1";
+            sd3_name_map[block_prefix + "attn.to_k.bias"]   = dst_prefix + "x_block.attn.qkv.bias.1";
+            sd3_name_map[block_prefix + "attn.to_v.weight"] = dst_prefix + "x_block.attn.qkv.weight.2";
+            sd3_name_map[block_prefix + "attn.to_v.bias"]   = dst_prefix + "x_block.attn.qkv.bias.2";
+
+            sd3_name_map[block_prefix + "attn.add_q_proj.weight"] = dst_prefix + "context_block.attn.qkv.weight";
+            sd3_name_map[block_prefix + "attn.add_q_proj.bias"]   = dst_prefix + "context_block.attn.qkv.bias";
+            sd3_name_map[block_prefix + "attn.add_k_proj.weight"] = dst_prefix + "context_block.attn.qkv.weight.1";
+            sd3_name_map[block_prefix + "attn.add_k_proj.bias"]   = dst_prefix + "context_block.attn.qkv.bias.1";
+            sd3_name_map[block_prefix + "attn.add_v_proj.weight"] = dst_prefix + "context_block.attn.qkv.weight.2";
+            sd3_name_map[block_prefix + "attn.add_v_proj.bias"]   = dst_prefix + "context_block.attn.qkv.bias.2";
+
+            // attn2
+            sd3_name_map[block_prefix + "attn2.to_q.weight"] = dst_prefix + "x_block.attn2.qkv.weight";
+            sd3_name_map[block_prefix + "attn2.to_q.bias"]   = dst_prefix + "x_block.attn2.qkv.bias";
+            sd3_name_map[block_prefix + "attn2.to_k.weight"] = dst_prefix + "x_block.attn2.qkv.weight.1";
+            sd3_name_map[block_prefix + "attn2.to_k.bias"]   = dst_prefix + "x_block.attn2.qkv.bias.1";
+            sd3_name_map[block_prefix + "attn2.to_v.weight"] = dst_prefix + "x_block.attn2.qkv.weight.2";
+            sd3_name_map[block_prefix + "attn2.to_v.bias"]   = dst_prefix + "x_block.attn2.qkv.bias.2";
+
+            sd3_name_map[block_prefix + "attn2.add_q_proj.weight"] = dst_prefix + "context_block.attn2.qkv.weight";
+            sd3_name_map[block_prefix + "attn2.add_q_proj.bias"]   = dst_prefix + "context_block.attn2.qkv.bias";
+            sd3_name_map[block_prefix + "attn2.add_k_proj.weight"] = dst_prefix + "context_block.attn2.qkv.weight.1";
+            sd3_name_map[block_prefix + "attn2.add_k_proj.bias"]   = dst_prefix + "context_block.attn2.qkv.bias.1";
+            sd3_name_map[block_prefix + "attn2.add_v_proj.weight"] = dst_prefix + "context_block.attn2.qkv.weight.2";
+            sd3_name_map[block_prefix + "attn2.add_v_proj.bias"]   = dst_prefix + "context_block.attn2.qkv.bias.2";
+
+            // norm
+            sd3_name_map[block_prefix + "attn.norm_q.weight"]       = dst_prefix + "x_block.attn.ln_q.weight";
+            sd3_name_map[block_prefix + "attn.norm_k.weight"]       = dst_prefix + "x_block.attn.ln_k.weight";
+            sd3_name_map[block_prefix + "attn.norm_added_q.weight"] = dst_prefix + "context_block.attn.ln_q.weight";
+            sd3_name_map[block_prefix + "attn.norm_added_k.weight"] = dst_prefix + "context_block.attn.ln_k.weight";
+
+            // norm2
+            sd3_name_map[block_prefix + "attn2.norm_q.weight"] = dst_prefix + "x_block.attn2.ln_q.weight";
+            sd3_name_map[block_prefix + "attn2.norm_k.weight"] = dst_prefix + "x_block.attn2.ln_k.weight";
+
+            // ff
+            sd3_name_map[block_prefix + "ff.net.0.proj.weight"] = dst_prefix + "x_block.mlp.fc1.weight";
+            sd3_name_map[block_prefix + "ff.net.0.proj.bias"]   = dst_prefix + "x_block.mlp.fc1.bias";
+            sd3_name_map[block_prefix + "ff.net.2.weight"]      = dst_prefix + "x_block.mlp.fc2.weight";
+            sd3_name_map[block_prefix + "ff.net.2.bias"]        = dst_prefix + "x_block.mlp.fc2.bias";
+
+            sd3_name_map[block_prefix + "ff_context.net.0.proj.weight"] = dst_prefix + "context_block.mlp.fc1.weight";
+            sd3_name_map[block_prefix + "ff_context.net.0.proj.bias"]   = dst_prefix + "context_block.mlp.fc1.bias";
+            sd3_name_map[block_prefix + "ff_context.net.2.weight"]      = dst_prefix + "context_block.mlp.fc2.weight";
+            sd3_name_map[block_prefix + "ff_context.net.2.bias"]        = dst_prefix + "context_block.mlp.fc2.bias";
+
+            // output projections
+            sd3_name_map[block_prefix + "attn.to_out.0.weight"]   = dst_prefix + "x_block.attn.proj.weight";
+            sd3_name_map[block_prefix + "attn.to_out.0.bias"]     = dst_prefix + "x_block.attn.proj.bias";
+            sd3_name_map[block_prefix + "attn.to_add_out.weight"] = dst_prefix + "context_block.attn.proj.weight";
+            sd3_name_map[block_prefix + "attn.to_add_out.bias"]   = dst_prefix + "context_block.attn.proj.bias";
+
+            // output projections 2
+            sd3_name_map[block_prefix + "attn2.to_out.0.weight"]   = dst_prefix + "x_block.attn2.proj.weight";
+            sd3_name_map[block_prefix + "attn2.to_out.0.bias"]     = dst_prefix + "x_block.attn2.proj.bias";
+            sd3_name_map[block_prefix + "attn2.to_add_out.weight"] = dst_prefix + "context_block.attn2.proj.weight";
+            sd3_name_map[block_prefix + "attn2.to_add_out.bias"]   = dst_prefix + "context_block.attn2.proj.bias";
+        }
+
+        // --- final layers ---
+        sd3_name_map["proj_out.weight"]        = "final_layer.linear.weight";
+        sd3_name_map["proj_out.bias"]          = "final_layer.linear.bias";
+        sd3_name_map["norm_out.linear.weight"] = "final_layer.adaLN_modulation.1.weight";
+        sd3_name_map["norm_out.linear.bias"]   = "final_layer.adaLN_modulation.1.bias";
+    }
+
+    replace_with_prefix_map(name, sd3_name_map);
+
+    return name;
+}
+
+std::string convert_diffusers_dit_to_original_flux(std::string name) {
+    int num_layers        = 19;
+    int num_single_layers = 38;
+    static std::unordered_map<std::string, std::string> flux_name_map;
+
+    if (flux_name_map.empty()) {
+        // --- time_text_embed ---
+        flux_name_map["time_text_embed.timestep_embedder.linear_1.weight"] = "time_in.in_layer.weight";
+        flux_name_map["time_text_embed.timestep_embedder.linear_1.bias"]   = "time_in.in_layer.bias";
+        flux_name_map["time_text_embed.timestep_embedder.linear_2.weight"] = "time_in.out_layer.weight";
+        flux_name_map["time_text_embed.timestep_embedder.linear_2.bias"]   = "time_in.out_layer.bias";
+
+        flux_name_map["time_text_embed.text_embedder.linear_1.weight"] = "vector_in.in_layer.weight";
+        flux_name_map["time_text_embed.text_embedder.linear_1.bias"]   = "vector_in.in_layer.bias";
+        flux_name_map["time_text_embed.text_embedder.linear_2.weight"] = "vector_in.out_layer.weight";
+        flux_name_map["time_text_embed.text_embedder.linear_2.bias"]   = "vector_in.out_layer.bias";
+
+        // guidance
+        flux_name_map["time_text_embed.guidance_embedder.linear_1.weight"] = "guidance_in.in_layer.weight";
+        flux_name_map["time_text_embed.guidance_embedder.linear_1.bias"]   = "guidance_in.in_layer.bias";
+        flux_name_map["time_text_embed.guidance_embedder.linear_2.weight"] = "guidance_in.out_layer.weight";
+        flux_name_map["time_text_embed.guidance_embedder.linear_2.bias"]   = "guidance_in.out_layer.bias";
+
+        // --- context_embedder / x_embedder ---
+        flux_name_map["context_embedder.weight"] = "txt_in.weight";
+        flux_name_map["context_embedder.bias"]   = "txt_in.bias";
+        flux_name_map["x_embedder.weight"]       = "img_in.weight";
+        flux_name_map["x_embedder.bias"]         = "img_in.bias";
+
+        // --- double transformer blocks ---
+        for (int i = 0; i < num_layers; ++i) {
+            std::string block_prefix = "transformer_blocks." + std::to_string(i) + ".";
+            std::string dst_prefix   = "double_blocks." + std::to_string(i) + ".";
+
+            flux_name_map[block_prefix + "norm1.linear.weight"]         = dst_prefix + "img_mod.lin.weight";
+            flux_name_map[block_prefix + "norm1.linear.bias"]           = dst_prefix + "img_mod.lin.bias";
+            flux_name_map[block_prefix + "norm1_context.linear.weight"] = dst_prefix + "txt_mod.lin.weight";
+            flux_name_map[block_prefix + "norm1_context.linear.bias"]   = dst_prefix + "txt_mod.lin.bias";
+
+            // attn
+            flux_name_map[block_prefix + "attn.to_q.weight"] = dst_prefix + "img_attn.qkv.weight";
+            flux_name_map[block_prefix + "attn.to_q.bias"]   = dst_prefix + "img_attn.qkv.bias";
+            flux_name_map[block_prefix + "attn.to_k.weight"] = dst_prefix + "img_attn.qkv.weight.1";
+            flux_name_map[block_prefix + "attn.to_k.bias"]   = dst_prefix + "img_attn.qkv.bias.1";
+            flux_name_map[block_prefix + "attn.to_v.weight"] = dst_prefix + "img_attn.qkv.weight.2";
+            flux_name_map[block_prefix + "attn.to_v.bias"]   = dst_prefix + "img_attn.qkv.bias.2";
+
+            flux_name_map[block_prefix + "attn.add_q_proj.weight"] = dst_prefix + "txt_attn.qkv.weight";
+            flux_name_map[block_prefix + "attn.add_q_proj.bias"]   = dst_prefix + "txt_attn.qkv.bias";
+            flux_name_map[block_prefix + "attn.add_k_proj.weight"] = dst_prefix + "txt_attn.qkv.weight.1";
+            flux_name_map[block_prefix + "attn.add_k_proj.bias"]   = dst_prefix + "txt_attn.qkv.bias.1";
+            flux_name_map[block_prefix + "attn.add_v_proj.weight"] = dst_prefix + "txt_attn.qkv.weight.2";
+            flux_name_map[block_prefix + "attn.add_v_proj.bias"]   = dst_prefix + "txt_attn.qkv.bias.2";
+
+            // norm
+            flux_name_map[block_prefix + "attn.norm_q.weight"]       = dst_prefix + "img_attn.norm.query_norm.scale";
+            flux_name_map[block_prefix + "attn.norm_k.weight"]       = dst_prefix + "img_attn.norm.key_norm.scale";
+            flux_name_map[block_prefix + "attn.norm_added_q.weight"] = dst_prefix + "txt_attn.norm.query_norm.scale";
+            flux_name_map[block_prefix + "attn.norm_added_k.weight"] = dst_prefix + "txt_attn.norm.key_norm.scale";
+
+            // ff
+            flux_name_map[block_prefix + "ff.net.0.proj.weight"] = dst_prefix + "img_mlp.0.weight";
+            flux_name_map[block_prefix + "ff.net.0.proj.bias"]   = dst_prefix + "img_mlp.0.bias";
+            flux_name_map[block_prefix + "ff.net.2.weight"]      = dst_prefix + "img_mlp.2.weight";
+            flux_name_map[block_prefix + "ff.net.2.bias"]        = dst_prefix + "img_mlp.2.bias";
+
+            flux_name_map[block_prefix + "ff_context.net.0.proj.weight"] = dst_prefix + "txt_mlp.0.weight";
+            flux_name_map[block_prefix + "ff_context.net.0.proj.bias"]   = dst_prefix + "txt_mlp.0.bias";
+            flux_name_map[block_prefix + "ff_context.net.2.weight"]      = dst_prefix + "txt_mlp.2.weight";
+            flux_name_map[block_prefix + "ff_context.net.2.bias"]        = dst_prefix + "txt_mlp.2.bias";
+
+            // output projections
+            flux_name_map[block_prefix + "attn.to_out.0.weight"]   = dst_prefix + "img_attn.proj.weight";
+            flux_name_map[block_prefix + "attn.to_out.0.bias"]     = dst_prefix + "img_attn.proj.bias";
+            flux_name_map[block_prefix + "attn.to_add_out.weight"] = dst_prefix + "txt_attn.proj.weight";
+            flux_name_map[block_prefix + "attn.to_add_out.bias"]   = dst_prefix + "txt_attn.proj.bias";
+        }
+
+        // --- single transformer blocks ---
+        for (int i = 0; i < num_single_layers; ++i) {
+            std::string block_prefix = "single_transformer_blocks." + std::to_string(i) + ".";
+            std::string dst_prefix   = "single_blocks." + std::to_string(i) + ".";
+
+            flux_name_map[block_prefix + "norm.linear.weight"] = dst_prefix + "modulation.lin.weight";
+            flux_name_map[block_prefix + "norm.linear.bias"]   = dst_prefix + "modulation.lin.bias";
+
+            flux_name_map[block_prefix + "attn.to_q.weight"] = dst_prefix + "linear1.weight";
+            flux_name_map[block_prefix + "attn.to_q.bias"]   = dst_prefix + "linear1.bias";
+            flux_name_map[block_prefix + "attn.to_k.weight"] = dst_prefix + "linear1.weight.1";
+            flux_name_map[block_prefix + "attn.to_k.bias"]   = dst_prefix + "linear1.bias.1";
+            flux_name_map[block_prefix + "attn.to_v.weight"] = dst_prefix + "linear1.weight.2";
+            flux_name_map[block_prefix + "attn.to_v.bias"]   = dst_prefix + "linear1.bias.2";
+            flux_name_map[block_prefix + "proj_mlp.weight"]  = dst_prefix + "linear1.weight.3";
+            flux_name_map[block_prefix + "proj_mlp.bias"]    = dst_prefix + "linear1.bias.3";
+
+            flux_name_map[block_prefix + "attn.norm_q.weight"] = dst_prefix + "norm.query_norm.scale";
+            flux_name_map[block_prefix + "attn.norm_k.weight"] = dst_prefix + "norm.key_norm.scale";
+            flux_name_map[block_prefix + "proj_out.weight"]    = dst_prefix + "linear2.weight";
+            flux_name_map[block_prefix + "proj_out.bias"]      = dst_prefix + "linear2.bias";
+        }
+
+        // --- final layers ---
+        flux_name_map["proj_out.weight"]        = "final_layer.linear.weight";
+        flux_name_map["proj_out.bias"]          = "final_layer.linear.bias";
+        flux_name_map["norm_out.linear.weight"] = "final_layer.adaLN_modulation.1.weight";
+        flux_name_map["norm_out.linear.bias"]   = "final_layer.adaLN_modulation.1.bias";
+    }
+
+    replace_with_prefix_map(name, flux_name_map);
+
+    return name;
+}
+
+std::string convert_diffusion_model_name(std::string name, std::string prefix, SDVersion version) {
+    if (sd_version_is_sd1(version) || sd_version_is_sd2(version)) {
+        name = convert_diffusers_unet_to_original_sd1(name);
+    } else if (sd_version_is_sdxl(version)) {
+        name = convert_diffusers_unet_to_original_sdxl(name);
+    } else if (sd_version_is_sd3(version)) {
+        name = convert_diffusers_dit_to_original_sd3(name);
+    } else if (sd_version_is_flux(version)) {
+        name = convert_diffusers_dit_to_original_flux(name);
+    }
+    return name;
+}
+
+std::string convert_diffusers_vae_to_original_sd1(std::string name) {
+    static const std::vector<std::pair<std::string, std::string>> vae_conversion_map_base = {
+        {"nin_shortcut", "conv_shortcut"},
+        {"norm_out", "conv_norm_out"},
+        {"mid.attn_1.", "mid_block.attentions.0."},
+    };
+
+    static std::vector<std::pair<std::string, std::string>> vae_conversion_map_layer;
+    if (vae_conversion_map_layer.empty()) {
+        for (int i = 0; i < 4; ++i) {
+            // --- encoder down blocks ---
+            for (int j = 0; j < 2; ++j) {
+                std::string hf_down_prefix = "encoder.down_blocks." + std::to_string(i) + ".resnets." + std::to_string(j) + ".";
+                std::string sd_down_prefix = "encoder.down." + std::to_string(i) + ".block." + std::to_string(j) + ".";
+                vae_conversion_map_layer.emplace_back(sd_down_prefix, hf_down_prefix);
+            }
+
+            if (i < 3) {
+                std::string hf_downsample_prefix = "down_blocks." + std::to_string(i) + ".downsamplers.0.";
+                std::string sd_downsample_prefix = "down." + std::to_string(i) + ".downsample.";
+                vae_conversion_map_layer.emplace_back(sd_downsample_prefix, hf_downsample_prefix);
+
+                std::string hf_upsample_prefix = "up_blocks." + std::to_string(i) + ".upsamplers.0.";
+                std::string sd_upsample_prefix = "up." + std::to_string(3 - i) + ".upsample.";
+                vae_conversion_map_layer.emplace_back(sd_upsample_prefix, hf_upsample_prefix);
+            }
+
+            // --- decoder up blocks (reverse) ---
+            for (int j = 0; j < 3; ++j) {
+                std::string hf_up_prefix = "decoder.up_blocks." + std::to_string(i) + ".resnets." + std::to_string(j) + ".";
+                std::string sd_up_prefix = "decoder.up." + std::to_string(3 - i) + ".block." + std::to_string(j) + ".";
+                vae_conversion_map_layer.emplace_back(sd_up_prefix, hf_up_prefix);
+            }
+        }
+
+        // --- mid block (encoder + decoder) ---
+        for (int i = 0; i < 2; ++i) {
+            std::string hf_mid_res_prefix = "mid_block.resnets." + std::to_string(i) + ".";
+            std::string sd_mid_res_prefix = "mid.block_" + std::to_string(i + 1) + ".";
+            vae_conversion_map_layer.emplace_back(sd_mid_res_prefix, hf_mid_res_prefix);
+        }
+    }
+
+    static const std::vector<std::pair<std::string, std::string>> vae_conversion_map_attn = {
+        {"norm.", "group_norm."},
+        {"q.", "query."},
+        {"k.", "key."},
+        {"v.", "value."},
+        {"proj_out.", "proj_attn."},
+    };
+
+    static const std::vector<std::pair<std::string, std::string>> vae_extra_conversion_map = {
+        {"to_q", "q"},
+        {"to_k", "k"},
+        {"to_v", "v"},
+        {"to_out.0", "proj_out"},
+    };
+
+    std::string result = name;
+
+    for (const auto& p : vae_conversion_map_base) {
+        size_t pos = result.find(p.second);
+        if (pos != std::string::npos) {
+            result.replace(pos, p.second.size(), p.first);
+        }
+    }
+
+    for (const auto& p : vae_conversion_map_layer) {
+        size_t pos = result.find(p.second);
+        if (pos != std::string::npos) {
+            result.replace(pos, p.second.size(), p.first);
+        }
+    }
+
+    if (name.find("attentions") != std::string::npos) {
+        for (const auto& p : vae_conversion_map_attn) {
+            size_t pos = result.find(p.second);
+            if (pos != std::string::npos) {
+                result.replace(pos, p.second.size(), p.first);
+            }
+        }
+    }
+
+    if (result.find("mid.attn_1.") != std::string::npos) {
+        for (const auto& p : vae_extra_conversion_map) {
+            size_t pos = result.find(p.first);
+            if (pos != std::string::npos) {
+                result.replace(pos, p.first.size(), p.second);
+            }
+        }
+    }
+
+    return result;
+}
+
+std::string convert_first_stage_model_name(std::string name, std::string prefix) {
+    name = convert_diffusers_vae_to_original_sd1(name);
+    return name;
+}
+
+std::string convert_pmid_name(const std::string& name) {
+    static std::unordered_map<std::string, std::string> pmid_name_map = {
+        {"pmid.vision_model.visual_projection.weight", "pmid.visual_projection.weight"},
+    };
+    if (pmid_name_map.find(name) != pmid_name_map.end()) {
+        return pmid_name_map[name];
+    }
+    return name;
+}
+
+std::string convert_pmid_v2_name(const std::string& name) {
+    static std::unordered_map<std::string, std::string> pmid_v2_name_map = {
+        {"pmid.qformer_perceiver.perceiver_resampler.layers.0.1.1.weight",
+         "pmid.qformer_perceiver.perceiver_resampler.layers.0.1.1.fc1.weight"},
+        {"pmid.qformer_perceiver.perceiver_resampler.layers.0.1.3.weight",
+         "pmid.qformer_perceiver.perceiver_resampler.layers.0.1.1.fc2.weight"},
+        {"pmid.qformer_perceiver.perceiver_resampler.layers.1.1.1.weight",
+         "pmid.qformer_perceiver.perceiver_resampler.layers.1.1.1.fc1.weight"},
+        {"pmid.qformer_perceiver.perceiver_resampler.layers.1.1.3.weight",
+         "pmid.qformer_perceiver.perceiver_resampler.layers.1.1.1.fc2.weight"},
+        {"pmid.qformer_perceiver.perceiver_resampler.layers.2.1.1.weight",
+         "pmid.qformer_perceiver.perceiver_resampler.layers.2.1.1.fc1.weight"},
+        {"pmid.qformer_perceiver.perceiver_resampler.layers.2.1.3.weight",
+         "pmid.qformer_perceiver.perceiver_resampler.layers.2.1.1.fc2.weight"},
+        {"pmid.qformer_perceiver.perceiver_resampler.layers.3.1.1.weight",
+         "pmid.qformer_perceiver.perceiver_resampler.layers.3.1.1.fc1.weight"},
+        {"pmid.qformer_perceiver.perceiver_resampler.layers.3.1.3.weight",
+         "pmid.qformer_perceiver.perceiver_resampler.layers.3.1.1.fc2.weight"},
+        {"pmid.qformer_perceiver.token_proj.0.bias",
+         "pmid.qformer_perceiver.token_proj.fc1.bias"},
+        {"pmid.qformer_perceiver.token_proj.2.bias",
+         "pmid.qformer_perceiver.token_proj.fc2.bias"},
+        {"pmid.qformer_perceiver.token_proj.0.weight",
+         "pmid.qformer_perceiver.token_proj.fc1.weight"},
+        {"pmid.qformer_perceiver.token_proj.2.weight",
+         "pmid.qformer_perceiver.token_proj.fc2.weight"},
+    };
+    if (pmid_v2_name_map.find(name) != pmid_v2_name_map.end()) {
+        return pmid_v2_name_map[name];
+    }
+    return name;
+}
+
+std::string convert_sep_to_dot(std::string name) {
+    const std::vector<std::string> protected_tokens = {
+        "self_attn",
+        "out_proj",
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "to_k",
+        "to_q",
+        "to_v",
+        "to_out",
+        "text_model",
+        "down_blocks",
+        "mid_block",
+        "up_block",
+        "proj_in",
+        "proj_out",
+        "transformer_blocks",
+        "single_transformer_blocks",
+        "diffusion_model",
+        "cond_stage_model",
+        "first_stage_model",
+        "conv_in",
+        "conv_out",
+        "lora_down",
+        "lora_up",
+        "diff_b",
+        "hada_w1_a",
+        "hada_w1_b",
+        "hada_w2_a",
+        "hada_w2_b",
+        "hada_t1",
+        "hada_t2",
+        ".lokr_w1",
+        ".lokr_w1_a",
+        ".lokr_w1_b",
+        ".lokr_w2",
+        ".lokr_w2_a",
+        ".lokr_w2_b",
+        "time_emb_proj",
+        "conv_shortcut",
+        "time_embedding",
+        "conv_norm_out",
+        "double_blocks",
+        "txt_attn",
+        "img_attn",
+        "input_blocks",
+        "output_blocks",
+        "middle_block",
+        "skip_connection",
+        "emb_layers",
+        "in_layers",
+        "out_layers",
+        "add_q_proj",
+        "add_k_proj",
+        "add_v_proj",
+        "add_out_proj",
+        "ff_context",
+        "norm_added_q",
+        "norm_added_v",
+        "to_add_out"};
+
+    // record the positions of underscores that should NOT be replaced
+    std::unordered_set<size_t> protected_positions;
+
+    for (const auto& token : protected_tokens) {
+        size_t start = 0;
+        while ((start = name.find(token, start)) != std::string::npos) {
+            size_t local_pos = token.find('_');
+            while (local_pos != std::string::npos) {
+                protected_positions.insert(start + local_pos);
+                local_pos = token.find('_', local_pos + 1);
+            }
+            start += token.size();
+        }
+    }
+
+    for (size_t i = 0; i < name.size(); ++i) {
+        if (name[i] == '_' && !protected_positions.count(i)) {
+            name[i] = '.';
+        }
+    }
+
+    return name;
+}
+
+std::string convert_tensor_name(std::string name, SDVersion version) {
+    bool is_lora                             = false;
+    bool is_lycoris_underline                = false;
+    std::vector<std::string> lora_prefix_vec = {
+        "lora.lora.",
+        "lora.lora_",
+        "lora.lycoris_",
+        "lora.lycoris.",
+        "lora.",
+    };
+    for (const auto& prefix : lora_prefix_vec) {
+        if (starts_with(name, prefix)) {
+            is_lora = true;
+            name    = name.substr(prefix.size());
+            if (contains(prefix, "lycoris_")) {
+                is_lycoris_underline = true;
+            }
+            break;
+        }
+    }
+    // preprocess lora tensor name
+    if (is_lora) {
+        std::map<std::string, std::string> lora_suffix_map = {
+            {".lora_down.weight", ".weight.lora_down"},
+            {".lora_up.weight", ".weight.lora_up"},
+            {".lora.down.weight", ".weight.lora_down"},
+            {".lora.up.weight", ".weight.lora_up"},
+            {"_lora.down.weight", ".weight.lora_down"},
+            {"_lora.up.weight", ".weight.lora_up"},
+            {".lora_A.weight", ".weight.lora_down"},
+            {".lora_B.weight", ".weight.lora_up"},
+            {".lora_A.default.weight", ".weight.lora_down"},
+            {".lora_B.default.weight", ".weight.lora_up"},
+            {".lora_linear", ".weight.alpha"},
+            {".alpha", ".weight.alpha"},
+            {".scale", ".weight.scale"},
+            {".diff", ".weight.diff"},
+            {".diff_b", ".bias.diff"},
+            {".hada_w1_a", ".weight.hada_w1_a"},
+            {".hada_w1_b", ".weight.hada_w1_b"},
+            {".hada_w2_a", ".weight.hada_w2_a"},
+            {".hada_w2_b", ".weight.hada_w2_b"},
+            {".hada_t1", ".weight.hada_t1"},
+            {".hada_t2", ".weight.hada_t2"},
+            {".lokr_w1", ".weight.lokr_w1"},
+            {".lokr_w1_a", ".weight.lokr_w1_a"},
+            {".lokr_w1_b", ".weight.lokr_w1_b"},
+            {".lokr_w2", ".weight.lokr_w2"},
+            {".lokr_w2_a", ".weight.lokr_w2_a"},
+            {".lokr_w2_b", ".weight.lokr_w2_b"},
+        };
+
+        for (const auto& [old_suffix, new_suffix] : lora_suffix_map) {
+            if (ends_with(name, old_suffix)) {
+                name.replace(name.size() - old_suffix.size(), old_suffix.size(), new_suffix);
+                break;
+            }
+        }
+
+        size_t pos = name.find(".processor");
+        if (pos != std::string::npos) {
+            name.replace(pos, strlen(".processor"), "");
+        }
+
+        std::vector<std::string> dit_prefix_vec = {
+            "transformer_blocks",
+            "single_transformer_blocks",
+        };
+        for (const auto& prefix : dit_prefix_vec) {
+            if (starts_with(name, prefix)) {
+                name = "transformer." + name;
+                break;
+            }
+        }
+
+        if (sd_version_is_unet(version) || is_lycoris_underline) {
+            name = convert_sep_to_dot(name);
+        }
+    }
+
+    std::vector<std::pair<std::string, std::string>> prefix_map = {
+        {"diffusion_model.", "model.diffusion_model."},
+        {"unet.", "model.diffusion_model."},
+        {"transformer.", "model.diffusion_model."},  // dit
+        {"vae.", "first_stage_model."},
+        {"text_encoder.", "cond_stage_model.transformer."},
+        {"te.", "cond_stage_model.transformer."},
+        {"text_encoder.2.", "cond_stage_model.1.transformer."},
+        {"conditioner.embedders.0.open_clip.", "cond_stage_model."},
+        // https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0
+        {"conditioner.embedders.0.", "cond_stage_model."},
+        {"conditioner.embedders.1.", "cond_stage_model.1."},
+        // {"te2.text_model.encoder.layers.", "cond_stage_model.1.model.transformer.resblocks."},
+        {"te2.", "cond_stage_model.1.transformer."},
+        {"te1.", "cond_stage_model.transformer."},
+    };
+
+    replace_with_prefix_map(name, prefix_map);
+
+    // diffusion model
+    {
+        std::vector<std::string> diffuison_model_prefix_vec = {
+            "model.diffusion_model.",
+        };
+        for (const auto& prefix : diffuison_model_prefix_vec) {
+            if (starts_with(name, prefix)) {
+                name = convert_diffusion_model_name(name.substr(prefix.size()), prefix, version);
+                name = prefix + name;
+                break;
+            }
+        }
+    }
+
+    // cond_stage_model
+    {
+        std::vector<std::string> cond_stage_model_prefix_vec = {
+            "cond_stage_model.1.",
+            "cond_stage_model.",
+            "conditioner.embedders.",
+            "text_encoders.",
+        };
+        for (const auto& prefix : cond_stage_model_prefix_vec) {
+            if (starts_with(name, prefix)) {
+                name = convert_cond_stage_model_name(name.substr(prefix.size()), prefix);
+                name = prefix + name;
+                break;
+            }
+        }
+    }
+
+    // first_stage_model
+    {
+        std::vector<std::string> first_stage_model_prefix_vec = {
+            "first_stage_model.",
+            "vae.",
+        };
+        for (const auto& prefix : first_stage_model_prefix_vec) {
+            if (starts_with(name, prefix)) {
+                name = convert_first_stage_model_name(name.substr(prefix.size()), prefix);
+                name = prefix + name;
+                break;
+            }
+        }
+    }
+
+    // pmid
+    {
+        if (starts_with(name, "pmid.")) {
+            name = convert_pmid_name(name);
+        }
+        if (starts_with(name, "pmid.qformer_perceiver")) {
+            name = convert_pmid_v2_name(name);
+        }
+    }
+
+    // controlnet
+    {
+        if (starts_with(name, "control_model.")) {  // for controlnet pth models
+            size_t pos = name.find('.');
+            if (pos != std::string::npos) {
+                name = name.substr(pos + 1);
+            }
+        }
+    }
+
+    if (is_lora) {
+        name = "lora." + name;
+    }
+
+    return name;
+}

--- a/name_conversion.h
+++ b/name_conversion.h
@@ -1,0 +1,10 @@
+#ifndef __NAME_CONVERSTION_H__
+#define __NAME_CONVERSTION_H__
+
+#include <string>
+
+#include "model.h"
+
+std::string convert_tensor_name(std::string name, SDVersion version);
+
+#endif  // __NAME_CONVERSTION_H__

--- a/ordered_map.hpp
+++ b/ordered_map.hpp
@@ -1,0 +1,177 @@
+#ifndef __ORDERED_MAP_HPP__
+#define __ORDERED_MAP_HPP__
+
+#include <iostream>
+#include <list>
+#include <string>
+#include <unordered_map>
+
+#include <initializer_list>
+#include <iterator>
+#include <list>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+
+template <typename Key, typename T>
+class OrderedMap {
+public:
+    using key_type        = Key;
+    using mapped_type     = T;
+    using value_type      = std::pair<const Key, T>;
+    using list_type       = std::list<value_type>;
+    using size_type       = typename list_type::size_type;
+    using difference_type = typename list_type::difference_type;
+    using iterator        = typename list_type::iterator;
+    using const_iterator  = typename list_type::const_iterator;
+
+private:
+    list_type data_;
+    std::unordered_map<Key, iterator> index_;
+
+public:
+    // --- constructors ---
+    OrderedMap() = default;
+
+    OrderedMap(std::initializer_list<value_type> init) {
+        for (const auto& kv : init)
+            insert(kv);
+    }
+
+    OrderedMap(const OrderedMap&)                = default;
+    OrderedMap(OrderedMap&&) noexcept            = default;
+    OrderedMap& operator=(const OrderedMap&)     = default;
+    OrderedMap& operator=(OrderedMap&&) noexcept = default;
+
+    // --- element access ---
+    T& at(const Key& key) {
+        auto it = index_.find(key);
+        if (it == index_.end())
+            throw std::out_of_range("OrderedMap::at: key not found");
+        return it->second->second;
+    }
+
+    const T& at(const Key& key) const {
+        auto it = index_.find(key);
+        if (it == index_.end())
+            throw std::out_of_range("OrderedMap::at: key not found");
+        return it->second->second;
+    }
+
+    T& operator[](const Key& key) {
+        auto it = index_.find(key);
+        if (it == index_.end()) {
+            data_.emplace_back(key, T{});
+            auto iter   = std::prev(data_.end());
+            index_[key] = iter;
+            return iter->second;
+        }
+        return it->second->second;
+    }
+
+    // --- iterators ---
+    iterator begin() noexcept { return data_.begin(); }
+    const_iterator begin() const noexcept { return data_.begin(); }
+    const_iterator cbegin() const noexcept { return data_.cbegin(); }
+
+    iterator end() noexcept { return data_.end(); }
+    const_iterator end() const noexcept { return data_.end(); }
+    const_iterator cend() const noexcept { return data_.cend(); }
+
+    // --- capacity ---
+    bool empty() const noexcept { return data_.empty(); }
+    size_type size() const noexcept { return data_.size(); }
+
+    // --- modifiers ---
+    void clear() noexcept {
+        data_.clear();
+        index_.clear();
+    }
+
+    std::pair<iterator, bool> insert(const value_type& value) {
+        auto it = index_.find(value.first);
+        if (it != index_.end()) {
+            return {it->second, false};
+        }
+        data_.push_back(value);
+        auto iter           = std::prev(data_.end());
+        index_[value.first] = iter;
+        return {iter, true};
+    }
+
+    std::pair<iterator, bool> insert(value_type&& value) {
+        auto it = index_.find(value.first);
+        if (it != index_.end()) {
+            return {it->second, false};
+        }
+        data_.push_back(std::move(value));
+        auto iter           = std::prev(data_.end());
+        index_[iter->first] = iter;
+        return {iter, true};
+    }
+
+    void erase(const Key& key) {
+        auto it = index_.find(key);
+        if (it != index_.end()) {
+            data_.erase(it->second);
+            index_.erase(it);
+        }
+    }
+
+    iterator erase(iterator pos) {
+        index_.erase(pos->first);
+        return data_.erase(pos);
+    }
+
+    // --- lookup ---
+    size_type count(const Key& key) const {
+        return index_.count(key);
+    }
+
+    iterator find(const Key& key) {
+        auto it = index_.find(key);
+        if (it == index_.end())
+            return data_.end();
+        return it->second;
+    }
+
+    const_iterator find(const Key& key) const {
+        auto it = index_.find(key);
+        if (it == index_.end())
+            return data_.end();
+        return it->second;
+    }
+
+    bool contains(const Key& key) const {
+        return index_.find(key) != index_.end();
+    }
+
+    // --- comparison ---
+    bool operator==(const OrderedMap& other) const {
+        return data_ == other.data_;
+    }
+
+    bool operator!=(const OrderedMap& other) const {
+        return !(*this == other);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        value_type value(std::forward<Args>(args)...);
+        auto it = index_.find(value.first);
+        if (it != index_.end()) {
+            return {it->second, false};
+        }
+        data_.push_back(std::move(value));
+        auto iter           = std::prev(data_.end());
+        index_[iter->first] = iter;
+        return {iter, true};
+    }
+
+    void swap(OrderedMap& other) noexcept {
+        data_.swap(other.data_);
+        index_.swap(other.index_);
+    }
+};
+
+#endif  // __ORDERED_MAP_HPP__

--- a/pmid.hpp
+++ b/pmid.hpp
@@ -578,7 +578,7 @@ struct PhotoMakerIDEmbed : public GGMLRunner {
                       const std::string& file_path = "",
                       const std::string& prefix    = "")
         : file_path(file_path), GGMLRunner(backend, offload_params_to_cpu), model_loader(ml) {
-        if (!model_loader->init_from_file(file_path, prefix)) {
+        if (!model_loader->init_from_file_and_convert_name(file_path, prefix)) {
             load_failed = true;
         }
     }

--- a/qwen_image.hpp
+++ b/qwen_image.hpp
@@ -644,7 +644,7 @@ namespace Qwen {
             ggml_type model_data_type = GGML_TYPE_Q8_0;
 
             ModelLoader model_loader;
-            if (!model_loader.init_from_file(file_path, "model.diffusion_model.")) {
+            if (!model_loader.init_from_file_and_convert_name(file_path, "model.diffusion_model.")) {
                 LOG_ERROR("init model loader from file failed: '%s'", file_path.c_str());
                 return;
             }

--- a/qwenvl.hpp
+++ b/qwenvl.hpp
@@ -1342,7 +1342,7 @@ namespace Qwen {
             ggml_type model_data_type = GGML_TYPE_F16;
 
             ModelLoader model_loader;
-            if (!model_loader.init_from_file(file_path, "qwen2vl.")) {
+            if (!model_loader.init_from_file_and_convert_name(file_path, "qwen2vl.")) {
                 LOG_ERROR("init model loader from file failed: '%s'", file_path.c_str());
                 return;
             }

--- a/t5.hpp
+++ b/t5.hpp
@@ -1004,7 +1004,7 @@ struct T5Embedder {
         ggml_type model_data_type = GGML_TYPE_F16;
 
         ModelLoader model_loader;
-        if (!model_loader.init_from_file(file_path)) {
+        if (!model_loader.init_from_file_and_convert_name(file_path)) {
             LOG_ERROR("init model loader from file failed: '%s'", file_path.c_str());
             return;
         }

--- a/tae.hpp
+++ b/tae.hpp
@@ -222,7 +222,7 @@ struct TinyAutoEncoder : public GGMLRunner {
         }
 
         ModelLoader model_loader;
-        if (!model_loader.init_from_file(file_path)) {
+        if (!model_loader.init_from_file_and_convert_name(file_path)) {
             LOG_ERROR("init taesd model loader from file failed: '%s'", file_path.c_str());
             return false;
         }

--- a/upscaler.cpp
+++ b/upscaler.cpp
@@ -42,7 +42,7 @@ struct UpscalerGGML {
         backend = ggml_backend_sycl_init(0);
 #endif
         ModelLoader model_loader;
-        if (!model_loader.init_from_file(esrgan_path)) {
+        if (!model_loader.init_from_file_and_convert_name(esrgan_path)) {
             LOG_ERROR("init model loader from file failed: '%s'", esrgan_path.c_str());
         }
         model_loader.set_wtype_override(model_data_type);

--- a/wan.hpp
+++ b/wan.hpp
@@ -1271,7 +1271,7 @@ namespace WAN {
                 vae->get_param_tensors(tensors, "first_stage_model");
 
                 ModelLoader model_loader;
-                if (!model_loader.init_from_file(file_path, "vae.")) {
+                if (!model_loader.init_from_file_and_convert_name(file_path, "vae.")) {
                     LOG_ERROR("init model loader from file failed: '%s'", file_path.c_str());
                     return;
                 }
@@ -2255,7 +2255,7 @@ namespace WAN {
             LOG_INFO("loading from '%s'", file_path.c_str());
 
             ModelLoader model_loader;
-            if (!model_loader.init_from_file(file_path, "model.diffusion_model.")) {
+            if (!model_loader.init_from_file_and_convert_name(file_path, "model.diffusion_model.")) {
                 LOG_ERROR("init model loader from file failed: '%s'", file_path.c_str());
                 return;
             }


### PR DESCRIPTION
Tested LoRA models
```sh
# SD1.x
# https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5/tree/main?show_file_info=v1-5-pruned-emaonly.safetensors

# unet|lora_down+lora_up+alpha|hf
# https://huggingface.co/latent-consistency/lcm-lora-sdv1-5/tree/main?show_file_info=pytorch_lora_weights.safetensors
.\bin\Release\sd.exe -m ..\..\stable-diffusion-webui\models\Stable-diffusion\v1-5-pruned-emaonly.safetensors --lora-model-dir ..\..\stable-diffusion-webui\models\Lora\ -p "a lovely cat<lora:lcm-lora-sdv1-5:1>" -v --cfg-scale 1 --steps 4

# unet+te|lora_down+lora_up+alpha|hf
# https://huggingface.co/soinov/My_models/tree/main/Lora/Effects?show_file_info=Lora%2FEffects%2Fmarblesh.safetensors
.\bin\Release\sd.exe -m ..\..\stable-diffusion-webui\models\Stable-diffusion\v1-5-pruned-emaonly.safetensors --lora-model-dir ..\..\stable-diffusion-webui\models\Lora\ -p "a lovely cat<lora:marblesh:1>" -v

# unet+te|lora_down+lora_up+alpha|hf
.\bin\Release\sd.exe -m ..\..\stable-diffusion-webui\models\Stable-diffusion\v1-5-pruned-emaonly.safetensors --lora-model-dir ..\..\stable-diffusion-webui\models\Lora\ -p "a lovely cat<lora:VolleyballUniform_v20LyCORIS:1>" -v

# uent+te|loha(hada_w1_a+hada_w1_b+hada_w2_a+hada_w2_b+alpha)|hf
# https://huggingface.co/Tymy/cepotopoto/tree/0410fc780e7b15408ab589c65baf1b4fa88b1fb6?show_file_info=%5BLoHa%5D+Longan%E7%AB%9C%E7%9C%BC+Style+%28With+multires+noise+version%29.safetensors
.\bin\Release\sd.exe -m ..\..\stable-diffusion-webui\models\Stable-diffusion\v1-5-pruned-emaonly.safetensors --lora-model-dir ..\..\stable-diffusion-webui\models\Lora\ -p "a lovely cat<lora:[LoHa] Longan Style (With multires noise version):1>" -v

# uent+te|lokr(lokr_w1+lokr_w2+alpha)|hf
# https://huggingface.co/CyberHarem/surtr_arknights_lokr/tree/main/4250?not-for-all-audiences=true&show_file_info=4250%2Fsurtr_arknights.safetensors
.\bin\Release\sd.exe -m ..\..\stable-diffusion-webui\models\Stable-diffusion\v1-5-pruned-emaonly.safetensors --lora-model-dir ..\..\stable-diffusion-webui\models\Lora\ -p "a lovely cat<lora:surtr_arknights:1>" -v



# SDXL
# https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0/tree/main?show_file_info=sd_xl_base_1.0.safetensors

# unet|lora_down+lora_up+alpha|hf
# https://huggingface.co/latent-consistency/lcm-lora-sdxl/tree/main?show_file_info=pytorch_lora_weights.safetensors
.\bin\Release\sd.exe -m ..\..\stable-diffusion-webui\models\Stable-diffusion\sd_xl_base_1.0.safetensors --vae ..\..\stable-diffusion-webui\models\VAE\sdxl_vae-fp16-fix.safetensors --lora-model-dir ..\..\stable-diffusion-webui\models\Lora\ -p "a lovely cat<lora:lcm-lora-xl:1>" -v   -H 1024 -W 1024 --cfg-scale 1 --steps 4


# unet+te1+te2|lora_down+lora_up+alpha|hf
# https://huggingface.co/Alptekinege/loras/tree/02b20c7efa88eafb5c7f3efaad1a5337762aba99?show_file_info=MJ52_v2.0.safetensors
.\bin\Release\sd.exe -m ..\..\stable-diffusion-webui\models\Stable-diffusion\sd_xl_base_1.0.safetensors --vae ..\..\stable-diffusion-webui\models\VAE\sdxl_vae-fp16-fix.safetensors --lora-model-dir ..\..\stable-diffusion-webui\models\Lora\ -p "a lovely cat<lora:MJ52_v2.0:1>" -v -H 1024 -W 1024 --diffusion-fa


# FLUX
# https://huggingface.co/black-forest-labs/FLUX.1-dev/tree/main?show_file_info=flux1-dev.safetensors

# diffusion_model|lora_down+lora_up|orig
# https://huggingface.co/XLabs-AI/flux-lora-collection/tree/main?show_file_info=anime_lora_comfy_converted.safetensors
.\bin\Release\sd.exe --diffusion-model  ..\models\flux1-dev-q8_0.gguf --vae ..\..\ComfyUI\models\vae\ae.sft --clip_l ..\..\ComfyUI\models\clip\clip_l.safetensors --t5xxl ..\..\ComfyUI\models\clip\t5xxl_fp16.safetensors  -p "a lovely cat holding a sign says 'flux.cpp'<lora:anime_lora_comfy_converted:1>" --cfg-scale 1.0 --sampling-method euler -v --lora-model-dir ../models --offload-to-cpu

# diffusion_model|lora_A+lora_B|hf
# https://huggingface.co/saquiboye/omini-kontext-character/tree/main?show_file_info=character_5000.safetensors
.\bin\Release\sd.exe --diffusion-model  ..\models\flux1-kontext-dev-Q8_0.gguf --vae ..\..\ComfyUI\models\vae\ae.sft --clip_l ..\..\ComfyUI\models\clip\clip_l.safetensors --t5xxl ..\..\ComfyUI\models\clip\t5xxl_fp16.safetensors  -W 1024 -H 512 -p "Add the character to the scene  <lora:character_5000:1>" -r balloon.png -r boy.png --cfg-scale 1 --sampling-method euler --color --lora-model-dir ..\..\ComfyUI\models\loras --diffusion-fa -v --offload-to-cpu

#diffusion_model|lora_A+lora_B|hf
# https://huggingface.co/eduaaart/anadearmas-flux/tree/main?show_file_info=ana_de_armas_flux_lora_v1_000002000.safetensors
.\bin\Release\sd.exe --diffusion-model  ..\models\flux1-dev-q8_0.gguf --vae ..\..\ComfyUI\models\vae\ae.sft --clip_l ..\..\ComfyUI\models\clip\clip_l.safetensors --t5xxl ..\..\ComfyUI\models\clip\t5xxl_fp16.safetensors  -p "a lovely cat holding a sign says 'flux.cpp'<lora:ana_de_armas_flux_lora_v1_000002000:1>" --cfg-scale 1.0 --sampling-method euler -v --lora-model-dir ..\..\ComfyUI\models\loras --offload-to-cpu

#diffusion_model|lokr(lokr_w1+lokr_w2+alpha)|hf
# https://huggingface.co/toxicwind/minimalclass-lokr-flux/tree/main?show_file_info=pytorch_lora_weights.safetensors
.\bin\Release\sd.exe --diffusion-model  ..\models\flux1-dev-q8_0.gguf --vae ..\..\ComfyUI\models\vae\ae.sft --clip_l ..\..\ComfyUI\models\clip\clip_l.safetensors --t5xxl ..\..\ComfyUI\models\clip\t5xxl_fp16.safetensors  -p "a lovely cat holding a sign says 'flux.cpp'<lora:minimalclass-lokr-flux:1>" --cfg-scale 1.0 --sampling-method euler -v --lora-model-dir ..\..\stable-diffusion-webui\models\Lora\  --offload-to-cpu

# Wan2.1 14B

# diffusion_model|lora_down+lora_up+diff+diff_b|original
# https://huggingface.co/vrgamedevgirl84/Wan14BT2VFusioniX/tree/main/FusionX_LoRa?show_file_info=FusionX_LoRa%2FWan2.1_T2V_14B_FusionX_LoRA.safetensors
.\bin\Release\sd.exe -M vid_gen --diffusion-model  ..\..\ComfyUI\models\diffusion_models\wan2.1-t2v-14b-Q8_0.gguf --vae ..\..\ComfyUI\models\vae\wan_2.1_vae.safetensors --t5xxl ..\..\ComfyUI\models\text_encoders\umt5-xxl-encoder-Q8_0.gguf  -p "a lovely cat<lora:Wan2.1_T2V_14B_FusionX_LoRA:1>" --cfg-scale 1.0 --steps 8 --sampling-method euler -v -n "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" -W 832 -H 480 --diffusion-fa --offload-to-cpu  --lora-model-dir ..\..\ComfyUI\models\loras


# Wan2.2 14B

# diffusion_model|lora_down+lora_up+alpha|original
# https://huggingface.co/Comfy-Org/Wan_2.2_ComfyUI_Repackaged/tree/main/split_files/loras?show_file_info=split_files%2Floras%2Fwan2.2_t2v_lightx2v_4steps_lora_v1.1_low_noise.safetensors
.\bin\Release\sd.exe -M vid_gen --diffusion-model  ..\..\ComfyUI\models\diffusion_models\Wan2.2-T2V-A14B-LowNoise-Q8_0.gguf --high-noise-diffusion-model  ..\..\ComfyUI\models\diffusion_models\Wan2.2-T2V-A14B-HighNoise-Q8_0.gguf --vae ..\..\ComfyUI\models\vae\wan_2.1_vae.safetensors --t5xxl ..\..\ComfyUI\models\text_encoders\umt5-xxl-encoder-Q8_0.gguf  -p "a lovely cat<lora:wan2.2_t2v_lightx2v_4steps_lora_v1.1_low_noise:1><lora:|high_noise|wan2.2_t2v_lightx2v_4steps_lora_v1.1_high_noise:1>" --cfg-scale 3.5 --sampling-method euler --steps 4 --high-noise-cfg-scale 3.5 --high-noise-sampling-method euler --high-noise-steps 4 -v -n "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走" -W 832 -H 480 --diffusion-fa --offload-to-cpu --lora-model-dir ..\..\ComfyUI\models\loras


# Qwen Image

# https://huggingface.co/dx8152/Qwen-Edit-2509-Multiple-angles/tree/main?show_file_info=%E9%95%9C%E5%A4%B4%E8%BD%AC%E6%8D%A2.safetensors
# dit|lora_A.default+lora_B.default|hf
.\bin\Release\sd.exe --diffusion-model  ..\..\ComfyUI\models\diffusion_models\Qwen-Image-Edit-2509-Q8_0.gguf --vae ..\..\ComfyUI\models\vae\qwen_image_vae.safetensors  --qwen2vl ..\..\ComfyUI\models\text_encoders\Qwen2.5-VL-7B-Instruct-Q8_0.gguf --qwen2vl_vision ..\..\ComfyUI\models\text_encoders\Qwen2.5-VL-7B-Instruct.mmproj-Q8_0.gguf --cfg-scale 2.5 --sampling-method euler -v --offload-to-cpu --diffusion-fa --flow-shift 3 -r ..\assets\flux\flux1-dev-q8_0.png -p "Rotate the camera 45 degrees to the right.<lora:qwen_image/multiple_angles:1>"  --lora-model-dir ..\..\ComfyUI\models\loras


# https://huggingface.co/lovis93/next-scene-qwen-image-lora-2509/tree/main?show_file_info=next-scene_lora-v2-3000.safetensors
# dit|lora_A+lora_B|hf
.\bin\Release\sd.exe --diffusion-model  ..\..\ComfyUI\models\diffusion_models\Qwen-Image-Edit-2509-Q8_0.gguf --vae ..\..\ComfyUI\models\vae\qwen_image_vae.safetensors  --qwen2vl ..\..\ComfyUI\models\text_encoders\Qwen2.5-VL-7B-Instruct-Q8_0.gguf --qwen2vl_vision ..\..\ComfyUI\models\text_encoders\Qwen2.5-VL-7B-Instruct.mmproj-Q8_0.gguf --cfg-scale 2.5 --sampling-method euler -v --offload-to-cpu --diffusion-fa --flow-shift 3 -r ..\assets\flux\flux1-dev-q8_0.png -p "Next Scene: The camera pushes in from behind the cat, showing cat gripping the rail as the storm rages and lightning illuminates his weathered face. realistic cinematic style<lora:qwen_image/next-scene_lora-v2-3000:1>"  --lora-model-dir ..\..\ComfyUI\models\loras
```