### PR TITLE
fix: avoid crash with LoRAs and type override

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -336,10 +336,14 @@ public:
 
         if (sd_ctx_params->lora_apply_mode == LORA_APPLY_AUTO) {
             bool have_quantized_weight = false;
-            for (const auto& [type, _] : wtype_stat) {
-                if (ggml_is_quantized(type)) {
-                    have_quantized_weight = true;
-                    break;
+            if (wtype != GGML_TYPE_COUNT && ggml_is_quantized(wtype)) {
+                have_quantized_weight = true;
+            } else {
+                for (const auto& [type, _] : wtype_stat) {
+                    if (ggml_is_quantized(type)) {
+                        have_quantized_weight = true;
+                        break;
+                    }
                 }
             }
             if (have_quantized_weight) {


### PR DESCRIPTION
Using a LoRA with e.g. `--type q8_0` on Vulkan triggers:

> ggml/src/ggml-vulkan/ggml-vulkan.cpp:6093: GGML_ASSERT(ggml_vk_dim01_contiguous(src1) || src1->type == GGML_TYPE_F32 || src1->type == GGML_TYPE_F16) failed