### PR TITLE
feat: give feedback about cfg values smaller than 1

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1484,7 +1484,7 @@ public:
         std::vector<int> skip_layers(guidance.slg.layers, guidance.slg.layers + guidance.slg.layer_count);
 
         float cfg_scale     = guidance.txt_cfg;
-        if (cfg_scale < 1) {
+        if (cfg_scale < 1.f) {
             if (cfg_scale == 0.f) {
                 // Diffusers follow the convention from the original paper
                 // (https://arxiv.org/abs/2207.12598v1), so many distilled model docs


### PR DESCRIPTION
The documentation and examples for many distilled models, such as [SDXL Turbo](https://huggingface.co/stabilityai/sdxl-turbo) and [Z-Image Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo), specify a CFG scale of 0. So add a few warnings to nudge the user in the right direction.

Edit: removed the cfg cap, as per @stduhpf  suggestion.