### PR TITLE
fix: check the PhotoMaker id_embeds tensor ONLY in PhotoMaker V2 mode

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -2673,7 +2673,7 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
                 LOG_WARN("Turn off PhotoMaker");
                 sd_ctx->sd->stacked_id = false;
             } else {
-                if (pm_params.id_images_count != id_embeds->ne[1]) {
+                if (pmv2 && pm_params.id_images_count != id_embeds->ne[1]) {
                     LOG_WARN("PhotoMaker image count (%d) does NOT match ID embeds (%d). You should run face_detect.py again.", pm_params.id_images_count, id_embeds->ne[1]);
                     LOG_WARN("Turn off PhotoMaker");
                     sd_ctx->sd->stacked_id = false;


### PR DESCRIPTION
We need to validate the id_embeds tensor  _only_ for PM2. 
(This is a  bugfix of my last week patch ...  I am sorry)