### PR TITLE
fix: specify enum modifier in sd_set_preview_callback signature

### DIFF
--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -267,7 +267,7 @@ typedef void (*sd_preview_cb_t)(int step, int frame_count, sd_image_t* frames, b
 
 SD_API void sd_set_log_callback(sd_log_cb_t sd_log_cb, void* data);
 SD_API void sd_set_progress_callback(sd_progress_cb_t cb, void* data);
-SD_API void sd_set_preview_callback(sd_preview_cb_t cb, preview_t mode, int interval, bool denoised, bool noisy);
+SD_API void sd_set_preview_callback(sd_preview_cb_t cb, enum preview_t mode, int interval, bool denoised, bool noisy);
 SD_API int32_t get_num_physical_cores();
 SD_API const char* sd_get_system_info();
 


### PR DESCRIPTION
A small fix to make clang happy

` ./stable-diffusion.cpp/stable-diffusion.h:270:57: error: must use 'enum' tag to refer to type 'preview_t'`