### PR TITLE
Fix download link for Stable Diffusion v1.5 in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ API and command-line option may change frequently.***
 ### Download model weights
 
 - download weights(.ckpt or .safetensors or .gguf). For example
-    - Stable Diffusion v1.5 from https://huggingface.co/runwayml/stable-diffusion-v1-5
+    - Stable Diffusion v1.5 from https://huggingface.co/stable-diffusion-v1-5/stable-diffusion-v1-5 
 
     ```sh
     curl -L -O https://huggingface.co/runwayml/stable-diffusion-v1-5/resolve/main/v1-5-pruned-emaonly.safetensors


### PR DESCRIPTION
Updated the download link for Stable Diffusion v1.5, Runway stopped maintaining a HF org (as per note on https://huggingface.co/runwayml)