### PR TITLE
fix(server): mask file multipart

### DIFF
--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -537,7 +537,7 @@ int main(int argc, const char** argv) {
             }
 
             std::vector<uint8_t> mask_bytes;
-            if (req.form.has_field("mask")) {
+            if (req.form.has_file("mask")) {
                 auto file = req.form.get_file("mask");
                 mask_bytes.assign(file.content.begin(), file.content.end());
             }


### PR DESCRIPTION
`mask` is a file, and was incorrectly being checked via `has_field`

___

https://github.com/leejet/stable-diffusion.cpp/blob/9f0e24306f2c239fb0d88296d150347b267a8a8a/thirdparty/httplib.h#L620-L624