### PR TITLE
refactor: move utility functions out of the global namespace

### DIFF
--- a/util.h
+++ b/util.h
@@ -10,6 +10,8 @@
 #define SAFE_STR(s) ((s) ? (s) : "")
 #define BOOL_STR(b) ((b) ? "true" : "false")
 
+inline namespace sd_internal {
+
 bool ends_with(const std::string& str, const std::string& ending);
 bool starts_with(const std::string& str, const std::string& start);
 bool contains(const std::string& str, const std::string& substr);
@@ -67,4 +69,7 @@ bool sd_should_preview_noisy();
 #define LOG_INFO(format, ...) log_printf(SD_LOG_INFO, __FILE__, __LINE__, format, ##__VA_ARGS__)
 #define LOG_WARN(format, ...) log_printf(SD_LOG_WARN, __FILE__, __LINE__, format, ##__VA_ARGS__)
 #define LOG_ERROR(format, ...) log_printf(SD_LOG_ERROR, __FILE__, __LINE__, format, ##__VA_ARGS__)
+
+}
+
 #endif  // __UTIL_H__


### PR DESCRIPTION
Many utility functions have generic names that may conflict with symbols from other libraries, causing linkage issues.

The 'inline namespace' approach seems ideal for this case, since it's automatically added by any source code that includes `util.h`. Moving the whole library to its own namespace would also work, of course.

I kept the functions in place to avoid a huge diff, but they should probably be reorganized by visibility.

This is related to #967 , which I suggested for the same reason.

Should fix #1011 .