### PR TITLE
feat: support server random seed flag

### DIFF
--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -202,11 +202,17 @@ void parse_args(int argc, const char** argv, SDSvrParams& svr_params, SDContextP
         exit(svr_params.normal_exit ? 0 : 1);
     }
 
+    const bool random_seed_requested = default_gen_params.seed < 0;
+
     if (!svr_params.process_and_check() ||
         !ctx_params.process_and_check(IMG_GEN) ||
         !default_gen_params.process_and_check(IMG_GEN, ctx_params.lora_model_dir)) {
         print_usage(argc, argv, options_vec);
         exit(1);
+    }
+
+    if (random_seed_requested) {
+        default_gen_params.seed = -1;
     }
 }
 


### PR DESCRIPTION
This PR ensures that each image generation request uses a unique random seed when the user specifies `seed: -1`. Previously, a seed of `-1` would result in the server selecting one random seed and reusing it across generations.