### PR TITLE
feat: support for SDXS-512 model

### DIFF
--- a/docs/distilled_sd.md
+++ b/docs/distilled_sd.md
@@ -101,22 +101,27 @@ torch.save(ckpt, "tinySDdistilled_fixed.ckpt")
 
 ### SDXS-512
 
-Another very tiny and **incredibly fast**  model is SDXS.  The authors refer to it as *"Real-Time One-Step Latent Diffusion Models with Image Conditions"*. For details read the paper: https://arxiv.org/pdf/2403.16627 . Once again the authors removed some more blocks of U-Net part and unlike other SD1 models they use an adjusted _AutoencoderTiny_ instead of default _AutoencoderKL_ for the VAE part.
+Another very tiny and **incredibly fast**  model is SDXS by IDKiro et al.  The authors refer to it as *"Real-Time One-Step Latent Diffusion Models with Image Conditions"*. For details read the paper: https://arxiv.org/pdf/2403.16627 . Once again the authors removed some more blocks of U-Net part and unlike other SD1 models they use an adjusted _AutoEncoderTiny_ instead of default _AutoEncoderKL_ for the VAE part.
 
-##### First download the diffusers models from  Hugging Face using Python:
+##### 1. Download the diffusers model from  Hugging Face using Python:
 
 ```python
 from diffusers import StableDiffusionPipeline
 pipe = StableDiffusionPipeline.from_pretrained("IDKiro/sdxs-512-dreamshaper")
 pipe.save_pretrained(save_directory="sdxs")
 ```
+##### 2. Create a safetensors file
 
-##### Second run the model as follows:
-
-```python
-~/stable-diffusion.cpp/build/bin/sd-cli -m sdxs  -p "portrait of a lovely cat" \
-  --cfg-scale 1 --steps 1 \
-  --taesd  sdxs/vae/diffusion_pytorch_model.safetensors
+```bash
+python convert_diffusers_to_original_stable_diffusion.py \
+    --model_path  sdxs  --checkpoint_path sdxs.safetensors --half --use_safetensors
 ```
 
-All options: ``` --cfg-scale 1 ``` , ``` --steps 1 ```  and  ``` --taesd sdxs/vae/diffusion_pytorch_model.safetensors```  are mandatory here.                                                 
+##### 3. Run the model as follows:
+
+```bash
+~/stable-diffusion.cpp/build/bin/sd-cli -m sdxs.safetensors -p "portrait of a lovely cat" \
+  --cfg-scale 1 --steps 1
+```
+
+Both options: ``` --cfg-scale 1 ``` and  ``` --steps 1 ``` are mandatory here.                                                 

--- a/docs/distilled_sd.md
+++ b/docs/distilled_sd.md
@@ -83,7 +83,7 @@ python convert_diffusers_to_original_stable_diffusion.py \
 The file segmind_tiny-sd.ckpt will be generated and is now ready for use with sd.cpp. You can follow a similar process for the other models mentioned above.
 
 
-### Another available .ckpt file:
+##### Another available .ckpt file:
 
  * https://huggingface.co/ClashSAN/small-sd/resolve/main/tinySDdistilled.ckpt
 
@@ -97,3 +97,26 @@ for key, value in ckpt['state_dict'].items():
         ckpt['state_dict'][key] = value.contiguous()
 torch.save(ckpt, "tinySDdistilled_fixed.ckpt")
 ```
+
+
+### SDXS-512
+
+Another very tiny and **incredibly fast**  model is SDXS.  The authors refer to it as *"Real-Time One-Step Latent Diffusion Models with Image Conditions"*. For details read the paper: https://arxiv.org/pdf/2403.16627 . Once again the authors removed some more blocks of U-Net part and unlike other SD1 models they use an adjusted _AutoencoderTiny_ instead of default _AutoencoderKL_ for the VAE part.
+
+##### First download the diffusers models from  Hugging Face using Python:
+
+```python
+from diffusers import StableDiffusionPipeline
+pipe = StableDiffusionPipeline.from_pretrained("IDKiro/sdxs-512-dreamshaper")
+pipe.save_pretrained(save_directory="sdxs")
+```
+
+##### Second run the model as follows:
+
+```python
+~/stable-diffusion.cpp/build/bin/sd-cli -m sdxs  -p "portrait of a lovely cat" \
+  --cfg-scale 1 --steps 1 \
+  --taesd  sdxs/vae/diffusion_pytorch_model.safetensors
+```
+
+All options: ``` --cfg-scale 1 ``` , ``` --steps 1 ```  and  ``` --taesd sdxs/vae/diffusion_pytorch_model.safetensors```  are mandatory here.                                                 

--- a/model.cpp
+++ b/model.cpp
@@ -1038,6 +1038,7 @@ SDVersion ModelLoader::get_sd_version() {
     int64_t patch_embedding_channels = 0;
     bool has_img_emb                 = false;
     bool has_middle_block_1          = false;
+    bool has_output_block_71         = false;
 
     for (auto& [name, tensor_storage] : tensor_storage_map) {
         if (!(is_xl)) {
@@ -1093,6 +1094,9 @@ SDVersion ModelLoader::get_sd_version() {
         if (tensor_storage.name.find("model.diffusion_model.middle_block.1.") != std::string::npos ||
             tensor_storage.name.find("unet.mid_block.resnets.1.") != std::string::npos) {
             has_middle_block_1 = true;
+        }
+        if (tensor_storage.name.find("model.diffusion_model.output_blocks.7.1") != std::string::npos) {
+            has_output_block_71 = true;
         }
         if (tensor_storage.name == "cond_stage_model.transformer.text_model.embeddings.token_embedding.weight" ||
             tensor_storage.name == "cond_stage_model.model.token_embedding.weight" ||
@@ -1155,6 +1159,9 @@ SDVersion ModelLoader::get_sd_version() {
             return VERSION_SD1_PIX2PIX;
         }
         if (!has_middle_block_1) {
+            if (!has_output_block_71) {
+                return VERSION_SDXS;
+            }
             return VERSION_SD1_TINY_UNET;
         }
         return VERSION_SD1;

--- a/model.h
+++ b/model.h
@@ -28,6 +28,7 @@ enum SDVersion {
     VERSION_SD2,
     VERSION_SD2_INPAINT,
     VERSION_SD2_TINY_UNET,
+    VERSION_SDXS,
     VERSION_SDXL,
     VERSION_SDXL_INPAINT,
     VERSION_SDXL_PIX2PIX,
@@ -50,7 +51,7 @@ enum SDVersion {
 };
 
 static inline bool sd_version_is_sd1(SDVersion version) {
-    if (version == VERSION_SD1 || version == VERSION_SD1_INPAINT || version == VERSION_SD1_PIX2PIX || version == VERSION_SD1_TINY_UNET) {
+    if (version == VERSION_SD1 || version == VERSION_SD1_INPAINT || version == VERSION_SD1_PIX2PIX || version == VERSION_SD1_TINY_UNET || version == VERSION_SDXS) {
         return true;
     }
     return false;

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -31,6 +31,7 @@ const char* model_version_to_str[] = {
     "SD 2.x",
     "SD 2.x Inpaint",
     "SD 2.x Tiny UNet",
+    "SDXS",
     "SDXL",
     "SDXL Inpaint",
     "SDXL Instruct-Pix2Pix",

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -408,6 +408,11 @@ public:
             vae_decode_only = false;
         }
 
+        bool tae_preview_only = sd_ctx_params->tae_preview_only;
+        if (version == VERSION_SDXS) {
+            tae_preview_only = false;
+        }
+
         if (sd_ctx_params->circular_x || sd_ctx_params->circular_y) {
             LOG_INFO("Using circular padding for convolutions");
         }
@@ -592,7 +597,7 @@ public:
                 vae_backend = backend;
             }
 
-            if (!(use_tiny_autoencoder || version == VERSION_SDXS) || sd_ctx_params->tae_preview_only) {
+            if (!(use_tiny_autoencoder || version == VERSION_SDXS) || tae_preview_only) {
                 if (sd_version_is_wan(version) || sd_version_is_qwen_image(version)) {
                     first_stage_model = std::make_shared<WAN::WanVAERunner>(vae_backend,
                                                                             offload_params_to_cpu,
@@ -786,7 +791,7 @@ public:
                 unet_params_mem_size += high_noise_diffusion_model->get_params_buffer_size();
             }
             size_t vae_params_mem_size = 0;
-            if (!(use_tiny_autoencoder || version == VERSION_SDXS) || sd_ctx_params->tae_preview_only) {
+            if (!(use_tiny_autoencoder || version == VERSION_SDXS) || tae_preview_only) {
                 vae_params_mem_size = first_stage_model->get_params_buffer_size();
             }
             if (use_tiny_autoencoder || version == VERSION_SDXS) {
@@ -950,7 +955,7 @@ public:
         }
 
         ggml_free(ctx);
-        use_tiny_autoencoder = use_tiny_autoencoder && !sd_ctx_params->tae_preview_only;
+        use_tiny_autoencoder = use_tiny_autoencoder && !tae_preview_only;
         return true;
     }
 

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -116,8 +116,7 @@ public:
     std::shared_ptr<DiffusionModel> diffusion_model;
     std::shared_ptr<DiffusionModel> high_noise_diffusion_model;
     std::shared_ptr<VAE> first_stage_model = nullptr;
-    std::shared_ptr<TinyAutoEncoder> first_stage_model_tiny = nullptr;
-    std::shared_ptr<TinyAutoEncoder> tae_first_stage;
+    std::shared_ptr<TinyAutoEncoder> tae_first_stage = nullptr;
     std::shared_ptr<ControlNet> control_net;
     std::shared_ptr<PhotoMakerIDEncoder> pmid_model;
     std::shared_ptr<LoraModel> pmid_lora;
@@ -593,7 +592,7 @@ public:
                 vae_backend = backend;
             }
 
-            if (!use_tiny_autoencoder || sd_ctx_params->tae_preview_only) {
+            if (!(use_tiny_autoencoder || version == VERSION_SDXS) || sd_ctx_params->tae_preview_only) {
                 if (sd_version_is_wan(version) || sd_version_is_qwen_image(version)) {
                     first_stage_model = std::make_shared<WAN::WanVAERunner>(vae_backend,
                                                                             offload_params_to_cpu,
@@ -607,46 +606,31 @@ public:
                     first_stage_model = std::make_shared<FakeVAE>(vae_backend,
                                                                   offload_params_to_cpu);
                 } else {
-                    if (version == VERSION_SDXS) {
-                        first_stage_model_tiny = std::make_shared<TinyImageAutoEncoder>(vae_backend,
-                                                                                        offload_params_to_cpu,
-                                                                                        tensor_storage_map,
-                                                                                        "decoder.layers",
-                                                                                        vae_decode_only,
-                                                                                        version);
-                        first_stage_model_tiny->alloc_params_buffer();
-                        first_stage_model_tiny->get_param_tensors(tensors,"first_stage_model");
-                        if (sd_ctx_params->vae_conv_direct) {
-                            first_stage_model_tiny->set_conv2d_direct_enabled(true);
-                        }
-                    } else {
-                        first_stage_model = std::make_shared<AutoEncoderKL>(vae_backend,
-                                                                            offload_params_to_cpu,
-                                                                            tensor_storage_map,
-                                                                            "first_stage_model",
-                                                                            vae_decode_only,
-                                                                            false,
-                                                                            version);
-                        if (sd_ctx_params->vae_conv_direct) {
-                            LOG_INFO("Using Conv2d direct in the vae model");
-                            first_stage_model->set_conv2d_direct_enabled(true);
-                        }
-                        if (version == VERSION_SDXL &&
-                            (strlen(SAFE_STR(sd_ctx_params->vae_path)) == 0 || sd_ctx_params->force_sdxl_vae_conv_scale)) {
-                            float vae_conv_2d_scale = 1.f / 32.f;
-                            LOG_WARN(
-                                "No VAE specified with --vae or --force-sdxl-vae-conv-scale flag set, "
-                                "using Conv2D scale %.3f",
-                                 vae_conv_2d_scale);
-                            first_stage_model->set_conv2d_scale(vae_conv_2d_scale);
-                        }
-                        first_stage_model->alloc_params_buffer();
-                        first_stage_model->get_param_tensors(tensors, "first_stage_model");
+                    first_stage_model = std::make_shared<AutoEncoderKL>(vae_backend,
+                                                                        offload_params_to_cpu,
+                                                                        tensor_storage_map,
+                                                                        "first_stage_model",
+                                                                        vae_decode_only,
+                                                                        false,
+                                                                        version);
+                    if (sd_ctx_params->vae_conv_direct) {
+                        LOG_INFO("Using Conv2d direct in the vae model");
+                        first_stage_model->set_conv2d_direct_enabled(true);
                     }
+                    if (version == VERSION_SDXL &&
+                        (strlen(SAFE_STR(sd_ctx_params->vae_path)) == 0 || sd_ctx_params->force_sdxl_vae_conv_scale)) {
+                        float vae_conv_2d_scale = 1.f / 32.f;
+                        LOG_WARN(
+                            "No VAE specified with --vae or --force-sdxl-vae-conv-scale flag set, "
+                            "using Conv2D scale %.3f",
+                            vae_conv_2d_scale);
+                        first_stage_model->set_conv2d_scale(vae_conv_2d_scale);
+                    }
+                    first_stage_model->alloc_params_buffer();
+                    first_stage_model->get_param_tensors(tensors, "first_stage_model");
                 }
             }
-
-            if (use_tiny_autoencoder) {
+            if (use_tiny_autoencoder || version == VERSION_SDXS) {
                 if (sd_version_is_wan(version) || sd_version_is_qwen_image(version)) {
                     tae_first_stage = std::make_shared<TinyVideoAutoEncoder>(vae_backend,
                                                                              offload_params_to_cpu,
@@ -661,6 +645,10 @@ public:
                                                                              "decoder.layers",
                                                                              vae_decode_only,
                                                                              version);
+                    if (version == VERSION_SDXS) {
+                        tae_first_stage->alloc_params_buffer();
+                        tae_first_stage->get_param_tensors(tensors,"first_stage_model");
+                    } 
                 }
                 if (sd_ctx_params->vae_conv_direct) {
                     LOG_INFO("Using Conv2d direct in the tae model");
@@ -738,9 +726,6 @@ public:
             if (first_stage_model) {
                 first_stage_model->set_circular_axes(sd_ctx_params->circular_x, sd_ctx_params->circular_y);
             }
-            if (first_stage_model_tiny) {
-                first_stage_model_tiny->set_circular_axes(sd_ctx_params->circular_x, sd_ctx_params->circular_y);
-            }
             if (tae_first_stage) {
                 tae_first_stage->set_circular_axes(sd_ctx_params->circular_x, sd_ctx_params->circular_y);
             }
@@ -801,17 +786,14 @@ public:
                 unet_params_mem_size += high_noise_diffusion_model->get_params_buffer_size();
             }
             size_t vae_params_mem_size = 0;
-            if (!use_tiny_autoencoder || sd_ctx_params->tae_preview_only) {
-                if (first_stage_model_tiny != nullptr) {
-                    vae_params_mem_size = first_stage_model_tiny->get_params_buffer_size();
-                } else {
-                    vae_params_mem_size = first_stage_model->get_params_buffer_size();
-                }
+            if (!(use_tiny_autoencoder || version == VERSION_SDXS) || sd_ctx_params->tae_preview_only) {
+                vae_params_mem_size = first_stage_model->get_params_buffer_size();
             }
-            if (use_tiny_autoencoder) {
-                if (!tae_first_stage->load_from_file(taesd_path, n_threads)) {
+            if (use_tiny_autoencoder || version == VERSION_SDXS) {
+                if (use_tiny_autoencoder && !tae_first_stage->load_from_file(taesd_path, n_threads)) {
                     return false;
                 }
+                use_tiny_autoencoder = true; // now the processing is identical for VERSION_SDXS
                 vae_params_mem_size = tae_first_stage->get_params_buffer_size();
             }
             size_t control_net_params_mem_size = 0;
@@ -2540,17 +2522,9 @@ public:
                 };
                 sd_tiling_non_square(x, result, vae_scale_factor, tile_size_x, tile_size_y, tile_overlap, on_tiling);
             } else {
-                if (version == VERSION_SDXS) {
-                    first_stage_model_tiny->compute(n_threads, x, false, &result, work_ctx);
-                } else {
-                    first_stage_model->compute(n_threads, x, false, &result, work_ctx);
-                }
+                first_stage_model->compute(n_threads, x, false, &result, work_ctx);
             }
-            if (version == VERSION_SDXS) {
-                first_stage_model_tiny->free_compute_buffer();
-            } else {
-                first_stage_model->free_compute_buffer();
-            }
+            first_stage_model->free_compute_buffer();
         } else {
             if (vae_tiling_params.enabled && !encode_video) {
                 // split latent in 32x32 tiles and compute in several steps
@@ -2604,7 +2578,6 @@ public:
             sd_version_is_qwen_image(version) ||
             sd_version_is_wan(version) ||
             sd_version_is_flux2(version) ||
-            version == VERSION_SDXS ||
             version == VERSION_CHROMA_RADIANCE) {
             latent = vae_output;
         } else if (version == VERSION_SD1_PIX2PIX) {
@@ -2663,9 +2636,7 @@ public:
             if (sd_version_is_qwen_image(version)) {
                 x = ggml_reshape_4d(work_ctx, x, x->ne[0], x->ne[1], 1, x->ne[2] * x->ne[3]);
             }
-            if (first_stage_model_tiny == nullptr) {
-                process_latent_out(x);
-            }
+            process_latent_out(x);
             // x = load_tensor_from_file(work_ctx, "wan_vae_z.bin");
             if (vae_tiling_params.enabled && !decode_video) {
                 float tile_overlap;
@@ -2676,22 +2647,14 @@ public:
 
                 // split latent in 32x32 tiles and compute in several steps
                 auto on_tiling = [&](ggml_tensor* in, ggml_tensor* out, bool init) {
-                    first_stage_model_tiny != nullptr ? first_stage_model_tiny->compute(n_threads, in, true, &out, nullptr) : first_stage_model->compute(n_threads, in, true, &out, nullptr);
+                    first_stage_model->compute(n_threads, in, true, &out, nullptr);
                 };
                 sd_tiling_non_square(x, result, vae_scale_factor, tile_size_x, tile_size_y, tile_overlap, on_tiling);
             } else {
-                if (first_stage_model_tiny != nullptr) {
-                    first_stage_model_tiny->compute(n_threads, x, true, &result, work_ctx);
-                } else {
-                    first_stage_model->compute(n_threads, x, true, &result, work_ctx);
-                }
+                first_stage_model->compute(n_threads, x, true, &result, work_ctx);
             }
-            if (first_stage_model_tiny != nullptr) {
-                first_stage_model_tiny->free_compute_buffer();
-            } else {
-                first_stage_model->free_compute_buffer();
-                process_vae_output_tensor(result);
-            }
+            first_stage_model->free_compute_buffer();
+            process_vae_output_tensor(result);
         } else {
             if (vae_tiling_params.enabled && !decode_video) {
                 // split latent in 64x64 tiles and compute in several steps
@@ -3453,11 +3416,7 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
     int64_t t4 = ggml_time_ms();
     LOG_INFO("decode_first_stage completed, taking %.2fs", (t4 - t3) * 1.0f / 1000);
     if (sd_ctx->sd->free_params_immediately && !sd_ctx->sd->use_tiny_autoencoder) {
-        if (sd_ctx->sd->first_stage_model_tiny != nullptr) {
-            sd_ctx->sd->first_stage_model_tiny->free_params_buffer();
-        } else {
-            sd_ctx->sd->first_stage_model->free_params_buffer();
-        }
+        sd_ctx->sd->first_stage_model->free_params_buffer();
     }
 
     sd_ctx->sd->lora_stat();

--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -115,8 +115,8 @@ public:
     std::shared_ptr<FrozenCLIPVisionEmbedder> clip_vision;  // for svd or wan2.1 i2v
     std::shared_ptr<DiffusionModel> diffusion_model;
     std::shared_ptr<DiffusionModel> high_noise_diffusion_model;
-    std::shared_ptr<VAE> first_stage_model = nullptr;
-    std::shared_ptr<TinyAutoEncoder> tae_first_stage = nullptr;
+    std::shared_ptr<VAE> first_stage_model;
+    std::shared_ptr<TinyAutoEncoder> tae_first_stage;
     std::shared_ptr<ControlNet> control_net;
     std::shared_ptr<PhotoMakerIDEncoder> pmid_model;
     std::shared_ptr<LoraModel> pmid_lora;
@@ -647,8 +647,8 @@ public:
                                                                              version);
                     if (version == VERSION_SDXS) {
                         tae_first_stage->alloc_params_buffer();
-                        tae_first_stage->get_param_tensors(tensors,"first_stage_model");
-                    } 
+                        tae_first_stage->get_param_tensors(tensors, "first_stage_model");
+                    }
                 }
                 if (sd_ctx_params->vae_conv_direct) {
                     LOG_INFO("Using Conv2d direct in the tae model");
@@ -793,8 +793,8 @@ public:
                 if (use_tiny_autoencoder && !tae_first_stage->load_from_file(taesd_path, n_threads)) {
                     return false;
                 }
-                use_tiny_autoencoder = true; // now the processing is identical for VERSION_SDXS
-                vae_params_mem_size = tae_first_stage->get_params_buffer_size();
+                use_tiny_autoencoder = true;  // now the processing is identical for VERSION_SDXS
+                vae_params_mem_size  = tae_first_stage->get_params_buffer_size();
             }
             size_t control_net_params_mem_size = 0;
             if (control_net) {

--- a/tae.hpp
+++ b/tae.hpp
@@ -506,6 +506,7 @@ struct TinyAutoEncoder : public GGMLRunner {
                          struct ggml_context* output_ctx = nullptr) = 0;
 
     virtual bool load_from_file(const std::string& file_path, int n_threads) = 0;
+    virtual void get_param_tensors(std::map<std::string, struct ggml_tensor*>& tensors, const std::string prefix) = 0;
 };
 
 struct TinyImageAutoEncoder : public TinyAutoEncoder {
@@ -553,6 +554,10 @@ struct TinyImageAutoEncoder : public TinyAutoEncoder {
 
         LOG_INFO("taesd model loaded");
         return success;
+    }
+
+    void get_param_tensors(std::map<std::string, struct ggml_tensor*>& tensors, const std::string prefix) {
+        taesd.get_param_tensors(tensors,prefix);
     }
 
     struct ggml_cgraph* build_graph(struct ggml_tensor* z, bool decode_graph) {
@@ -622,6 +627,10 @@ struct TinyVideoAutoEncoder : public TinyAutoEncoder {
 
         LOG_INFO("taehv model loaded");
         return success;
+    }
+
+    void get_param_tensors(std::map<std::string, struct ggml_tensor*>& tensors, const std::string prefix) {
+        taehv.get_param_tensors(tensors,prefix);
     }
 
     struct ggml_cgraph* build_graph(struct ggml_tensor* z, bool decode_graph) {

--- a/tae.hpp
+++ b/tae.hpp
@@ -505,7 +505,7 @@ struct TinyAutoEncoder : public GGMLRunner {
                          struct ggml_tensor** output,
                          struct ggml_context* output_ctx = nullptr) = 0;
 
-    virtual bool load_from_file(const std::string& file_path, int n_threads) = 0;
+    virtual bool load_from_file(const std::string& file_path, int n_threads)                                      = 0;
     virtual void get_param_tensors(std::map<std::string, struct ggml_tensor*>& tensors, const std::string prefix) = 0;
 };
 
@@ -557,7 +557,7 @@ struct TinyImageAutoEncoder : public TinyAutoEncoder {
     }
 
     void get_param_tensors(std::map<std::string, struct ggml_tensor*>& tensors, const std::string prefix) {
-        taesd.get_param_tensors(tensors,prefix);
+        taesd.get_param_tensors(tensors, prefix);
     }
 
     struct ggml_cgraph* build_graph(struct ggml_tensor* z, bool decode_graph) {
@@ -630,7 +630,7 @@ struct TinyVideoAutoEncoder : public TinyAutoEncoder {
     }
 
     void get_param_tensors(std::map<std::string, struct ggml_tensor*>& tensors, const std::string prefix) {
-        taehv.get_param_tensors(tensors,prefix);
+        taehv.get_param_tensors(tensors, prefix);
     }
 
     struct ggml_cgraph* build_graph(struct ggml_tensor* z, bool decode_graph) {

--- a/unet.hpp
+++ b/unet.hpp
@@ -215,10 +215,13 @@ public:
         } else if (sd_version_is_unet_edit(version)) {
             in_channels = 8;
         }
-        if (version == VERSION_SD1_TINY_UNET || version == VERSION_SD2_TINY_UNET) {
+        if (version == VERSION_SD1_TINY_UNET || version == VERSION_SD2_TINY_UNET || version == VERSION_SDXS) {
             num_res_blocks = 1;
             channel_mult   = {1, 2, 4};
             tiny_unet      = true;
+            if (version == VERSION_SDXS) {
+                attention_resolutions = {4, 2};  // here just like SDXL
+            }
         }
 
         // dims is always 2


### PR DESCRIPTION
Once I wrote "three TinySD models should be enough"  ( #939 ),  but I changed my mind on user's request in December 2025 ( #603 ) and because SDXS-512 is so **incredible fast**.  (That makes SDXS very handy for my sdcpp-on-android project.)

The main challenge for me was that SDXS does not use AutoEncoderKL as primary VAE (as most else)  but AutoEncoderTiny,   see also  https://huggingface.co/IDKiro/sdxs-512-dreamshaper .  I also hope that including SDXS into sd.cpp will convince @IDkiro to release into the public his SDXS-1024  one day. 