### PR TITLE
fix: avoid crash when the lora file is not found using immediately mode

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -991,6 +991,9 @@ public:
             int64_t t0 = ggml_time_ms();
 
             auto lora = load_lora_model_from_file(kv.first, kv.second, backend);
+            if (!lora || lora->lora_tensors.empty()) {
+                continue;
+            }
             lora->apply(tensors, version, n_threads);
             lora->free_params_buffer();
 


### PR DESCRIPTION
Fix https://github.com/leejet/stable-diffusion.cpp/issues/1019.