### PR TITLE
Add compute kernels to Windows CUDA build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,7 +163,7 @@ jobs:
           - build: "avx512"
             defines: "-DGGML_NATIVE=OFF -DGGML_AVX512=ON -DGGML_AVX=ON -DGGML_AVX2=ON -DSD_BUILD_SHARED_LIBS=ON"
           - build: "cuda12"
-            defines: "-DSD_CUDA=ON -DSD_BUILD_SHARED_LIBS=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90;100;103;120'"
+            defines: "-DSD_CUDA=ON -DSD_BUILD_SHARED_LIBS=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90;100;120'"
           - build: 'vulkan'
             defines: "-DSD_VULKAN=ON -DSD_BUILD_SHARED_LIBS=ON"
     steps:


### PR DESCRIPTION
Fixes #1061, Fixes #1060 

Current status: running CI on my fork

---

Changes:
1. Updated Jimver/cuda-toolkit to 0.2.22
2. Updated CUDA compiler to 12.8.1
3. Fixes single CUDA architecture issue

Current supported GPUs:
1. `6.1`: Tesla P40 generation, GTX 10 Series, Quadro Pascal generation
2. `7.0`: V100
3. `7.5`: Tesla T4, GTX 16 Series, RTX 20 Series, Quadro Turing Series
4. `8.0`: A100
5. `8.6`: A40, Workstation Ampere Series, RTX 30 Series
6. `8.9`: L40, Workstation Ada Series, RTX 40 Series
7. `9.0`: H100, H200
8. `10.0`: B200
9. `12.0`: Workstation Blackwell Series, RTX 50 Series