### PR TITLE
Use Ninja on Windows to speed up build process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,7 +201,7 @@ jobs:
           mkdir build
           cd build
           cmake .. -DCMAKE_CXX_FLAGS='/bigobj' -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe ${{ matrix.defines }}
-          cmake --build . --config Release
+          cmake --build .
 
       - name: Check AVX512F support
         id: check_avx512f


### PR DESCRIPTION
The current MSBuild does not support parallel compiling of CUDA. Switching to Ninja can speed up as GH Actions uses 2-core VM.

Besides, CUDA warnings 177 and 550 are also suppressed (declared but unused / set but unused) to clean up build logs