### PR TITLE
Restore asymmetric padding in DownSampleBlock::forward

### DIFF
--- a/common.hpp
+++ b/common.hpp
@@ -28,7 +28,13 @@ public:
         if (vae_downsample) {
             auto conv = std::dynamic_pointer_cast<Conv2d>(blocks["conv"]);
 
-            x = ggml_ext_pad(ctx->ggml_ctx, x, 1, 1, 0, 0, ctx->circular_x_enabled, ctx->circular_y_enabled);
+            // Commenting out (from commit 50ff966)
+            // x = ggml_ext_pad(ctx->ggml_ctx, x, 1, 1, 0, 0, ctx->circular_x_enabled, ctx->circular_y_enabled);
+
+            // Restoring asymmetric padding (right/bottom only) while keeping circular padding support.
+            // Matches original ggml_pad behavior, maintains spatial alignment through VAE encode/decode cycles.
+            x = ggml_ext_pad_ext(ctx->ggml_ctx, x, 0, 1, 0, 1, 0, 0, 0, 0, ctx->circular_x_enabled, ctx->circular_y_enabled);
+
             x = conv->forward(ctx, x);
         } else {
             auto conv = std::dynamic_pointer_cast<Conv2d>(blocks["op"]);


### PR DESCRIPTION
I noticed that after commit 50ff966 that I was getting 8-pixel borders added to the top and left of all my inpainting outputs (with images of any dimensions). I experimented with different fixes until I found this one key line in DownSampleBlock::forward (`common.hpp`) that seems to be contributing to the 2x2x2 (8 px) offset / borders that I was seeing. I also attempted to keep circular padding in there while maintaining the original behavior overall. 

Now whether this is the ideal fix for all use cases I am not 100% sure, but I am hoping someone with more expertise can see if this is a valid fix as it has been working well so far.

Thank you.