### PR TITLE
feat: generate new random seed per request when seed is -1 (server)

### DIFF
--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <sstream>
 #include <vector>
+#include <random>
 
 #include "httplib.h"
 #include "stable-diffusion.h"
@@ -407,6 +408,12 @@ int main(int argc, const char** argv) {
             gen_params.width              = width;
             gen_params.height             = height;
             gen_params.batch_count        = n;
+
+            // If seed is -1 (random), generate a fresh seed for each request
+            if (gen_params.seed == -1) {
+                std::random_device rd;
+                gen_params.seed = static_cast<int64_t>(rd());
+            }
 
             if (!sd_cpp_extra_args_str.empty() && !gen_params.from_json_str(sd_cpp_extra_args_str)) {
                 res.status = 400;


### PR DESCRIPTION
This PR ensures that each image generation request uses a unique random seed when the user specifies `seed: -1`. Previously, a seed of `-1` would result in deterministic behavior across requests. The changes introduce:

1. Inclusion of `<random>` header for random device usage.
2. Logic in `examples/server/main.cpp` to detect `seed == -1` and replace it with a freshly generated 64‑bit seed using `std::random_device`.