### PR TITLE
fix: consistently pass 2nd-order samplers half steps as negatives

### DIFF
--- a/denoiser.hpp
+++ b/denoiser.hpp
@@ -830,7 +830,7 @@ static bool sample_k_diffusion(sample_method_t method,
 
             for (int i = 0; i < steps; i++) {
                 // denoise
-                ggml_tensor* denoised = model(x, sigmas[i], i + 1);
+                ggml_tensor* denoised = model(x, sigmas[i], -(i + 1));
                 if (denoised == nullptr) {
                     return false;
                 }
@@ -888,7 +888,7 @@ static bool sample_k_diffusion(sample_method_t method,
 
             for (int i = 0; i < steps; i++) {
                 // denoise
-                ggml_tensor* denoised = model(x, sigmas[i], i + 1);
+                ggml_tensor* denoised = model(x, sigmas[i], -(i + 1));
                 if (denoised == nullptr) {
                     return false;
                 }


### PR DESCRIPTION
Makes dpm2 and dpm++2s_a match the heun implementation.