### PR TITLE
fix: avoid crash with VAE tiling and certain image sizes

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -848,8 +848,6 @@ __STATIC_INLINE__ void sd_tiling_non_square(ggml_tensor* input,
     LOG_DEBUG("num tiles : %d, %d ", num_tiles_x, num_tiles_y);
     LOG_DEBUG("optimal overlap : %f, %f (targeting %f)", tile_overlap_factor_x, tile_overlap_factor_y, tile_overlap_factor);
 
-    GGML_ASSERT(input_width % 2 == 0 && input_height % 2 == 0 && output_width % 2 == 0 && output_height % 2 == 0);  // should be multiple of 2
-
     int tile_overlap_x     = (int32_t)(p_tile_size_x * tile_overlap_factor_x);
     int non_tile_overlap_x = p_tile_size_x - tile_overlap_x;
 


### PR DESCRIPTION
I'm getting crashes with VAE tiling and specific image sizes, e.g. between 513 and 520.

> ./sd-cli --diffusion-model z_image_turbo-Q8_0_bf16.gguf --llm josiefied-qwen3-4b-abliterated-v2-q8_0.gguf -W 512 -H 520 --vae ae_bf16.safetensors --cfg-scale 1 --steps 2 -p forest --diffusion-fa --vae-tiling

> ggml_extend.hpp:851: GGML_ASSERT(input_width % 2 == 0 && input_height % 2 == 0 && output_width % 2 == 0 && output_height % 2 == 0) failed

@stduhpf , I was able to avoid the crash by simply removing the assertion, but I'm not entirely sure whether it was triggered by a subtle bug elsewhere or if it's just no longer needed. The resulting images look fine.

Related to #1073 .