### PR TITLE
Qwen image layered - fix make issues, add configurable layers, add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ API and command-line option may change frequently.***
     - [Chroma](./docs/chroma.md)
     - [Chroma1-Radiance](./docs/chroma_radiance.md)
     - [Qwen Image](./docs/qwen_image.md)
+    - [Qwen Image Layered](./docs/qwen_image_layered.md)
     - [Z-Image](./docs/z_image.md)
     - [Ovis-Image](./docs/ovis_image.md)
   - Image Edit Models

--- a/docs/qwen_image_layered.md
+++ b/docs/qwen_image_layered.md
@@ -1,0 +1,26 @@
+# How to Use
+
+## Download weights
+
+- Download Qwen Image Layered
+    - safetensors: https://huggingface.co/Comfy-Org/Qwen-Image-Layered_ComfyUI/tree/main/split_files/diffusion_models
+    - gguf: https://huggingface.co/QuantStack/Qwen-Image-Layered-GGUF/tree/main
+- Download vae
+    - safetensors: https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/tree/main/split_files/vae
+- Download qwen_2.5_vl 7b
+    - safetensors: https://huggingface.co/Comfy-Org/Qwen-Image_ComfyUI/tree/main/split_files/text_encoders
+    - gguf: https://huggingface.co/mradermacher/Qwen2.5-VL-7B-Instruct-GGUF/tree/main
+
+## Examples
+
+### Text to Layered Image
+
+This model generates 4 RGBA layers from a text prompt.
+
+```
+.\bin\Release\sd-cli.exe --diffusion-model  ..\..\ComfyUI\models\diffusion_models\Qwen-Image-Layered-Q8_0.gguf --vae ..\..\ComfyUI\models\vae\qwen_image_vae.safetensors  --llm ..\..\ComfyUI\models\text_encoders\Qwen2.5-VL-7B-Instruct-Q8_0.gguf  -p "a lovely cat" --cfg-scale 2.5 --sampling-method euler -v --offload-to-cpu -H 1024 -W 1024 --diffusion-fa --flow-shift 3
+```
+
+The output will consist of multiple images corresponding to the generated layers.
+
+```

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -601,6 +601,7 @@ int main(int argc, const char* argv[]) {
                 gen_params.strength,
                 gen_params.seed,
                 gen_params.batch_count,
+                gen_params.video_frames,
                 control_image,
                 gen_params.control_strength,
                 {

--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -423,6 +423,7 @@ int main(int argc, const char** argv) {
                 gen_params.strength,
                 gen_params.seed,
                 gen_params.batch_count,
+                1,
                 control_image,
                 gen_params.control_strength,
                 {
@@ -636,6 +637,7 @@ int main(int argc, const char** argv) {
                 gen_params.strength,
                 gen_params.seed,
                 gen_params.batch_count,
+                1,
                 control_image,
                 gen_params.control_strength,
                 {

--- a/stable-diffusion.h
+++ b/stable-diffusion.h
@@ -266,6 +266,7 @@ typedef struct {
     float strength;
     int64_t seed;
     int batch_count;
+    int video_frames;
     sd_image_t control_image;
     float control_strength;
     sd_pm_params_t pm_params;


### PR DESCRIPTION
Amends #1119, fixes #1118 with configurable layers and documentation for running qwen-image-layered. fixes macOS cmake errors (and maybe windows)