### PR TITLE
Feat: Select backend devices via arg ( +add RPC backend support)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,12 @@ if(SD_MUSA)
     add_definitions(-DSD_USE_CUDA)
 endif()
 
+if (SD_RPC)
+    message("-- Use RPC as backend stable-diffusion")
+    set(GGML_RPC ON)
+    add_definitions(-DSD_USE_RPC)
+endif ()
+
 set(SD_LIB stable-diffusion)
 
 file(GLOB SD_LIB_SOURCES

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -1,0 +1,202 @@
+# Building and Using the RPC Server with `stable-diffusion.cpp`
+
+This guide covers how to build a version of the RPC server from `llama.cpp` that is compatible with your version of `stable-diffusion.cpp` to manage multi-backends setups. RPC allows you to offload specific model components to a remote server.
+
+> **Note on Model Location:** The model files (e.g., `.safetensors` or `.gguf`) remain on the **Client** machine. The client parses the file and transmits the necessary tensor data and computational graphs to the server. The server does not need to store the model files locally.
+
+## 1. Building `stable-diffusion.cpp` with RPC client
+
+First, you should build the client application from source. It requires `GGML_RPC=ON` to include the RPC backend to your client.
+```bash
+mkdir build
+cd build
+cmake .. \
+    -DGGML_RPC=ON \
+    # Add other build flags here (e.g., -DSD_VULKAN=ON)
+cmake --build . --config Release -j $(nproc)
+```
+
+> **Note:** Ensure you add the other flags you would normally use (e.g., `-DSD_VULKAN=ON`, `-DSD_CUDA=ON`, `-DSD_HIPBLAS=ON`, or `-DGGML_METAL=ON`), for more information about building `stable-diffusion.cpp` from source, please refer to the `build.md` documentation.
+
+## 2. Ensure `llama.cpp` is at the correct commit
+
+`stable-diffusion.cpp`'s RPC client is designed to work with a specific version of `llama.cpp` (compatible with the `ggml` submodule) to ensure API compatibility. The commit hash for `llama.cpp` is stored in `ggml/scripts/sync-llama.last`.
+
+> **Start from Root:** Perform these steps from the root of your `stable-diffusion.cpp` directory.
+
+1.  Read the target commit hash from the submodule tracker:
+    ```bash
+    # Linux / WSL / MacOS
+    HASH=$(cat ggml/scripts/sync-llama.last)
+
+    # Windows (PowerShell)
+    $HASH = Get-Content -Path "ggml\scripts\sync-llama.last"
+    ```
+
+2.  Clone `llama.cpp` at the target commit .
+    ```bash
+    git clone https://github.com/ggml-org/llama.cpp.git
+    cd llama.cpp
+    git checkout $HASH
+    ```
+
+To save on download time and storage, you can use a shallow clone to download only the target commit: 
+    ```bash
+    mkdir -p llama.cpp
+    cd llama.cpp
+    git init
+    git remote add origin https://github.com/ggml-org/llama.cpp.git
+    git fetch --depth 1 origin $HASH
+    git checkout FETCH_HEAD
+    ```
+
+## 3. Build `llama.cpp` (RPC Server)
+
+The RPC server acts as the worker. You must explicitly enable the **backend** (the hardware interface, such as CUDA for Nvidia, Metal for Apple Silicon, or Vulkan) when building, otherwise the server will default to using only the CPU.
+
+To find the correct flags, refer to the official documentation for the `llama.cpp` repository.
+
+> **Crucial:** You must include the compiler flags required to satisfy the API compatibility with `stable-diffusion.cpp` (`-DGGML_MAX_NAME=128`). Without this flag, `GGML_MAX_NAME` will default to `64` for the server, and data transfers between the client and server will fail. Of course, `-DGGML_RPC` must also be enabled.
+>
+> I recommend disabling the `LLAMA_CURL` flag to avoid unnecessary dependencies, and disabling shared library builds to avoid potential conflicts.
+
+> **Build Target:** We are specifically building the `rpc-server` target. This prevents the build system from compiling the entire `llama.cpp` suite (like `llama-cli`), making the build significantly faster.
+
+### Linux / WSL (Vulkan)
+```bash
+mkdir build
+cd build
+cmake .. -DGGML_RPC=ON \
+    -DGGML_VULKAN=ON \        # Ensure backend is enabled
+    -DGGML_BUILD_SHARED_LIBS=OFF \
+    -DLLAMA_CURL=OFF \
+    -DCMAKE_C_FLAGS=-DGGML_MAX_NAME=128 \
+    -DCMAKE_CXX_FLAGS=-DGGML_MAX_NAME=128
+cmake --build . --config Release --target rpc-server -j $(nproc)
+```
+
+### macOS (Metal)
+```bash
+mkdir build
+cd build
+cmake .. -DGGML_RPC=ON \
+    -DGGML_METAL=ON \
+    -DGGML_BUILD_SHARED_LIBS=OFF \
+    -DLLAMA_CURL=OFF \
+    -DCMAKE_C_FLAGS=-DGGML_MAX_NAME=128 \
+    -DCMAKE_CXX_FLAGS=-DGGML_MAX_NAME=128
+cmake --build . --config Release --target rpc-server
+```
+
+### Windows (Visual Studio 2022, Vulkan)
+```powershell
+mkdir build
+cd build
+cmake .. -G "Visual Studio 17 2022" -A x64 `
+    -DGGML_RPC=ON `
+    -DGGML_VULKAN=ON `
+    -DGGML_BUILD_SHARED_LIBS=OFF `
+    -DLLAMA_CURL=OFF `
+    -DCMAKE_C_FLAGS=-DGGML_MAX_NAME=128 `
+    -DCMAKE_CXX_FLAGS=-DGGML_MAX_NAME=128
+cmake --build . --config Release --target rpc-server
+```
+
+## 4. Usage
+
+Once both applications are built, you can run the server and the client to manage your GPU allocation.
+
+### Step A: Run the RPC Server
+
+Start the server. It listens for connections on the default address (usually `localhost:50052`). If your server is on a different machine, ensure the server binds to the correct interface and your firewall allows the connection.
+
+**On the Server :**
+If running on the same machine, you can use the default address:
+```bash
+./rpc-server
+```
+If you want to allow connections from other machines on the network:
+```bash
+./rpc-server --host 0.0.0.0
+```
+
+> **Security Warning:** The RPC server does not currently support authentication or encryption. **Only run the server on trusted local networks**. Never expose the RPC server directly to the open internet.
+
+> **Drivers & Hardware:** Ensure the Server machine has the necessary drivers installed and functional (e.g., Nvidia Drivers for CUDA, Vulkan SDK, or Metal). If no devices are found, the server will simply fallback to CPU usage.
+
+### Step B: Check if the client is able to connect to the server and see the available devices
+
+We're assuming the server is running on your local machine, and listening on the default port `50052`. If it's running on a different machine, you can replace `localhost` with the IP address of the server.
+
+**On the Client:**
+```bash
+./sd-cli --rpc localhost:50052 --list-devices
+```
+If the server is running and the client is able to connect, you should see `RPC0    localhost:50052` in the list of devices.
+
+Example output: 
+(Client built without GPU acceleration, two GPUs available on the server)
+```
+List of available GGML devices:
+Name    Description
+-------------------
+CPU     AMD Ryzen 9 5900X 12-Core Processor
+RPC0    localhost:50052
+RPC1    localhost:50052
+```
+
+### Step C: Run with RPC device
+
+If everything is working correctly, you can now run the client while offloading some or all of the work to the RPC server.
+
+Example: Setting the main backend to the RPC0 device for doing all the work on the server.
+
+```bash
+./sd-cli -m models/sd1.5.safetensors -p "A cat" --rpc localhost:50052 --main-backend-device RPC0
+```
+
+---
+
+## 5. Scaling: Multiple RPC Servers
+
+You can connect the client to multiple RPC servers simultaneously to scale out your hardware usage.
+
+Example: A main machine (192.168.1.10) with 3 GPUs, with one GPU running CUDA and the other two running Vulkan, and a second machine (192.168.1.11) only one GPU.
+
+**On the first machine (Running two server instances):**
+
+**Terminal 1 (CUDA):**
+```bash
+# Linux / macOS / WSL
+export CUDA_VISIBLE_DEVICES=0
+./rpc-server-cuda --host 0.0.0.0
+
+# Windows PowerShell
+$env:CUDA_VISIBLE_DEVICES="0"
+./rpc-server-cuda --host 0.0.0.0
+```
+
+**Terminal 2 (Vulkan):**
+```bash
+./rpc-server-vulkan --host 0.0.0.0 --port 50053 -d Vulkan1,Vulkan2
+```
+
+**On the second machine:**
+```bash
+./rpc-server --host 0.0.0.0
+```
+
+**On the Client:**
+Pass multiple server addresses separated by commas.
+
+```bash
+./sd-cli --rpc 192.168.1.10:50052,192.168.1.10:50053,192.168.1.11:50052 --list-devices
+```
+
+The client will map these servers to sequential device IDs (e.g., RPC0 from the first server, RPC2, RPC3 from the second, and RPC4 from the third). With this setup, you could for example use RPC0 for the main backend, RPC1 and RPC2 for the text encoders, and RPC3 for the VAE.
+
+---
+
+## 6. Performance Considerations
+
+RPC performance is heavily dependent on network bandwidth, as large weights and activations must be transferred back and forth over the network, especially for large models, or when using high resolutions. For best results, ensure your network connection is stable and has sufficient bandwidth (>1Gbps recommended).

--- a/docs/rpc.md
+++ b/docs/rpc.md
@@ -6,13 +6,13 @@ This guide covers how to build a version of [the RPC server from `llama.cpp`](ht
 
 ## 1. Building `stable-diffusion.cpp` with RPC client
 
-First, you should build the client application from source. It requires `GGML_RPC=ON` to include the RPC backend to your client.
+First, you should build the client application from source. It requires `SD_RPC=ON` to include the RPC backend to your client.
 
 ```bash
 mkdir build
 cd build
 cmake .. \
-    -DGGML_RPC=ON \
+    -DSD_RPC=ON \
     # Add other build flags here (e.g., -DSD_VULKAN=ON)
 cmake --build . --config Release -j $(nproc)
 ```

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -19,6 +19,8 @@ CLI Options:
   -M, --mode                  run mode, one of [img_gen, vid_gen, upscale, convert], default: img_gen
   --preview                   preview method. must be one of the following [none, proj, tae, vae] (default is none)
   -h, --help                  show this help message and exit
+  --rpc                       add a rpc device
+  --list-devices              list available ggml compute devices
 
 Context Options:
   -m, --model <string>                     path to full model
@@ -41,6 +43,17 @@ Context Options:
   --tensor-type-rules <string>             weight type per tensor pattern (example: "^vae\.=f16,model\.=q8_0")
   --photo-maker <string>                   path to PHOTOMAKER model
   --upscale-model <string>                 path to esrgan model.
+  --main-backend-device <string>           default device to use for all backends (defaults to main gpu device if hardware acceleration is available, otherwise
+                                           cpu)
+  --diffusion-backend-device <string>      device to use for diffusion (defaults to main-backend-device)
+  --clip-backend-device <string>           device to use for clip (defaults to main-backend-device). Can be a comma-separated list of devices for models with
+                                           multiple encoders
+  --vae-backend-device <string>            device to use for vae (defaults to main-backend-device). Also applies to tae, unless tae-backend-device is specified
+  --tae-backend-device <string>            device to use for tae (defaults to vae-backend-device)
+  --control-net-backend-device <string>    device to use for control net (defaults to main-backend-device)
+  --upscaler-backend-device <string>       device to use for upscaling models (defaults to main-backend-device)
+  --photomaker-backend-device <string>     device to use for photomaker (defaults to main-backend-device)
+  --vision-backend-device <string>         device to use for clip-vision model (defaults to main-backend-device)
   -t, --threads <int>                      number of threads to use during computation (default: -1). If threads <= 0, then threads will be set to the number of
                                            CPU physical cores
   --chroma-t5-mask-pad <int>               t5 mask pad size of chroma
@@ -49,9 +62,6 @@ Context Options:
   --force-sdxl-vae-conv-scale              force use of conv scale on sdxl vae
   --offload-to-cpu                         place the weights in RAM to save VRAM, and automatically load them into VRAM when needed
   --mmap                                   whether to memory-map model
-  --control-net-cpu                        keep controlnet in cpu (for low vram)
-  --clip-on-cpu                            keep clip in cpu (for low vram)
-  --vae-on-cpu                             keep vae in cpu (for low vram)
   --fa                                     use flash attention
   --diffusion-fa                           use flash attention in the diffusion model only
   --diffusion-conv-direct                  use ggml_conv2d_direct in the diffusion model

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -829,7 +829,8 @@ int main(int argc, const char* argv[]) {
                                                         ctx_params.offload_params_to_cpu,
                                                         ctx_params.diffusion_conv_direct,
                                                         ctx_params.n_threads,
-                                                        gen_params.upscale_tile_size);
+                                                        gen_params.upscale_tile_size,
+                                                        ctx_params.upscaler_backend_device.c_str());
 
         if (upscaler_ctx == nullptr) {
             LOG_ERROR("new_upscaler_ctx failed");

--- a/examples/common/common.hpp
+++ b/examples/common/common.hpp
@@ -465,6 +465,8 @@ struct SDContextParams {
     std::string vae_backend_device;
     std::string tae_backend_device;
     std::string control_net_backend_device;
+    std::string upscaler_backend_device;
+
 
     std::map<std::string, std::string> embedding_map;
     std::vector<sd_embedding_t> embedding_vec;
@@ -602,6 +604,11 @@ struct SDContextParams {
              "--control-net-backend-device",
              "device to use for control net (defaults to main-backend-device)",
              &control_net_backend_device},
+             {"",
+             "--upscaler-backend-device",
+             "device to use for upscaling models (defaults to main-backend-device)",
+             &upscaler_backend_device},
+
 
         };
 

--- a/examples/common/common.hpp
+++ b/examples/common/common.hpp
@@ -591,7 +591,7 @@ struct SDContextParams {
              &diffusion_backend_device},
             {"",
              "--clip-backend-device",
-             "device to use for clip (defaults to main-backend-device)",
+             "device to use for clip (defaults to main-backend-device). Can be a comma-separated list of devices for models with multiple encoders",
              &clip_backend_device},
             {"",
              "--vae-backend-device",

--- a/examples/common/common.hpp
+++ b/examples/common/common.hpp
@@ -615,7 +615,7 @@ struct SDContextParams {
              &photomaker_backend_device},
              {"",
              "--vision-backend-device",
-             "device to use for clip-vision model (defaults to clip-backend-device)",
+             "device to use for clip-vision model (defaults to main-backend-device)",
              &vision_backend_device},
 
         };

--- a/examples/common/common.hpp
+++ b/examples/common/common.hpp
@@ -447,6 +447,13 @@ struct SDContextParams {
     std::string tensor_type_rules;
     std::string lora_model_dir = ".";
 
+    std::string main_backend_device;
+    std::string diffusion_backend_device;
+    std::string clip_backend_device;
+    std::string vae_backend_device;
+    std::string tae_backend_device;
+    std::string control_net_backend_device;
+
     std::map<std::string, std::string> embedding_map;
     std::vector<sd_embedding_t> embedding_vec;
 
@@ -454,9 +461,6 @@ struct SDContextParams {
     rng_type_t sampler_rng_type = RNG_TYPE_COUNT;
     bool offload_params_to_cpu  = false;
     bool enable_mmap            = false;
-    bool control_net_cpu        = false;
-    bool clip_on_cpu            = false;
-    bool vae_on_cpu             = false;
     bool flash_attn             = false;
     bool diffusion_flash_attn   = false;
     bool diffusion_conv_direct  = false;
@@ -562,6 +566,31 @@ struct SDContextParams {
              "--upscale-model",
              "path to esrgan model.",
              &esrgan_path},
+            {"",
+             "--main-backend-device",
+             "default device to use for all backends (defaults to main gpu device if hardware acceleration is available, otherwise cpu)",
+             &main_backend_device},
+            {"",
+             "--diffusion-backend-device",
+             "device to use for diffusion (defaults to main-backend-device)",
+             &diffusion_backend_device},
+            {"",
+             "--clip-backend-device",
+             "device to use for clip (defaults to main-backend-device)",
+             &clip_backend_device},
+            {"",
+             "--vae-backend-device",
+             "device to use for vae (defaults to main-backend-device). Also applies to tae, unless tae-backend-device is specified",
+             &vae_backend_device},
+            {"",
+             "--tae-backend-device",
+             "device to use for tae (defaults to vae-backend-device)",
+             &tae_backend_device},
+            {"",
+             "--control-net-backend-device",
+             "device to use for control net (defaults to main-backend-device)",
+             &control_net_backend_device},
+
         };
 
         options.int_options = {
@@ -600,18 +629,6 @@ struct SDContextParams {
              "--mmap",
              "whether to memory-map model",
              true, &enable_mmap},
-            {"",
-             "--control-net-cpu",
-             "keep controlnet in cpu (for low vram)",
-             true, &control_net_cpu},
-            {"",
-             "--clip-on-cpu",
-             "keep clip in cpu (for low vram)",
-             true, &clip_on_cpu},
-            {"",
-             "--vae-on-cpu",
-             "keep vae in cpu (for low vram)",
-             true, &vae_on_cpu},
             {"",
              "--fa",
              "use flash attention",
@@ -876,6 +893,7 @@ struct SDContextParams {
 
         std::string embeddings_str = emb_ss.str();
         std::ostringstream oss;
+        // TODO backend devices
         oss << "SDContextParams {\n"
             << "  n_threads: " << n_threads << ",\n"
             << "  model_path: \"" << model_path << "\",\n"
@@ -901,9 +919,9 @@ struct SDContextParams {
             << "  sampler_rng_type: " << sd_rng_type_name(sampler_rng_type) << ",\n"
             << "  offload_params_to_cpu: " << (offload_params_to_cpu ? "true" : "false") << ",\n"
             << "  enable_mmap: " << (enable_mmap ? "true" : "false") << ",\n"
-            << "  control_net_cpu: " << (control_net_cpu ? "true" : "false") << ",\n"
-            << "  clip_on_cpu: " << (clip_on_cpu ? "true" : "false") << ",\n"
-            << "  vae_on_cpu: " << (vae_on_cpu ? "true" : "false") << ",\n"
+            // << "  control_net_cpu: " << (control_net_cpu ? "true" : "false") << ",\n"
+            // << "  clip_on_cpu: " << (clip_on_cpu ? "true" : "false") << ",\n"
+            // << "  vae_on_cpu: " << (vae_on_cpu ? "true" : "false") << ",\n"
             << "  flash_attn: " << (flash_attn ? "true" : "false") << ",\n"
             << "  diffusion_flash_attn: " << (diffusion_flash_attn ? "true" : "false") << ",\n"
             << "  diffusion_conv_direct: " << (diffusion_conv_direct ? "true" : "false") << ",\n"
@@ -966,9 +984,6 @@ struct SDContextParams {
             lora_apply_mode,
             offload_params_to_cpu,
             enable_mmap,
-            clip_on_cpu,
-            control_net_cpu,
-            vae_on_cpu,
             flash_attn,
             diffusion_flash_attn,
             taesd_preview,
@@ -981,6 +996,12 @@ struct SDContextParams {
             chroma_use_t5_mask,
             chroma_t5_mask_pad,
             qwen_image_zero_cond_t,
+            main_backend_device.c_str(),
+            diffusion_backend_device.c_str(),
+            clip_backend_device.c_str(),
+            vae_backend_device.c_str(),
+            tae_backend_device.c_str(),
+            control_net_backend_device.c_str(),
         };
         return sd_ctx_params;
     }

--- a/examples/common/common.hpp
+++ b/examples/common/common.hpp
@@ -466,7 +466,7 @@ struct SDContextParams {
     std::string tae_backend_device;
     std::string control_net_backend_device;
     std::string upscaler_backend_device;
-
+    std::string photomaker_backend_device;
 
     std::map<std::string, std::string> embedding_map;
     std::vector<sd_embedding_t> embedding_vec;
@@ -608,6 +608,10 @@ struct SDContextParams {
              "--upscaler-backend-device",
              "device to use for upscaling models (defaults to main-backend-device)",
              &upscaler_backend_device},
+             {"",
+             "--photomaker-backend-device",
+             "device to use for photomaker (defaults to main-backend-device)",
+             &photomaker_backend_device},
 
 
         };
@@ -1021,6 +1025,7 @@ struct SDContextParams {
             vae_backend_device.c_str(),
             tae_backend_device.c_str(),
             control_net_backend_device.c_str(),
+            photomaker_backend_device.c_str(),
         };
         return sd_ctx_params;
     }

--- a/examples/common/common.hpp
+++ b/examples/common/common.hpp
@@ -467,6 +467,7 @@ struct SDContextParams {
     std::string control_net_backend_device;
     std::string upscaler_backend_device;
     std::string photomaker_backend_device;
+    std::string vision_backend_device;
 
     std::map<std::string, std::string> embedding_map;
     std::vector<sd_embedding_t> embedding_vec;
@@ -612,7 +613,10 @@ struct SDContextParams {
              "--photomaker-backend-device",
              "device to use for photomaker (defaults to main-backend-device)",
              &photomaker_backend_device},
-
+             {"",
+             "--vision-backend-device",
+             "device to use for clip-vision model (defaults to clip-backend-device)",
+             &vision_backend_device},
 
         };
 
@@ -1026,6 +1030,7 @@ struct SDContextParams {
             tae_backend_device.c_str(),
             control_net_backend_device.c_str(),
             photomaker_backend_device.c_str(),
+            vision_backend_device.c_str(),
         };
         return sd_ctx_params;
     }

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -121,6 +121,17 @@ Context Options:
   --tensor-type-rules <string>             weight type per tensor pattern (example: "^vae\.=f16,model\.=q8_0")
   --photo-maker <string>                   path to PHOTOMAKER model
   --upscale-model <string>                 path to esrgan model.
+  --main-backend-device <string>           default device to use for all backends (defaults to main gpu device if hardware acceleration is available, otherwise
+                                           cpu)
+  --diffusion-backend-device <string>      device to use for diffusion (defaults to main-backend-device)
+  --clip-backend-device <string>           device to use for clip (defaults to main-backend-device). Can be a comma-separated list of devices for models with
+                                           multiple encoders
+  --vae-backend-device <string>            device to use for vae (defaults to main-backend-device). Also applies to tae, unless tae-backend-device is specified
+  --tae-backend-device <string>            device to use for tae (defaults to vae-backend-device)
+  --control-net-backend-device <string>    device to use for control net (defaults to main-backend-device)
+  --upscaler-backend-device <string>       device to use for upscaling models (defaults to main-backend-device)
+  --photomaker-backend-device <string>     device to use for photomaker (defaults to main-backend-device)
+  --vision-backend-device <string>         device to use for clip-vision model (defaults to main-backend-device)
   -t, --threads <int>                      number of threads to use during computation (default: -1). If threads <= 0, then threads will be set to the number of
                                            CPU physical cores
   --chroma-t5-mask-pad <int>               t5 mask pad size of chroma
@@ -129,9 +140,6 @@ Context Options:
   --force-sdxl-vae-conv-scale              force use of conv scale on sdxl vae
   --offload-to-cpu                         place the weights in RAM to save VRAM, and automatically load them into VRAM when needed
   --mmap                                   whether to memory-map model
-  --control-net-cpu                        keep controlnet in cpu (for low vram)
-  --clip-on-cpu                            keep clip in cpu (for low vram)
-  --vae-on-cpu                             keep vae in cpu (for low vram)
   --fa                                     use flash attention
   --diffusion-fa                           use flash attention in the diffusion model only
   --diffusion-conv-direct                  use ggml_conv2d_direct in the diffusion model

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -395,7 +395,8 @@ SD_API upscaler_ctx_t* new_upscaler_ctx(const char* esrgan_path,
                                         bool offload_params_to_cpu,
                                         bool direct,
                                         int n_threads,
-                                        int tile_size);
+                                        int tile_size,
+                                        const char * device);
 SD_API void free_upscaler_ctx(upscaler_ctx_t* upscaler_ctx);
 
 SD_API sd_image_t upscale(upscaler_ctx_t* upscaler_ctx,

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -207,6 +207,7 @@ typedef struct {
     const char* vae_device;
     const char* tae_device;
     const char* control_net_device;
+    const char* photomaker_device;
 } sd_ctx_params_t;
 
 typedef struct {

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -421,6 +421,11 @@ SD_API bool preprocess_canny(sd_image_t image,
 SD_API const char* sd_commit(void);
 SD_API const char* sd_version(void);
 
+SD_API size_t backend_list_size(void);
+SD_API void list_backends_to_buffer(char* buffer, size_t buffer_size);
+
+SD_API void add_rpc_device(const char* address);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -186,9 +186,9 @@ typedef struct {
     enum lora_apply_mode_t lora_apply_mode;
     bool offload_params_to_cpu;
     bool enable_mmap;
-    bool keep_clip_on_cpu;
-    bool keep_control_net_on_cpu;
-    bool keep_vae_on_cpu;
+    // bool keep_clip_on_cpu;
+    // bool keep_control_net_on_cpu;
+    // bool keep_vae_on_cpu;
     bool flash_attn;
     bool diffusion_flash_attn;
     bool tae_preview_only;
@@ -201,6 +201,12 @@ typedef struct {
     bool chroma_use_t5_mask;
     int chroma_t5_mask_pad;
     bool qwen_image_zero_cond_t;
+    const char* main_device;
+    const char* diffusion_device;
+    const char* clip_device;
+    const char* vae_device;
+    const char* tae_device;
+    const char* control_net_device;
 } sd_ctx_params_t;
 
 typedef struct {

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -208,6 +208,7 @@ typedef struct {
     const char* tae_device;
     const char* control_net_device;
     const char* photomaker_device;
+    const char* vision_device;
 } sd_ctx_params_t;
 
 typedef struct {

--- a/src/common_block.hpp
+++ b/src/common_block.hpp
@@ -267,7 +267,7 @@ public:
         auto net_2 = std::dynamic_pointer_cast<Linear>(blocks["net.2"]);
         #ifdef SD_USE_VULKAN
             if(ggml_backend_is_vk(ctx->backend)){
-                net_2->set_force_prec_32(true);
+                net_2->set_force_prec_f32(true);
             }
         #endif
 

--- a/src/common_block.hpp
+++ b/src/common_block.hpp
@@ -248,9 +248,6 @@ public:
         float scale         = 1.f;
         if (precision_fix) {
             scale = 1.f / 128.f;
-#ifdef SD_USE_VULKAN
-            force_prec_f32 = true;
-#endif
         }
         // The purpose of the scale here is to prevent NaN issues in certain situations.
         // For example, when using Vulkan without enabling force_prec_f32,
@@ -264,6 +261,11 @@ public:
 
         auto net_0 = std::dynamic_pointer_cast<UnaryBlock>(blocks["net.0"]);
         auto net_2 = std::dynamic_pointer_cast<Linear>(blocks["net.2"]);
+        #ifdef SD_USE_VULKAN
+            if(ggml_backend_is_vk(ctx->backend)){
+                net_2->set_force_prec_32(true);
+            }
+        #endif
 
         x = net_0->forward(ctx, x);  // [ne3, ne2, ne1, inner_dim]
         x = net_2->forward(ctx, x);  // [ne3, ne2, ne1, dim_out]

--- a/src/common_block.hpp
+++ b/src/common_block.hpp
@@ -3,6 +3,10 @@
 
 #include "ggml_extend.hpp"
 
+#ifdef SD_USE_VULKAN
+#include "ggml-vulkan.h"
+#endif
+
 class DownSampleBlock : public GGMLBlock {
 protected:
     int channels;

--- a/src/conditioner.hpp
+++ b/src/conditioner.hpp
@@ -4,9 +4,12 @@
 #include <optional>
 
 #include "clip.hpp"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
 #include "llm.hpp"
 #include "t5.hpp"
 #include "tensor_ggml.hpp"
+#include "util.h"
 
 struct SDCondition {
     sd::Tensor<float> c_crossattn;
@@ -112,7 +115,7 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
     std::vector<uint8_t> token_embed_custom;
     std::map<std::string, std::pair<int, int>> embedding_pos_map;
 
-    FrozenCLIPEmbedderWithCustomWords(ggml_backend_t backend,
+    FrozenCLIPEmbedderWithCustomWords(std::vector<ggml_backend_t> backends,
                                       bool offload_params_to_cpu,
                                       const String2TensorStorage& tensor_storage_map,
                                       const std::map<std::string, std::string>& orig_embedding_map,
@@ -126,13 +129,27 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
             tokenizer.add_special_token(name);
         }
         bool force_clip_f32 = !embedding_map.empty();
+
+        ggml_backend_t clip_backend = backends[0];
+
         if (sd_version_is_sd1(version)) {
-            text_model = std::make_shared<CLIPTextModelRunner>(backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.transformer.text_model", OPENAI_CLIP_VIT_L_14, true, force_clip_f32);
+            LOG_INFO("CLIP-L: using %s backend", ggml_backend_name(clip_backend));
+            text_model = std::make_shared<CLIPTextModelRunner>(clip_backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.transformer.text_model", OPENAI_CLIP_VIT_L_14, true, force_clip_f32);
         } else if (sd_version_is_sd2(version)) {
-            text_model = std::make_shared<CLIPTextModelRunner>(backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.transformer.text_model", OPEN_CLIP_VIT_H_14, true, force_clip_f32);
+            LOG_INFO("CLIP-H: using %s backend", ggml_backend_name(clip_backend));
+            text_model = std::make_shared<CLIPTextModelRunner>(clip_backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.transformer.text_model", OPEN_CLIP_VIT_H_14, true, force_clip_f32);
         } else if (sd_version_is_sdxl(version)) {
-            text_model  = std::make_shared<CLIPTextModelRunner>(backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.transformer.text_model", OPENAI_CLIP_VIT_L_14, false, force_clip_f32);
-            text_model2 = std::make_shared<CLIPTextModelRunner>(backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.1.transformer.text_model", OPEN_CLIP_VIT_BIGG_14, false, force_clip_f32);
+            ggml_backend_t clip_g_backend = clip_backend;
+            if (backends.size() >= 2){
+                clip_g_backend = backends[1];
+                if (backends.size() > 2) {
+                    LOG_WARN("More than 2 clip backends provided, but the model only supports 2 text encoders. Ignoring the rest.");
+                }
+            }
+            LOG_INFO("CLIP-L: using %s backend", ggml_backend_name(clip_backend));
+            LOG_INFO("CLIP-G: using %s backend", ggml_backend_name(clip_g_backend));
+            text_model  = std::make_shared<CLIPTextModelRunner>(clip_backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.transformer.text_model", OPENAI_CLIP_VIT_L_14, false, force_clip_f32);
+            text_model2 = std::make_shared<CLIPTextModelRunner>(clip_g_backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.1.transformer.text_model", OPEN_CLIP_VIT_BIGG_14, false, force_clip_f32);
         }
     }
 
@@ -716,13 +733,29 @@ struct SD3CLIPEmbedder : public Conditioner {
     std::shared_ptr<CLIPTextModelRunner> clip_g;
     std::shared_ptr<T5Runner> t5;
 
-    SD3CLIPEmbedder(ggml_backend_t backend,
+    SD3CLIPEmbedder(std::vector<ggml_backend_t> backends,
                     bool offload_params_to_cpu,
                     const String2TensorStorage& tensor_storage_map = {})
         : clip_g_tokenizer(0) {
         bool use_clip_l = false;
         bool use_clip_g = false;
         bool use_t5     = false;
+
+        ggml_backend_t clip_l_backend, clip_g_backend, t5_backend;
+        if (backends.size() == 1) {
+            clip_l_backend = clip_g_backend = t5_backend = backends[0];
+        } else if (backends.size() == 2) {
+            clip_l_backend = clip_g_backend = backends[0];
+            t5_backend = backends[1];
+        } else if (backends.size() >= 3) {
+            clip_l_backend = backends[0];
+            clip_g_backend = backends[1];
+            t5_backend     = backends[2];
+            if (backends.size() > 3) {
+                LOG_WARN("More than 3 clip backends provided, but the model only supports 3 text encoders. Ignoring the rest.");
+            }
+        }
+
         for (auto pair : tensor_storage_map) {
             if (pair.first.find("text_encoders.clip_l") != std::string::npos) {
                 use_clip_l = true;
@@ -737,13 +770,16 @@ struct SD3CLIPEmbedder : public Conditioner {
             return;
         }
         if (use_clip_l) {
-            clip_l = std::make_shared<CLIPTextModelRunner>(backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.clip_l.transformer.text_model", OPENAI_CLIP_VIT_L_14, false);
+            LOG_INFO("CLIP-L: using %s backend", ggml_backend_name(clip_l_backend));
+            clip_l = std::make_shared<CLIPTextModelRunner>(clip_l_backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.clip_l.transformer.text_model", OPENAI_CLIP_VIT_L_14, false);
         }
         if (use_clip_g) {
-            clip_g = std::make_shared<CLIPTextModelRunner>(backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.clip_g.transformer.text_model", OPEN_CLIP_VIT_BIGG_14, false);
+            LOG_INFO("CLIP-G: using %s backend", ggml_backend_name(clip_g_backend));
+            clip_g = std::make_shared<CLIPTextModelRunner>(clip_g_backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.clip_g.transformer.text_model", OPEN_CLIP_VIT_BIGG_14, false);
         }
         if (use_t5) {
-            t5 = std::make_shared<T5Runner>(backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.t5xxl.transformer");
+            LOG_INFO("T5-XXL: using %s backend", ggml_backend_name(t5_backend));
+            t5 = std::make_shared<T5Runner>(t5_backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.t5xxl.transformer");
         }
     }
 
@@ -1071,11 +1107,25 @@ struct FluxCLIPEmbedder : public Conditioner {
     std::shared_ptr<T5Runner> t5;
     size_t chunk_len = 256;
 
-    FluxCLIPEmbedder(ggml_backend_t backend,
+    FluxCLIPEmbedder(std::vector<ggml_backend_t> backends,
                      bool offload_params_to_cpu,
                      const String2TensorStorage& tensor_storage_map = {}) {
         bool use_clip_l = false;
         bool use_t5     = false;
+
+
+        ggml_backend_t clip_l_backend, t5_backend;
+        if (backends.size() == 1) {
+            clip_l_backend = t5_backend = backends[0];
+        } else if (backends.size() >= 2) {
+            clip_l_backend = backends[0];
+            t5_backend = backends[1];
+            if (backends.size() > 2) {
+                LOG_WARN("More than 2 clip backends provided, but the model only supports 2 text encoders. Ignoring the rest.");
+            }
+        }
+
+
         for (auto pair : tensor_storage_map) {
             if (pair.first.find("text_encoders.clip_l") != std::string::npos) {
                 use_clip_l = true;
@@ -1090,12 +1140,14 @@ struct FluxCLIPEmbedder : public Conditioner {
         }
 
         if (use_clip_l) {
-            clip_l = std::make_shared<CLIPTextModelRunner>(backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.clip_l.transformer.text_model", OPENAI_CLIP_VIT_L_14, true);
+            LOG_INFO("CLIP-L: using %s backend", ggml_backend_name(clip_l_backend));
+            clip_l = std::make_shared<CLIPTextModelRunner>(clip_l_backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.clip_l.transformer.text_model", OPENAI_CLIP_VIT_L_14, true);
         } else {
             LOG_WARN("clip_l text encoder not found! Prompt adherence might be degraded.");
         }
         if (use_t5) {
-            t5 = std::make_shared<T5Runner>(backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.t5xxl.transformer");
+            LOG_INFO("T5-XXL: using %s backend", ggml_backend_name(clip_l_backend));
+            t5 = std::make_shared<T5Runner>(t5_backend, offload_params_to_cpu, tensor_storage_map, "text_encoders.t5xxl.transformer");
         } else {
             LOG_WARN("t5xxl text encoder not found! Prompt adherence might be degraded.");
         }

--- a/src/conditioner.hpp
+++ b/src/conditioner.hpp
@@ -82,6 +82,7 @@ struct Conditioner {
     virtual ~Conditioner() = default;
 
 public:
+    int model_count                                                                        = 1;
     virtual SDCondition get_learned_condition(int n_threads,
                                               const ConditionerParams& conditioner_params) = 0;
     virtual void alloc_params_buffer()                                                     = 0;
@@ -97,6 +98,11 @@ public:
     virtual std::string remove_trigger_from_prompt(const std::string& prompt) {
         GGML_ABORT("Not implemented yet!");
     }
+    virtual bool is_cond_stage_model_name_at_index(const std::string& name, int index) {
+        return true;
+    }
+    virtual ggml_backend_t get_params_backend_at_index(int index) = 0;
+    virtual ggml_backend_t get_runtime_backend_at_index(int index) = 0;
 };
 
 // ldm.modules.encoders.modules.FrozenCLIPEmbedder
@@ -139,8 +145,9 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
             LOG_INFO("CLIP-H: using %s backend", ggml_backend_name(clip_backend));
             text_model = std::make_shared<CLIPTextModelRunner>(clip_backend, offload_params_to_cpu, tensor_storage_map, "cond_stage_model.transformer.text_model", OPEN_CLIP_VIT_H_14, true, force_clip_f32);
         } else if (sd_version_is_sdxl(version)) {
+            model_count                   = 2;
             ggml_backend_t clip_g_backend = clip_backend;
-            if (backends.size() >= 2){
+            if (backends.size() >= 2) {
                 clip_g_backend = backends[1];
                 if (backends.size() > 2) {
                     LOG_WARN("More than 2 clip backends provided, but the model only supports 2 text encoders. Ignoring the rest.");
@@ -669,6 +676,42 @@ struct FrozenCLIPEmbedderWithCustomWords : public Conditioner {
                                             conditioner_params.adm_in_channels,
                                             conditioner_params.zero_out_masked);
     }
+
+    bool is_cond_stage_model_name_at_index(const std::string& name, int index) override {
+        if (sd_version_is_sdxl(version)) {
+            if (index == 0) {
+                return contains(name, "cond_stage_model.model.transformer");
+            } else if (index == 1) {
+                return contains(name, "cond_stage_model.model.1");
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    ggml_backend_t get_params_backend_at_index(int index){
+        if (sd_version_is_sdxl(version) && index == 1){
+            if(text_model2) {
+                return text_model2->get_params_backend();
+            }
+        } else if (text_model) {
+            return text_model->get_params_backend();
+        }
+        return nullptr;
+    }
+
+    ggml_backend_t get_runtime_backend_at_index(int index){
+        if (sd_version_is_sdxl(version) && index == 1){
+            if(text_model2) {
+                return text_model2->get_runtime_backend();
+            }
+        } else if (text_model) {
+            return text_model->get_runtime_backend();
+        }
+        return nullptr;
+    }
+
 };
 
 struct FrozenCLIPVisionEmbedder : public GGMLRunner {
@@ -741,12 +784,14 @@ struct SD3CLIPEmbedder : public Conditioner {
         bool use_clip_g = false;
         bool use_t5     = false;
 
+        model_count = 3;
+
         ggml_backend_t clip_l_backend, clip_g_backend, t5_backend;
         if (backends.size() == 1) {
             clip_l_backend = clip_g_backend = t5_backend = backends[0];
         } else if (backends.size() == 2) {
             clip_l_backend = clip_g_backend = backends[0];
-            t5_backend = backends[1];
+            t5_backend                      = backends[1];
         } else if (backends.size() >= 3) {
             clip_l_backend = backends[0];
             clip_g_backend = backends[1];
@@ -1098,6 +1143,42 @@ struct SD3CLIPEmbedder : public Conditioner {
                                             conditioner_params.clip_skip,
                                             conditioner_params.zero_out_masked);
     }
+
+    bool is_cond_stage_model_name_at_index(const std::string& name, int index) override {
+        if (index == 0) {
+            return contains(name, "text_encoders.clip_l");
+        } else if (index == 1) {
+            return contains(name, "text_encoders.clip_g");
+        } else if (index == 2) {
+            return contains(name, "text_encoders.t5xxl");
+        } else {
+            return false;
+        }
+    }
+
+    ggml_backend_t get_params_backend_at_index(int index){
+        if (index == 0 && clip_l) {
+            return clip_l->get_params_backend();
+        } else if (index == 1 && clip_g) {
+            return clip_g->get_params_backend();
+        } else if (index == 2 && t5) {
+            return t5->get_params_backend();
+        } else {
+            return nullptr;
+        }
+    }
+
+    ggml_backend_t get_runtime_backend_at_index(int index){
+        if (index == 0 && clip_l) {
+            return clip_l->get_runtime_backend();
+        } else if (index == 1 && clip_g) {
+            return clip_g->get_runtime_backend();
+        } else if (index == 2 && t5) {
+            return t5->get_runtime_backend();
+        } else {
+            return nullptr;
+        }
+    }
 };
 
 struct FluxCLIPEmbedder : public Conditioner {
@@ -1113,18 +1194,18 @@ struct FluxCLIPEmbedder : public Conditioner {
         bool use_clip_l = false;
         bool use_t5     = false;
 
+        model_count = 2;
 
         ggml_backend_t clip_l_backend, t5_backend;
         if (backends.size() == 1) {
             clip_l_backend = t5_backend = backends[0];
         } else if (backends.size() >= 2) {
             clip_l_backend = backends[0];
-            t5_backend = backends[1];
+            t5_backend     = backends[1];
             if (backends.size() > 2) {
                 LOG_WARN("More than 2 clip backends provided, but the model only supports 2 text encoders. Ignoring the rest.");
             }
         }
-
 
         for (auto pair : tensor_storage_map) {
             if (pair.first.find("text_encoders.clip_l") != std::string::npos) {
@@ -1358,6 +1439,36 @@ struct FluxCLIPEmbedder : public Conditioner {
                                             conditioner_params.clip_skip,
                                             conditioner_params.zero_out_masked);
     }
+
+    bool is_cond_stage_model_name_at_index(const std::string& name, int index) override {
+        if (index == 0) {
+            return contains(name, "text_encoders.clip_l");
+        } else if (index == 1) {
+            return contains(name, "text_encoders.t5xxl");
+        } else {
+            return false;
+        }
+    }
+
+    ggml_backend_t get_params_backend_at_index(int index){
+        if (index == 0 && clip_l) {
+            return clip_l->get_params_backend();
+        } else if (index == 1 && t5) {
+            return t5->get_params_backend();
+        } else {
+            return nullptr;
+        }
+    }
+
+    ggml_backend_t get_runtime_backend_at_index(int index){
+        if (index == 0 && clip_l) {
+            return clip_l->get_runtime_backend();
+        } else if (index == 1 && t5) {
+            return t5->get_runtime_backend();
+        } else {
+            return nullptr;
+        }
+    }
 };
 
 struct T5CLIPEmbedder : public Conditioner {
@@ -1554,6 +1665,20 @@ struct T5CLIPEmbedder : public Conditioner {
                                             conditioner_params.clip_skip,
                                             conditioner_params.zero_out_masked);
     }
+
+    ggml_backend_t get_params_backend_at_index(int index){
+        if (t5){
+            return t5->get_params_backend();
+        }
+        return nullptr;
+    }
+
+    ggml_backend_t get_runtime_backend_at_index(int index){
+        if (t5){
+            return t5->get_runtime_backend();
+        }
+        return nullptr;
+    }
 };
 
 struct AnimaConditioner : public Conditioner {
@@ -1566,11 +1691,11 @@ struct AnimaConditioner : public Conditioner {
                      const String2TensorStorage& tensor_storage_map = {}) {
         qwen_tokenizer = std::make_shared<LLM::Qwen2Tokenizer>();
         llm            = std::make_shared<LLM::LLMRunner>(LLM::LLMArch::QWEN3,
-                                               backend,
-                                               offload_params_to_cpu,
-                                               tensor_storage_map,
-                                               "text_encoders.llm",
-                                               false);
+                                                          backend,
+                                                          offload_params_to_cpu,
+                                                          tensor_storage_map,
+                                                          "text_encoders.llm",
+                                                          false);
     }
 
     void get_param_tensors(std::map<std::string, ggml_tensor*>& tensors) override {
@@ -1667,6 +1792,20 @@ struct AnimaConditioner : public Conditioner {
         result.c_t5_ids     = std::move(t5_ids_tensor);
         result.c_t5_weights = std::move(t5_weight_tensor);
         return result;
+    }
+
+    ggml_backend_t get_params_backend_at_index(int index){
+        if (llm){
+            return llm->get_params_backend();
+        }
+        return nullptr;
+    }
+
+    ggml_backend_t get_runtime_backend_at_index(int index){
+        if (llm){
+            return llm->get_runtime_backend();
+        }
+        return nullptr;
     }
 };
 
@@ -2011,6 +2150,20 @@ struct LLMEmbedder : public Conditioner {
         result.c_crossattn        = std::move(hidden_states);
         result.extra_c_crossattns = std::move(extra_hidden_states_vec);
         return result;
+    }
+
+    ggml_backend_t get_params_backend_at_index(int index){
+        if (llm){
+            return llm->get_params_backend();
+        }
+        return nullptr;
+    }
+
+    ggml_backend_t get_runtime_backend_at_index(int index){
+        if (llm){
+            return llm->get_runtime_backend();
+        }
+        return nullptr;
     }
 };
 

--- a/src/ggml_extend.hpp
+++ b/src/ggml_extend.hpp
@@ -91,6 +91,42 @@ __STATIC_INLINE__ void ggml_log_callback_default(ggml_log_level level, const cha
     }
 }
 
+__STATIC_INLINE__ bool backend_name_exists(std::string name) {
+    const int device_count = ggml_backend_dev_count();
+    for (int i = 0; i < device_count; i++) {
+        if (name == ggml_backend_dev_name(ggml_backend_dev_get(i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+__STATIC_INLINE__ std::string sanitize_backend_name(std::string name) {
+    if (name == "" || backend_name_exists(name)) {
+        return name;
+    } else {
+        LOG_WARN("Backend %s not found, using default backend", name.c_str());
+        return "";
+    }
+}
+
+__STATIC_INLINE__ std::string get_default_backend_name() {
+    // should pick the same backend as ggml_backend_init_best
+    ggml_backend_dev_t dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_GPU);
+    dev                    = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_IGPU);
+    dev                    = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    return ggml_backend_dev_name(dev);
+}
+
+__STATIC_INLINE__ ggml_backend_t init_named_backend(std::string name = "") {
+    LOG_DEBUG("Initializing backend: %s", name.c_str());
+    if (name.empty()) {
+        return ggml_backend_init_best();
+    } else {
+        return ggml_backend_init_by_name(name.c_str(), nullptr);
+    }
+}
+
 static_assert(GGML_MAX_NAME >= 128, "GGML_MAX_NAME must be at least 128");
 
 // n-mode tensor-matrix product

--- a/src/ggml_extend.hpp
+++ b/src/ggml_extend.hpp
@@ -2208,6 +2208,14 @@ public:
     void set_weight_adapter(const std::shared_ptr<WeightAdapter>& adapter) {
         weight_adapter = adapter;
     }
+
+    ggml_backend_t get_runtime_backend() {
+        return runtime_backend;
+    }
+
+    ggml_backend_t get_params_backend() {
+        return params_backend;
+    }
 };
 
 class GGMLBlock {

--- a/src/ggml_extend.hpp
+++ b/src/ggml_extend.hpp
@@ -2356,7 +2356,7 @@ public:
         scale = scale_;
     }
 
-    void set_force_prec_32(bool force_prec_f32_){
+    void set_force_prec_f32(bool force_prec_f32_){
         force_prec_f32 = force_prec_f32_;
     }
 

--- a/src/ggml_extend.hpp
+++ b/src/ggml_extend.hpp
@@ -30,26 +30,6 @@
 #include "model.h"
 #include "tensor.hpp"
 
-#ifdef SD_USE_CUDA
-#include "ggml-cuda.h"
-#endif
-
-#ifdef SD_USE_METAL
-#include "ggml-metal.h"
-#endif
-
-#ifdef SD_USE_VULKAN
-#include "ggml-vulkan.h"
-#endif
-
-#ifdef SD_USE_OPENCL
-#include "ggml-opencl.h"
-#endif
-
-#ifdef SD_USE_SYCL
-#include "ggml-sycl.h"
-#endif
-
 #include "rng.hpp"
 #include "tensor_ggml.hpp"
 #include "util.h"
@@ -2371,6 +2351,14 @@ public:
           force_f32(force_f32),
           force_prec_f32(force_prec_f32),
           scale(scale) {}
+
+    void set_scale(float scale_){
+        scale = scale_;
+    }
+
+    void set_force_prec_32(bool force_prec_f32_){
+        force_prec_f32 = force_prec_f32_;
+    }
 
     ggml_tensor* forward(GGMLRunnerContext* ctx, ggml_tensor* x) {
         ggml_tensor* w = params["weight"];

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -25,18 +25,6 @@
 #include "name_conversion.h"
 #include "stable-diffusion.h"
 
-#ifdef SD_USE_METAL
-#include "ggml-metal.h"
-#endif
-
-#ifdef SD_USE_VULKAN
-#include "ggml-vulkan.h"
-#endif
-
-#ifdef SD_USE_OPENCL
-#include "ggml-opencl.h"
-#endif
-
 #define ST_HEADER_SIZE_LEN 8
 
 uint64_t read_u64(uint8_t* buffer) {

--- a/src/qwen_image.hpp
+++ b/src/qwen_image.hpp
@@ -6,6 +6,10 @@
 #include "common_block.hpp"
 #include "flux.hpp"
 
+#ifdef SD_USE_VULKAN
+#include "ggml-vulkan.h"
+#endif
+
 namespace Qwen {
     constexpr int QWEN_IMAGE_GRAPH_SIZE = 20480;
 

--- a/src/qwen_image.hpp
+++ b/src/qwen_image.hpp
@@ -95,9 +95,7 @@ namespace Qwen {
 
             float scale         = 1.f / 32.f;
             bool force_prec_f32 = false;
-#ifdef SD_USE_VULKAN
-            force_prec_f32 = true;
-#endif
+
             // The purpose of the scale here is to prevent NaN issues in certain situations.
             // For example when using CUDA but the weights are k-quants (not all prompts).
             blocks["to_out.0"] = std::shared_ptr<GGMLBlock>(new Linear(inner_dim, out_dim, out_bias, false, force_prec_f32, scale));
@@ -123,6 +121,11 @@ namespace Qwen {
             auto to_k     = std::dynamic_pointer_cast<Linear>(blocks["to_k"]);
             auto to_v     = std::dynamic_pointer_cast<Linear>(blocks["to_v"]);
             auto to_out_0 = std::dynamic_pointer_cast<Linear>(blocks["to_out.0"]);
+#ifdef SD_USE_VULKAN
+            if(ggml_backend_is_vk(ctx->backend)){
+                to_out_0->set_force_prec_32(true);
+            }
+#endif
 
             auto norm_added_q = std::dynamic_pointer_cast<UnaryBlock>(blocks["norm_added_q"]);
             auto norm_added_k = std::dynamic_pointer_cast<UnaryBlock>(blocks["norm_added_k"]);

--- a/src/qwen_image.hpp
+++ b/src/qwen_image.hpp
@@ -127,7 +127,7 @@ namespace Qwen {
             auto to_out_0 = std::dynamic_pointer_cast<Linear>(blocks["to_out.0"]);
 #ifdef SD_USE_VULKAN
             if(ggml_backend_is_vk(ctx->backend)){
-                to_out_0->set_force_prec_32(true);
+                to_out_0->set_force_prec_f32(true);
             }
 #endif
 

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1210,22 +1210,60 @@ public:
         }
 
         for (auto& kv : lora_state_diff) {
+            bool applied = false;
             int64_t t0 = ggml_time_ms();
             // TODO: Fix that
-            bool are_clip_backends_compatible = true;
+            bool are_clip_backends_similar = true;
             for (auto backend: clip_backends){
-                are_clip_backends_compatible = are_clip_backends_compatible && (diffusion_backend==backend || ggml_backend_is_cpu(backend));
+                are_clip_backends_similar = are_clip_backends_similar && (clip_backends[0]==backend || ggml_backend_is_cpu(backend));
             }
-            if(!are_clip_backends_compatible){
-                LOG_WARN("Diffusion models and text encoders are running on different backends. This may cause issues when immediately applying LoRAs.");
+            if(!are_clip_backends_similar){
+                LOG_WARN("Text encoders are running on different backends. This may cause issues when immediately applying LoRAs.");
             }
-            auto lora = load_lora_model_from_file(kv.first, kv.second, diffusion_backend);
-            if (!lora || lora->lora_tensors.empty()) {
+            auto lora_tensor_filter_diff = [&](const std::string& tensor_name) {
+                if (is_diffusion_model_name(tensor_name)) {
+                    return true;
+                }
+                return false;
+            };
+            auto lora = load_lora_model_from_file(kv.first, kv.second, diffusion_backend, lora_tensor_filter_diff);
+            if (lora && !lora->lora_tensors.empty()) {
+                lora->apply(tensors, version, n_threads);
+                lora->free_params_buffer();
+                applied = true;
+            }
+
+            auto lora_tensor_filter_cond = [&](const std::string& tensor_name) {
+                if (is_cond_stage_model_name(tensor_name)) {
+                    return true;
+                }
+                return false;
+            };
+            // TODO: split by model
+            lora = load_lora_model_from_file(kv.first, kv.second, clip_backends[0], lora_tensor_filter_cond);
+            if (lora && !lora->lora_tensors.empty()) {
+                lora->apply(tensors, version, n_threads);
+                lora->free_params_buffer();
+                applied = true;
+            }
+
+            auto lora_tensor_filter_first = [&](const std::string& tensor_name) {
+                if (is_first_stage_model_name(tensor_name)) {
+                    return true;
+                }
+                return false;
+            };
+            auto first_stage_backend = use_tiny_autoencoder ? tae_backend : vae_backend;
+            lora                     = load_lora_model_from_file(kv.first, kv.second, first_stage_backend, lora_tensor_filter_first);
+            if (lora && !lora->lora_tensors.empty()) {
+                lora->apply(tensors, version, n_threads);
+                lora->free_params_buffer();
+                applied = true;
+            }
+
+            if (!applied) {
                 continue;
             }
-            lora->apply(tensors, version, n_threads);
-            lora->free_params_buffer();
-
             int64_t t1 = ggml_time_ms();
 
             LOG_INFO("lora '%s' applied, taking %.2fs", kv.first.c_str(), (t1 - t0) * 1.0f / 1000);

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -197,6 +197,7 @@ public:
     ggml_backend_t control_net_backend = nullptr;
     ggml_backend_t vae_backend         = nullptr;
     ggml_backend_t tae_backend         = nullptr;
+    ggml_backend_t pmid_backend        = nullptr;
 
     // TODO: clip_vision and photomaker backends
 
@@ -316,6 +317,7 @@ public:
         std::string control_net_backend_name = sanitize_backend_name(SAFE_STR(sd_ctx_params->control_net_device));
         std::string vae_backend_name         = sanitize_backend_name(SAFE_STR(sd_ctx_params->vae_device));
         std::string tae_backend_name         = sanitize_backend_name(SAFE_STR(sd_ctx_params->tae_device));
+        std::string pmid_backend_name        = sanitize_backend_name(SAFE_STR(sd_ctx_params->photomaker_device));
 
         bool diffusion_backend_is_default   = diffusion_backend_name.empty() || diffusion_backend_name == default_backend_name;
         bool clip_backend_is_default        = (clip_backend_name.empty() || clip_backend_name == default_backend_name);
@@ -323,9 +325,10 @@ public:
         bool vae_backend_is_default         = (vae_backend_name.empty() || vae_backend_name == default_backend_name);
         // if tae_backend_name is empty, it will use the same backend as vae
         bool tae_backend_is_default = (tae_backend_name.empty() && vae_backend_is_default) || tae_backend_name == default_backend_name;
+        bool pmid_backend_is_default = (pmid_backend_name.empty() || pmid_backend_name == default_backend_name);
 
         // if some backend is not specified or is the same as the default backend, use the default backend
-        bool use_default_backend = diffusion_backend_is_default || clip_backend_is_default || control_net_backend_is_default || vae_backend_is_default || tae_backend_is_default;
+        bool use_default_backend = diffusion_backend_is_default || clip_backend_is_default || control_net_backend_is_default || vae_backend_is_default || tae_backend_is_default || pmid_backend_is_default;
 
         if (use_default_backend) {
             backend = init_named_backend(override_default_backend_name);
@@ -775,14 +778,13 @@ public:
             }
 
             if (strlen(SAFE_STR(sd_ctx_params->control_net_path)) > 0) {
-                ggml_backend_t controlnet_backend = nullptr;
                 if (!control_net_backend_is_default) {
                     control_net_backend = init_named_backend(control_net_backend_name);
-                    LOG_INFO("ControlNet: Using %s backend", ggml_backend_name(controlnet_backend));
+                    LOG_INFO("ControlNet: Using %s backend", ggml_backend_name(control_net_backend));
                 } else {
-                    controlnet_backend = backend;
+                    control_net_backend = backend;
                 }
-                control_net = std::make_shared<ControlNet>(controlnet_backend,
+                control_net = std::make_shared<ControlNet>(control_net_backend,
                                                            offload_params_to_cpu,
                                                            tensor_storage_map,
                                                            version);
@@ -791,9 +793,15 @@ public:
                     control_net->set_conv2d_direct_enabled(true);
                 }
             }
-
+             pmid_backend = backend;
+            if (!pmid_backend_is_default) {
+                pmid_backend = init_named_backend(pmid_backend_name);
+                LOG_INFO("PhotoMaker: Using %s backend", ggml_backend_name(pmid_backend));
+            } else {
+                pmid_backend = backend;
+            }
             if (strstr(SAFE_STR(sd_ctx_params->photo_maker_path), "v2")) {
-                pmid_model = std::make_shared<PhotoMakerIDEncoder>(backend,
+                pmid_model = std::make_shared<PhotoMakerIDEncoder>(pmid_backend,
                                                                    offload_params_to_cpu,
                                                                    tensor_storage_map,
                                                                    "pmid",
@@ -801,7 +809,7 @@ public:
                                                                    PM_VERSION_2);
                 LOG_INFO("using PhotoMaker Version 2");
             } else {
-                pmid_model = std::make_shared<PhotoMakerIDEncoder>(backend,
+                pmid_model = std::make_shared<PhotoMakerIDEncoder>(pmid_backend,
                                                                    offload_params_to_cpu,
                                                                    tensor_storage_map,
                                                                    "pmid",
@@ -981,7 +989,7 @@ public:
                 control_net_params_mem_size / 1024.0 / 1024.0,
                 ggml_backend_is_cpu(control_net_backend) ? "RAM" : "VRAM",
                 pmid_params_mem_size / 1024.0 / 1024.0,
-                ggml_backend_is_cpu(clip_backend) ? "RAM" : "VRAM");
+                ggml_backend_is_cpu(pmid_backend) ? "RAM" : "VRAM");
         }
 
         // init denoiser

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -726,7 +726,7 @@ public:
                 ggml_backend_t controlnet_backend = nullptr;
                 if (!control_net_backend_is_default) {
                     control_net_backend = init_named_backend(control_net_backend_name);
-                    LOG_INFO("ControlNet: Using %s backend", control_net_backend_name);
+                    LOG_INFO("ControlNet: Using %s backend", ggml_backend_name(controlnet_backend));
                 } else {
                     controlnet_backend = backend;
                 }

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -198,8 +198,7 @@ public:
     ggml_backend_t vae_backend         = nullptr;
     ggml_backend_t tae_backend         = nullptr;
     ggml_backend_t pmid_backend        = nullptr;
-
-    // TODO: clip_vision and photomaker backends
+    ggml_backend_t vision_backend      = nullptr;
 
     SDVersion version;
     bool vae_decode_only         = false;
@@ -318,6 +317,7 @@ public:
         std::string vae_backend_name         = sanitize_backend_name(SAFE_STR(sd_ctx_params->vae_device));
         std::string tae_backend_name         = sanitize_backend_name(SAFE_STR(sd_ctx_params->tae_device));
         std::string pmid_backend_name        = sanitize_backend_name(SAFE_STR(sd_ctx_params->photomaker_device));
+        std::string vision_backend_name      = sanitize_backend_name(SAFE_STR(sd_ctx_params->vision_device));
 
         bool diffusion_backend_is_default   = diffusion_backend_name.empty() || diffusion_backend_name == default_backend_name;
         bool clip_backend_is_default        = (clip_backend_name.empty() || clip_backend_name == default_backend_name);
@@ -326,9 +326,11 @@ public:
         // if tae_backend_name is empty, it will use the same backend as vae
         bool tae_backend_is_default = (tae_backend_name.empty() && vae_backend_is_default) || tae_backend_name == default_backend_name;
         bool pmid_backend_is_default = (pmid_backend_name.empty() || pmid_backend_name == default_backend_name);
+        // if vision_backend_name is empty, it will use the same backend as clip
+        bool vision_backend_is_default = (vision_backend_name.empty() && clip_backend_is_default) || vision_backend_name == default_backend_name;
 
         // if some backend is not specified or is the same as the default backend, use the default backend
-        bool use_default_backend = diffusion_backend_is_default || clip_backend_is_default || control_net_backend_is_default || vae_backend_is_default || tae_backend_is_default || pmid_backend_is_default;
+        bool use_default_backend = diffusion_backend_is_default || clip_backend_is_default || control_net_backend_is_default || vae_backend_is_default || tae_backend_is_default || pmid_backend_is_default || vision_backend_is_default;
 
         if (use_default_backend) {
             backend = init_named_backend(override_default_backend_name);
@@ -597,7 +599,7 @@ public:
                 if (diffusion_model->get_desc() == "Wan2.1-I2V-14B" ||
                     diffusion_model->get_desc() == "Wan2.1-FLF2V-14B" ||
                     diffusion_model->get_desc() == "Wan2.1-I2V-1.3B") {
-                    clip_vision = std::make_shared<FrozenCLIPVisionEmbedder>(backend,
+                    clip_vision = std::make_shared<FrozenCLIPVisionEmbedder>(vision_backend,
                                                                              offload_params_to_cpu,
                                                                              tensor_storage_map);
                     clip_vision->alloc_params_buffer();

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -100,6 +100,90 @@ static float get_cache_reuse_threshold(const sd_cache_params_t& params) {
     return std::max(0.0f, reuse_threshold);
 }
 
+std::vector<std::string> string_split(const std::string & input, char separator)
+{
+    std::vector<std::string> parts;
+    size_t begin_pos = 0;
+    size_t separator_pos = input.find(separator);
+    while (separator_pos != std::string::npos) {
+        std::string part = input.substr(begin_pos, separator_pos - begin_pos);
+        parts.emplace_back(part);
+        begin_pos = separator_pos + 1;
+        separator_pos = input.find(separator, begin_pos);
+    }
+    parts.emplace_back(input.substr(begin_pos, separator_pos - begin_pos));
+    return parts;
+}
+
+static void add_rpc_devices(const std::string & servers) {
+    auto rpc_servers = string_split(servers, ',');
+    if (rpc_servers.empty()) {
+        throw std::invalid_argument("no RPC servers specified");
+    }
+    ggml_backend_reg_t rpc_reg = ggml_backend_reg_by_name("RPC");
+    if (!rpc_reg) {
+        throw std::invalid_argument("failed to find RPC backend");
+    }
+    typedef ggml_backend_reg_t (*ggml_backend_rpc_add_server_t)(const char * endpoint);
+    ggml_backend_rpc_add_server_t ggml_backend_rpc_add_server_fn = (ggml_backend_rpc_add_server_t) ggml_backend_reg_get_proc_address(rpc_reg, "ggml_backend_rpc_add_server");
+    if (!ggml_backend_rpc_add_server_fn) {
+        throw std::invalid_argument("failed to find RPC add server function");
+    }
+    for (const auto & server : rpc_servers) {
+        auto reg = ggml_backend_rpc_add_server_fn(server.c_str());
+        ggml_backend_register(reg);
+    }
+}
+
+void add_rpc_device(const char* servers_cstr){
+    std::string servers(servers_cstr);
+    add_rpc_devices(servers);
+}
+
+std::vector<std::pair<std::string, std::string>> list_backends_vector() {
+    std::vector<std::pair<std::string, std::string>> backends;
+    const int device_count = ggml_backend_dev_count();
+    for (int i = 0; i < device_count; i++) {
+        auto dev = ggml_backend_dev_get(i);
+        backends.push_back({ggml_backend_dev_name(dev), ggml_backend_dev_description(dev)});
+    }
+    return backends;
+}
+
+SD_API size_t backend_list_size(){
+    // for C API
+    size_t buffer_size = 0;
+    auto backends = list_backends_vector();
+    for (auto& backend : backends) {
+        auto dev_name_size = backend.first.size();
+        auto dev_desc_size = backend.second.size();
+        buffer_size+=dev_name_size+dev_desc_size+2; // +2 for the separators
+    }
+    return buffer_size;
+}
+
+// devices are separated by \n and name and description are separated by \t
+SD_API void list_backends_to_buffer(char* buffer, size_t buffer_size) {
+    auto backends = list_backends_vector();
+    size_t offset = 0;
+    for (auto& backend : backends) {
+        size_t name_size = backend.first.size();
+        size_t desc_size = backend.second.size();
+        if (offset + name_size + desc_size + 2 > buffer_size) {
+            break; // Not enough space in the buffer
+        }
+        memcpy(buffer + offset, backend.first.c_str(), name_size);
+        offset += name_size;
+        buffer[offset++] = '\t';
+        memcpy(buffer + offset, backend.second.c_str(), desc_size);
+        offset += desc_size;
+        buffer[offset++] = '\n'; 
+    }
+    if (offset < buffer_size) {
+        buffer[offset] = '\0'; // Ensure the buffer is null-terminated at the end
+    }
+}
+
 /*=============================================== StableDiffusionGGML ================================================*/
 
 class StableDiffusionGGML {
@@ -177,8 +261,8 @@ public:
         ggml_backend_free(backend);
     }
 
-    void list_backends() {
-        // TODO: expose via C API and fill a cstr
+
+    void log_backends() {
         const int device_count = ggml_backend_dev_count();
         for (int i = 0; i < device_count; i++) {
             auto dev = ggml_backend_dev_get(i);
@@ -249,7 +333,7 @@ public:
 
         ggml_log_set(ggml_log_callback_default, nullptr);
 
-        list_backends();
+        log_backends();
 
         std::string default_backend_name = get_default_backend_name();
 

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1249,14 +1249,6 @@ public:
         for (auto& kv : lora_state_diff) {
             bool applied = false;
             int64_t t0 = ggml_time_ms();
-            // TODO: Fix that
-            bool are_clip_backends_similar = true;
-            for (auto backend: clip_backends){
-                are_clip_backends_similar = are_clip_backends_similar && (clip_backends[0]==backend || ggml_backend_is_cpu(backend));
-            }
-            if(!are_clip_backends_similar){
-                LOG_WARN("Text encoders are running on different backends. This may cause issues when immediately applying LoRAs.");
-            }
             auto lora_tensor_filter_diff = [&](const std::string& tensor_name) {
                 if (is_diffusion_model_name(tensor_name)) {
                     return true;
@@ -1272,19 +1264,22 @@ public:
                 applied = true;
             }
 
-            auto lora_tensor_filter_cond = [&](const std::string& tensor_name) {
-                if (is_cond_stage_model_name(tensor_name)) {
-                    return true;
+            for (int i = 0; i < cond_stage_model->model_count; i++) {
+                auto lora_tensor_filter_cond = [&](const std::string& tensor_name) {
+                    if (is_cond_stage_model_name(tensor_name)) {
+                        return cond_stage_model->is_cond_stage_model_name_at_index(tensor_name, i);
+                    }
+                    return false;
+                };
+                // TODO: split by model
+                LOG_INFO("applying lora to text encoder (%d)", i);
+                auto backend = cond_stage_model->get_params_backend_at_index(i);
+                lora         = load_lora_model_from_file(kv.first, kv.second, backend, lora_tensor_filter_cond);
+                if (lora && !lora->lora_tensors.empty()) {
+                    lora->apply(tensors, version, n_threads);
+                    lora->free_params_buffer();
+                    applied = true;
                 }
-                return false;
-            };
-            // TODO: split by model
-            LOG_INFO("applying lora to text encoders");
-            lora = load_lora_model_from_file(kv.first, kv.second, clip_backends[0], lora_tensor_filter_cond);
-            if (lora && !lora->lora_tensors.empty()) {
-                lora->apply(tensors, version, n_threads);
-                lora->free_params_buffer();
-                applied = true;
             }
 
             auto lora_tensor_filter_first = [&](const std::string& tensor_name) {
@@ -1346,22 +1341,27 @@ public:
                 }
             }
             cond_stage_lora_models  = lora_models;
-            auto lora_tensor_filter = [&](const std::string& tensor_name) {
-                if (is_cond_stage_model_name(tensor_name)) {
-                    return true;
-                }
-                return false;
-            };
-            for (auto& kv : lora_state_diff) {
-                const std::string& lora_id = kv.first;
-                float multiplier           = kv.second;
-                //TODO: split by model
-                auto lora = load_lora_model_from_file(lora_id, multiplier, clip_backends[0], lora_tensor_filter);
-                if (lora && !lora->lora_tensors.empty()) {
-                    lora->preprocess_lora_tensors(tensors);
-                    cond_stage_lora_models.push_back(lora);
+
+            
+            for(int i=0;i<cond_stage_model->model_count;i++){
+                auto lora_tensor_filter_cond = [&](const std::string& tensor_name) {
+                    if (is_cond_stage_model_name(tensor_name)) {
+                        return cond_stage_model->is_cond_stage_model_name_at_index(tensor_name, i);
+                    }
+                    return false;
+                };
+                for (auto& kv : lora_state_diff) {
+                    const std::string& lora_id = kv.first;
+                    float multiplier           = kv.second;
+                    auto backend = cond_stage_model->get_runtime_backend_at_index(i);
+                    auto lora = load_lora_model_from_file(kv.first, kv.second, backend, lora_tensor_filter_cond);
+                    if (lora && !lora->lora_tensors.empty()) {
+                        lora->preprocess_lora_tensors(tensors);
+                        cond_stage_lora_models.push_back(lora);
+                    }
                 }
             }
+
             auto multi_lora_adapter = std::make_shared<MultiLoraAdapter>(cond_stage_lora_models);
             cond_stage_model->set_weight_adapter(multi_lora_adapter);
         }

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1,3 +1,4 @@
+#include "ggml-cpu.h"
 #include "ggml_extend.hpp"
 
 #include "model.h"
@@ -5,6 +6,7 @@
 #include "rng_mt19937.hpp"
 #include "rng_philox.hpp"
 #include "stable-diffusion.h"
+#include <vector>
 #include "util.h"
 
 #include "auto_encoder_kl.hpp"
@@ -140,6 +142,29 @@ void add_rpc_device(const char* servers_cstr){
     add_rpc_devices(servers);
 }
 
+std::vector<std::string> sanitize_backend_name_list(std::string name) {
+    std::vector<std::string> vec = {};
+    if (name == "" || backend_name_exists(name)) {
+        // single backend
+        vec.push_back(name);
+    } else if (name.find(",") != std::string::npos) {
+        // comma-separated backend names
+        std::stringstream ss(name);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            if (token == "" || backend_name_exists(token)) {
+                vec.push_back(token);
+            } else {
+                LOG_WARN("backend name %s not found, using default", token.c_str());
+                vec.push_back("");
+            }
+        }
+    } else {
+        vec.push_back("");
+    }
+    return vec;
+}
+
 std::vector<std::pair<std::string, std::string>> list_backends_vector() {
     std::vector<std::pair<std::string, std::string>> backends;
     const int device_count = ggml_backend_dev_count();
@@ -193,12 +218,13 @@ class StableDiffusionGGML {
 public:
     ggml_backend_t backend             = nullptr;  // general backend
     ggml_backend_t diffusion_backend   = nullptr;
-    ggml_backend_t clip_backend        = nullptr;
     ggml_backend_t control_net_backend = nullptr;
     ggml_backend_t vae_backend         = nullptr;
     ggml_backend_t tae_backend         = nullptr;
     ggml_backend_t pmid_backend        = nullptr;
     ggml_backend_t vision_backend      = nullptr;
+
+    std::vector<ggml_backend_t> clip_backends        = {nullptr};
 
     SDVersion version;
     bool vae_decode_only         = false;
@@ -249,8 +275,10 @@ public:
         if (diffusion_backend != backend) {
             ggml_backend_free(diffusion_backend);
         }
-        if (clip_backend != backend) {
-            ggml_backend_free(clip_backend);
+        for(auto clip_backend : clip_backends) {
+            if (clip_backend != backend) {
+                ggml_backend_free(clip_backend);
+            }
         }
         if (control_net_backend != backend) {
             ggml_backend_free(control_net_backend);
@@ -312,7 +340,7 @@ public:
         }
 
         std::string diffusion_backend_name   = sanitize_backend_name(SAFE_STR(sd_ctx_params->diffusion_device));
-        std::string clip_backend_name        = sanitize_backend_name(SAFE_STR(sd_ctx_params->clip_device));
+        std::vector<std::string> clip_backend_names        = sanitize_backend_name_list(SAFE_STR(sd_ctx_params->clip_device));
         std::string control_net_backend_name = sanitize_backend_name(SAFE_STR(sd_ctx_params->control_net_device));
         std::string vae_backend_name         = sanitize_backend_name(SAFE_STR(sd_ctx_params->vae_device));
         std::string tae_backend_name         = sanitize_backend_name(SAFE_STR(sd_ctx_params->tae_device));
@@ -320,17 +348,22 @@ public:
         std::string vision_backend_name      = sanitize_backend_name(SAFE_STR(sd_ctx_params->vision_device));
 
         bool diffusion_backend_is_default   = diffusion_backend_name.empty() || diffusion_backend_name == default_backend_name;
-        bool clip_backend_is_default        = (clip_backend_name.empty() || clip_backend_name == default_backend_name);
+        bool clip_backends_are_default = true;
+        for (const auto& clip_backend_name : clip_backend_names) {
+            if (!clip_backend_name.empty() && clip_backend_name != default_backend_name) {
+                clip_backends_are_default = false;
+                break;
+            }
+        }
         bool control_net_backend_is_default = (control_net_backend_name.empty() || control_net_backend_name == default_backend_name);
         bool vae_backend_is_default         = (vae_backend_name.empty() || vae_backend_name == default_backend_name);
         // if tae_backend_name is empty, it will use the same backend as vae
         bool tae_backend_is_default = (tae_backend_name.empty() && vae_backend_is_default) || tae_backend_name == default_backend_name;
         bool pmid_backend_is_default = (pmid_backend_name.empty() || pmid_backend_name == default_backend_name);
-        // if vision_backend_name is empty, it will use the same backend as clip
-        bool vision_backend_is_default = (vision_backend_name.empty() && clip_backend_is_default) || vision_backend_name == default_backend_name;
+        bool vision_backend_is_default = (vision_backend_name.empty() || vision_backend_name == default_backend_name);
 
         // if some backend is not specified or is the same as the default backend, use the default backend
-        bool use_default_backend = diffusion_backend_is_default || clip_backend_is_default || control_net_backend_is_default || vae_backend_is_default || tae_backend_is_default || pmid_backend_is_default || vision_backend_is_default;
+        bool use_default_backend = diffusion_backend_is_default || clip_backends_are_default || control_net_backend_is_default || vae_backend_is_default || tae_backend_is_default || pmid_backend_is_default || vision_backend_is_default;
 
         if (use_default_backend) {
             backend = init_named_backend(override_default_backend_name);
@@ -514,13 +547,18 @@ public:
         }
 
         {
-            clip_backend = backend;
-            if (!clip_backend_is_default) {
-                clip_backend = init_named_backend(clip_backend_name);
-                LOG_INFO("CLIP: Using %s backend", ggml_backend_name(clip_backend));
+            if (!clip_backends_are_default) {
+                clip_backends.clear();
+                for(auto clip_backend_name : clip_backend_names){
+                    auto clip_backend = init_named_backend(clip_backend_name);
+                    LOG_INFO("CLIP: Using %s backend", ggml_backend_name(clip_backend));
+                    clip_backends.push_back(clip_backend); 
+                }
+            }else{
+                clip_backends = {backend};
             }
             if (sd_version_is_sd3(version)) {
-                cond_stage_model = std::make_shared<SD3CLIPEmbedder>(clip_backend,
+                cond_stage_model = std::make_shared<SD3CLIPEmbedder>(clip_backends,
                                                                      offload_params_to_cpu,
                                                                      tensor_storage_map);
                 diffusion_model  = std::make_shared<MMDiTModel>(diffusion_backend,
@@ -544,20 +582,20 @@ public:
                             "--chroma-disable-dit-mask as a workaround.");
                     }
 
-                    cond_stage_model = std::make_shared<T5CLIPEmbedder>(clip_backend,
+                    cond_stage_model = std::make_shared<T5CLIPEmbedder>(clip_backends[0],
                                                                         offload_params_to_cpu,
                                                                         tensor_storage_map,
                                                                         sd_ctx_params->chroma_use_t5_mask,
                                                                         sd_ctx_params->chroma_t5_mask_pad);
                 } else if (version == VERSION_OVIS_IMAGE) {
-                    cond_stage_model = std::make_shared<LLMEmbedder>(clip_backend,
+                    cond_stage_model = std::make_shared<LLMEmbedder>(clip_backends[0],
                                                                      offload_params_to_cpu,
                                                                      tensor_storage_map,
                                                                      version,
                                                                      "",
                                                                      false);
                 } else {
-                    cond_stage_model = std::make_shared<FluxCLIPEmbedder>(clip_backend,
+                    cond_stage_model = std::make_shared<FluxCLIPEmbedder>(clip_backends,
                                                                           offload_params_to_cpu,
                                                                           tensor_storage_map);
                 }
@@ -568,7 +606,7 @@ public:
                                                               sd_ctx_params->chroma_use_dit_mask);
             } else if (sd_version_is_flux2(version)) {
                 bool is_chroma   = false;
-                cond_stage_model = std::make_shared<LLMEmbedder>(clip_backend,
+                cond_stage_model = std::make_shared<LLMEmbedder>(clip_backends[0],
                                                                  offload_params_to_cpu,
                                                                  tensor_storage_map,
                                                                  version);
@@ -578,7 +616,7 @@ public:
                                                                version,
                                                                sd_ctx_params->chroma_use_dit_mask);
             } else if (sd_version_is_wan(version)) {
-                cond_stage_model = std::make_shared<T5CLIPEmbedder>(clip_backend,
+                cond_stage_model = std::make_shared<T5CLIPEmbedder>(clip_backends[0],
                                                                     offload_params_to_cpu,
                                                                     tensor_storage_map,
                                                                     true,
@@ -610,7 +648,7 @@ public:
                 if (!vae_decode_only) {
                     enable_vision = true;
                 }
-                cond_stage_model = std::make_shared<LLMEmbedder>(clip_backend,
+                cond_stage_model = std::make_shared<LLMEmbedder>(clip_backends[0],
                                                                  offload_params_to_cpu,
                                                                  tensor_storage_map,
                                                                  version,
@@ -631,7 +669,7 @@ public:
                                                                tensor_storage_map,
                                                                "model.diffusion_model");
             } else if (sd_version_is_z_image(version)) {
-                cond_stage_model = std::make_shared<LLMEmbedder>(clip_backend,
+                cond_stage_model = std::make_shared<LLMEmbedder>(clip_backends[0],
                                                                  offload_params_to_cpu,
                                                                  tensor_storage_map,
                                                                  version);
@@ -646,14 +684,14 @@ public:
                     embbeding_map.emplace(SAFE_STR(sd_ctx_params->embeddings[i].name), SAFE_STR(sd_ctx_params->embeddings[i].path));
                 }
                 if (strstr(SAFE_STR(sd_ctx_params->photo_maker_path), "v2")) {
-                    cond_stage_model = std::make_shared<FrozenCLIPEmbedderWithCustomWords>(clip_backend,
+                    cond_stage_model = std::make_shared<FrozenCLIPEmbedderWithCustomWords>(clip_backends,
                                                                                            offload_params_to_cpu,
                                                                                            tensor_storage_map,
                                                                                            embbeding_map,
                                                                                            version,
                                                                                            PM_VERSION_2);
                 } else {
-                    cond_stage_model = std::make_shared<FrozenCLIPEmbedderWithCustomWords>(clip_backend,
+                    cond_stage_model = std::make_shared<FrozenCLIPEmbedderWithCustomWords>(clip_backends,
                                                                                            offload_params_to_cpu,
                                                                                            tensor_storage_map,
                                                                                            embbeding_map,
@@ -951,7 +989,9 @@ public:
 
             size_t total_params_ram_size  = 0;
             size_t total_params_vram_size = 0;
-            if (ggml_backend_is_cpu(clip_backend)) {
+            
+            // TODO: split by individual text encoders
+            if (ggml_backend_is_cpu(clip_backends[0])) {
                 total_params_ram_size += clip_params_mem_size + pmid_params_mem_size;
             } else {
                 total_params_vram_size += clip_params_mem_size + pmid_params_mem_size;
@@ -983,7 +1023,8 @@ public:
                 total_params_vram_size / 1024.0 / 1024.0,
                 total_params_ram_size / 1024.0 / 1024.0,
                 clip_params_mem_size / 1024.0 / 1024.0,
-                ggml_backend_is_cpu(clip_backend) ? "RAM" : "VRAM",
+                // TODO: split
+                ggml_backend_is_cpu(clip_backends[0]) ? "RAM" : "VRAM",
                 unet_params_mem_size / 1024.0 / 1024.0,
                 ggml_backend_is_cpu(backend) ? "RAM" : "VRAM",
                 vae_params_mem_size / 1024.0 / 1024.0,
@@ -1171,7 +1212,11 @@ public:
         for (auto& kv : lora_state_diff) {
             int64_t t0 = ggml_time_ms();
             // TODO: Fix that
-            if(diffusion_backend!=clip_backend && !ggml_backend_is_cpu(clip_backend)){
+            bool are_clip_backends_compatible = true;
+            for (auto backend: clip_backends){
+                are_clip_backends_compatible = are_clip_backends_compatible && (diffusion_backend==backend || ggml_backend_is_cpu(backend));
+            }
+            if(!are_clip_backends_compatible){
                 LOG_WARN("Diffusion models and text encoders are running on different backends. This may cause issues when immediately applying LoRAs.");
             }
             auto lora = load_lora_model_from_file(kv.first, kv.second, diffusion_backend);
@@ -1231,8 +1276,8 @@ public:
             for (auto& kv : lora_state_diff) {
                 const std::string& lora_id = kv.first;
                 float multiplier           = kv.second;
-
-                auto lora = load_lora_model_from_file(lora_id, multiplier, clip_backend, lora_tensor_filter);
+                //TODO: split by model
+                auto lora = load_lora_model_from_file(lora_id, multiplier, clip_backends[0], lora_tensor_filter);
                 if (lora && !lora->lora_tensors.empty()) {
                     lora->preprocess_lora_tensors(tensors);
                     cond_stage_lora_models.push_back(lora);

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -105,9 +105,13 @@ static float get_cache_reuse_threshold(const sd_cache_params_t& params) {
 class StableDiffusionGGML {
 public:
     ggml_backend_t backend             = nullptr;  // general backend
+    ggml_backend_t diffusion_backend   = nullptr;
     ggml_backend_t clip_backend        = nullptr;
     ggml_backend_t control_net_backend = nullptr;
     ggml_backend_t vae_backend         = nullptr;
+    ggml_backend_t tae_backend         = nullptr;
+
+    // TODO: clip_vision and photomaker backends
 
     SDVersion version;
     bool vae_decode_only         = false;
@@ -155,11 +159,17 @@ public:
     StableDiffusionGGML() = default;
 
     ~StableDiffusionGGML() {
+        if (diffusion_backend != backend) {
+            ggml_backend_free(diffusion_backend);
+        }
         if (clip_backend != backend) {
             ggml_backend_free(clip_backend);
         }
         if (control_net_backend != backend) {
             ggml_backend_free(control_net_backend);
+        }
+        if (tae_backend != vae_backend) {
+            ggml_backend_free(tae_backend);
         }
         if (vae_backend != backend) {
             ggml_backend_free(vae_backend);
@@ -167,60 +177,47 @@ public:
         ggml_backend_free(backend);
     }
 
-    void init_backend() {
-#ifdef SD_USE_CUDA
-        LOG_DEBUG("Using CUDA backend");
-        backend = ggml_backend_cuda_init(0);
-#endif
-#ifdef SD_USE_METAL
-        LOG_DEBUG("Using Metal backend");
-        backend = ggml_backend_metal_init();
-#endif
-#ifdef SD_USE_VULKAN
-        LOG_DEBUG("Using Vulkan backend");
-        size_t device          = 0;
-        const int device_count = ggml_backend_vk_get_device_count();
-        if (device_count) {
-            const char* SD_VK_DEVICE = getenv("SD_VK_DEVICE");
-            if (SD_VK_DEVICE != nullptr) {
-                std::string sd_vk_device_str = SD_VK_DEVICE;
-                try {
-                    device = std::stoull(sd_vk_device_str);
-                } catch (const std::invalid_argument&) {
-                    LOG_WARN("SD_VK_DEVICE environment variable is not a valid integer (%s). Falling back to device 0.", SD_VK_DEVICE);
-                    device = 0;
-                } catch (const std::out_of_range&) {
-                    LOG_WARN("SD_VK_DEVICE environment variable value is out of range for `unsigned long long` type (%s). Falling back to device 0.", SD_VK_DEVICE);
-                    device = 0;
-                }
-                if (device >= device_count) {
-                    LOG_WARN("Cannot find targeted vulkan device (%llu). Falling back to device 0.", device);
-                    device = 0;
-                }
-            }
-            LOG_INFO("Vulkan: Using device %llu", device);
-            backend = ggml_backend_vk_init(device);
+    void list_backends() {
+        // TODO: expose via C API and fill a cstr
+        const int device_count = ggml_backend_dev_count();
+        for (int i = 0; i < device_count; i++) {
+            LOG_INFO("%s", ggml_backend_dev_name(ggml_backend_dev_get(i)));
         }
-        if (!backend) {
-            LOG_WARN("Failed to initialize Vulkan backend");
-        }
-#endif
-#ifdef SD_USE_OPENCL
-        LOG_DEBUG("Using OpenCL backend");
-        // ggml_log_set(ggml_log_callback_default, nullptr); // Optional ggml logs
-        backend = ggml_backend_opencl_init();
-        if (!backend) {
-            LOG_WARN("Failed to initialize OpenCL backend");
-        }
-#endif
-#ifdef SD_USE_SYCL
-        LOG_DEBUG("Using SYCL backend");
-        backend = ggml_backend_sycl_init(0);
-#endif
+    }
 
-        if (!backend) {
-            LOG_DEBUG("Using CPU backend");
-            backend = ggml_backend_cpu_init();
+    bool backend_name_exists(std::string name) {
+        const int device_count = ggml_backend_dev_count();
+        for (int i = 0; i < device_count; i++) {
+            if (name == ggml_backend_dev_name(ggml_backend_dev_get(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::string sanitize_backend_name(std::string name) {
+        if (name == "" || backend_name_exists(name)) {
+            return name;
+        } else {
+            LOG_WARN("Backend %s not found, using default backend", name.c_str());
+            return "";
+        }
+    }
+
+    std::string get_default_backend_name() {
+        // should pick the same backend as ggml_backend_init_best
+        ggml_backend_dev_t dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_GPU);
+        dev                    = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_IGPU);
+        dev                    = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+        return ggml_backend_dev_name(dev);
+    }
+
+    ggml_backend_t init_named_backend(std::string name = "") {
+        LOG_DEBUG("Initializing backend: %s", name.c_str());
+        if (name.empty()) {
+            return ggml_backend_init_best();
+        } else {
+            return ggml_backend_init_by_name(name.c_str(), nullptr);
         }
     }
 
@@ -251,7 +248,44 @@ public:
 
         ggml_log_set(ggml_log_callback_default, nullptr);
 
-        init_backend();
+        list_backends();
+
+        std::string default_backend_name = get_default_backend_name();
+
+        std::string override_default_backend_name = sanitize_backend_name(SAFE_STR(sd_ctx_params->main_device));
+
+        if (override_default_backend_name.size() > 0) {
+            LOG_INFO("Setting default backend to %s", override_default_backend_name.c_str());
+            default_backend_name = override_default_backend_name;
+        }
+
+        std::string diffusion_backend_name   = sanitize_backend_name(SAFE_STR(sd_ctx_params->diffusion_device));
+        std::string clip_backend_name        = sanitize_backend_name(SAFE_STR(sd_ctx_params->clip_device));
+        std::string control_net_backend_name = sanitize_backend_name(SAFE_STR(sd_ctx_params->control_net_device));
+        std::string vae_backend_name         = sanitize_backend_name(SAFE_STR(sd_ctx_params->vae_device));
+        std::string tae_backend_name         = sanitize_backend_name(SAFE_STR(sd_ctx_params->tae_device));
+
+        bool diffusion_backend_is_default   = diffusion_backend_name.empty() || diffusion_backend_name == default_backend_name;
+        bool clip_backend_is_default        = (clip_backend_name.empty() || clip_backend_name == default_backend_name);
+        bool control_net_backend_is_default = (control_net_backend_name.empty() || control_net_backend_name == default_backend_name);
+        bool vae_backend_is_default         = (vae_backend_name.empty() || vae_backend_name == default_backend_name);
+        // if tae_backend_name is empty, it will use the same backend as vae
+        bool tae_backend_is_default = (tae_backend_name.empty() && vae_backend_is_default) || tae_backend_name == default_backend_name;
+
+        // if some backend is not specified or is the same as the default backend, use the default backend
+        bool use_default_backend = diffusion_backend_is_default || clip_backend_is_default || control_net_backend_is_default || vae_backend_is_default || tae_backend_is_default;
+
+        if (use_default_backend) {
+            backend = init_named_backend(override_default_backend_name);
+            LOG_DEBUG("Loaded default backend %s", ggml_backend_name(backend));
+        }
+
+        if (!diffusion_backend_is_default) {
+            diffusion_backend = init_named_backend(diffusion_backend_name);
+            LOG_INFO("Using diffusion backend: %s", ggml_backend_name(diffusion_backend));
+        } else {
+            diffusion_backend = backend;
+        }
 
         ModelLoader model_loader;
 
@@ -422,21 +456,19 @@ public:
             LOG_INFO("Using circular padding for convolutions");
         }
 
-        bool clip_on_cpu = sd_ctx_params->keep_clip_on_cpu;
-
         {
             clip_backend = backend;
-            if (clip_on_cpu && !ggml_backend_is_cpu(backend)) {
-                LOG_INFO("CLIP: Using CPU backend");
-                clip_backend = ggml_backend_cpu_init();
+            if (!clip_backend_is_default) {
+                clip_backend = init_named_backend(clip_backend_name);
+                LOG_INFO("CLIP: Using %s backend", ggml_backend_name(clip_backend));
             }
             if (sd_version_is_sd3(version)) {
                 cond_stage_model = std::make_shared<SD3CLIPEmbedder>(clip_backend,
                                                                      offload_params_to_cpu,
                                                                      tensor_storage_map);
-                diffusion_model  = std::make_shared<MMDiTModel>(backend,
-                                                               offload_params_to_cpu,
-                                                               tensor_storage_map);
+                diffusion_model  = std::make_shared<MMDiTModel>(diffusion_backend,
+                                                                offload_params_to_cpu,
+                                                                tensor_storage_map);
             } else if (sd_version_is_flux(version)) {
                 bool is_chroma = false;
                 for (auto pair : tensor_storage_map) {
@@ -472,7 +504,7 @@ public:
                                                                           offload_params_to_cpu,
                                                                           tensor_storage_map);
                 }
-                diffusion_model = std::make_shared<FluxModel>(backend,
+                diffusion_model = std::make_shared<FluxModel>(diffusion_backend,
                                                               offload_params_to_cpu,
                                                               tensor_storage_map,
                                                               version,
@@ -483,11 +515,11 @@ public:
                                                                  offload_params_to_cpu,
                                                                  tensor_storage_map,
                                                                  version);
-                diffusion_model  = std::make_shared<FluxModel>(backend,
-                                                              offload_params_to_cpu,
-                                                              tensor_storage_map,
-                                                              version,
-                                                              sd_ctx_params->chroma_use_dit_mask);
+                diffusion_model  = std::make_shared<FluxModel>(diffusion_backend,
+                                                               offload_params_to_cpu,
+                                                               tensor_storage_map,
+                                                               version,
+                                                               sd_ctx_params->chroma_use_dit_mask);
             } else if (sd_version_is_wan(version)) {
                 cond_stage_model = std::make_shared<T5CLIPEmbedder>(clip_backend,
                                                                     offload_params_to_cpu,
@@ -495,13 +527,13 @@ public:
                                                                     true,
                                                                     1,
                                                                     true);
-                diffusion_model  = std::make_shared<WanModel>(backend,
-                                                             offload_params_to_cpu,
-                                                             tensor_storage_map,
-                                                             "model.diffusion_model",
-                                                             version);
+                diffusion_model  = std::make_shared<WanModel>(diffusion_backend,
+                                                              offload_params_to_cpu,
+                                                              tensor_storage_map,
+                                                              "model.diffusion_model",
+                                                              version);
                 if (strlen(SAFE_STR(sd_ctx_params->high_noise_diffusion_model_path)) > 0) {
-                    high_noise_diffusion_model = std::make_shared<WanModel>(backend,
+                    high_noise_diffusion_model = std::make_shared<WanModel>(diffusion_backend,
                                                                             offload_params_to_cpu,
                                                                             tensor_storage_map,
                                                                             "model.high_noise_diffusion_model",
@@ -527,12 +559,12 @@ public:
                                                                  version,
                                                                  "",
                                                                  enable_vision);
-                diffusion_model  = std::make_shared<QwenImageModel>(backend,
-                                                                   offload_params_to_cpu,
-                                                                   tensor_storage_map,
-                                                                   "model.diffusion_model",
-                                                                   version,
-                                                                   sd_ctx_params->qwen_image_zero_cond_t);
+                diffusion_model  = std::make_shared<QwenImageModel>(diffusion_backend,
+                                                                    offload_params_to_cpu,
+                                                                    tensor_storage_map,
+                                                                    "model.diffusion_model",
+                                                                    version,
+                                                                    sd_ctx_params->qwen_image_zero_cond_t);
             } else if (sd_version_is_anima(version)) {
                 cond_stage_model = std::make_shared<AnimaConditioner>(clip_backend,
                                                                       offload_params_to_cpu,
@@ -546,11 +578,11 @@ public:
                                                                  offload_params_to_cpu,
                                                                  tensor_storage_map,
                                                                  version);
-                diffusion_model  = std::make_shared<ZImageModel>(backend,
-                                                                offload_params_to_cpu,
-                                                                tensor_storage_map,
-                                                                "model.diffusion_model",
-                                                                version);
+                diffusion_model  = std::make_shared<ZImageModel>(diffusion_backend,
+                                                                 offload_params_to_cpu,
+                                                                 tensor_storage_map,
+                                                                 "model.diffusion_model",
+                                                                 version);
             } else {  // SD1.x SD2.x SDXL
                 std::map<std::string, std::string> embbeding_map;
                 for (uint32_t i = 0; i < sd_ctx_params->embedding_count; i++) {
@@ -570,7 +602,7 @@ public:
                                                                                            embbeding_map,
                                                                                            version);
                 }
-                diffusion_model = std::make_shared<UNetModel>(backend,
+                diffusion_model = std::make_shared<UNetModel>(diffusion_backend,
                                                               offload_params_to_cpu,
                                                               tensor_storage_map,
                                                               version);
@@ -595,18 +627,22 @@ public:
                 high_noise_diffusion_model->get_param_tensors(tensors);
             }
 
-            if (sd_ctx_params->keep_vae_on_cpu && !ggml_backend_is_cpu(backend)) {
-                LOG_INFO("VAE Autoencoder: Using CPU backend");
-                vae_backend = ggml_backend_cpu_init();
-            } else {
-                vae_backend = backend;
+            vae_backend = backend;
+            if (!vae_backend_is_default) {
+                vae_backend = init_named_backend(vae_backend_name);
+                LOG_INFO("VAE Autoencoder: Using %s backend", ggml_backend_name(vae_backend));
+            }
+            tae_backend = vae_backend;
+            if (tae_backend_name.length() > 0 && tae_backend_name != vae_backend_name) {
+                tae_backend = init_named_backend(tae_backend_name);
+                LOG_INFO("Tiny Autoencoder: Using %s backend", ggml_backend_name(tae_backend));
             }
 
             auto create_tae = [&]() -> std::shared_ptr<VAE> {
                 if (sd_version_is_wan(version) ||
                     sd_version_is_qwen_image(version) ||
                     sd_version_is_anima(version)) {
-                    return std::make_shared<TinyVideoAutoEncoder>(vae_backend,
+                    return std::make_shared<TinyVideoAutoEncoder>(tae_backend,
                                                                   offload_params_to_cpu,
                                                                   tensor_storage_map,
                                                                   "decoder",
@@ -614,7 +650,7 @@ public:
                                                                   version);
 
                 } else {
-                    auto model = std::make_shared<TinyImageAutoEncoder>(vae_backend,
+                    auto model = std::make_shared<TinyImageAutoEncoder>(tae_backend,
                                                                         offload_params_to_cpu,
                                                                         tensor_storage_map,
                                                                         "decoder.layers",
@@ -688,9 +724,9 @@ public:
 
             if (strlen(SAFE_STR(sd_ctx_params->control_net_path)) > 0) {
                 ggml_backend_t controlnet_backend = nullptr;
-                if (sd_ctx_params->keep_control_net_on_cpu && !ggml_backend_is_cpu(backend)) {
-                    LOG_DEBUG("ControlNet: Using CPU backend");
-                    controlnet_backend = ggml_backend_cpu_init();
+                if (!control_net_backend_is_default) {
+                    control_net_backend = init_named_backend(control_net_backend_name);
+                    LOG_INFO("ControlNet: Using %s backend", control_net_backend_name);
                 } else {
                     controlnet_backend = backend;
                 }
@@ -859,7 +895,7 @@ public:
                 total_params_vram_size += clip_params_mem_size + pmid_params_mem_size;
             }
 
-            if (ggml_backend_is_cpu(backend)) {
+            if (ggml_backend_is_cpu(diffusion_backend)) {
                 total_params_ram_size += unet_params_mem_size;
             } else {
                 total_params_vram_size += unet_params_mem_size;
@@ -2127,9 +2163,6 @@ void sd_ctx_params_init(sd_ctx_params_t* sd_ctx_params) {
     sd_ctx_params->lora_apply_mode         = LORA_APPLY_AUTO;
     sd_ctx_params->offload_params_to_cpu   = false;
     sd_ctx_params->enable_mmap             = false;
-    sd_ctx_params->keep_clip_on_cpu        = false;
-    sd_ctx_params->keep_control_net_on_cpu = false;
-    sd_ctx_params->keep_vae_on_cpu         = false;
     sd_ctx_params->diffusion_flash_attn    = false;
     sd_ctx_params->circular_x              = false;
     sd_ctx_params->circular_y              = false;
@@ -2143,7 +2176,7 @@ char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {
     if (!buf)
         return nullptr;
     buf[0] = '\0';
-
+    // TODO devices
     snprintf(buf + strlen(buf), 4096 - strlen(buf),
              "model_path: %s\n"
              "clip_l_path: %s\n"
@@ -2167,9 +2200,6 @@ char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {
              "sampler_rng_type: %s\n"
              "prediction: %s\n"
              "offload_params_to_cpu: %s\n"
-             "keep_clip_on_cpu: %s\n"
-             "keep_control_net_on_cpu: %s\n"
-             "keep_vae_on_cpu: %s\n"
              "flash_attn: %s\n"
              "diffusion_flash_attn: %s\n"
              "circular_x: %s\n"
@@ -2199,9 +2229,6 @@ char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {
              sd_rng_type_name(sd_ctx_params->sampler_rng_type),
              sd_prediction_name(sd_ctx_params->prediction),
              BOOL_STR(sd_ctx_params->offload_params_to_cpu),
-             BOOL_STR(sd_ctx_params->keep_clip_on_cpu),
-             BOOL_STR(sd_ctx_params->keep_control_net_on_cpu),
-             BOOL_STR(sd_ctx_params->keep_vae_on_cpu),
              BOOL_STR(sd_ctx_params->flash_attn),
              BOOL_STR(sd_ctx_params->diffusion_flash_attn),
              BOOL_STR(sd_ctx_params->circular_x),

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -181,6 +181,9 @@ SD_API void list_backends_to_buffer(char* buffer, size_t buffer_size) {
     }
     if (offset < buffer_size) {
         buffer[offset] = '\0'; // Ensure the buffer is null-terminated at the end
+    } else {
+        LOG_WARN("Provided buffer size is too small to contain details of all devices.");
+        buffer[buffer_size - 1] = '\0';  // Ensure the buffer is null-terminated at the end
     }
 }
 

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -808,7 +808,7 @@ public:
                                                                    version);
             }
             if (strlen(SAFE_STR(sd_ctx_params->photo_maker_path)) > 0) {
-                pmid_lora               = std::make_shared<LoraModel>("pmid", backend, sd_ctx_params->photo_maker_path, "", version);
+                pmid_lora               = std::make_shared<LoraModel>("pmid", diffusion_backend, sd_ctx_params->photo_maker_path, "", version);
                 auto lora_tensor_filter = [&](const std::string& tensor_name) {
                     if (starts_with(tensor_name, "lora.model")) {
                         return true;
@@ -1160,8 +1160,11 @@ public:
 
         for (auto& kv : lora_state_diff) {
             int64_t t0 = ggml_time_ms();
-
-            auto lora = load_lora_model_from_file(kv.first, kv.second, backend);
+            // TODO: Fix that
+            if(diffusion_backend!=clip_backend && !ggml_backend_is_cpu(clip_backend)){
+                LOG_WARN("Diffusion models and text encoders are running on different backends. This may cause issues when immediately applying LoRAs.");
+            }
+            auto lora = load_lora_model_from_file(kv.first, kv.second, diffusion_backend);
             if (!lora || lora->lora_tensors.empty()) {
                 continue;
             }
@@ -1251,7 +1254,7 @@ public:
                 const std::string& lora_name = kv.first;
                 float multiplier             = kv.second;
 
-                auto lora = load_lora_model_from_file(lora_name, multiplier, backend, lora_tensor_filter);
+                auto lora = load_lora_model_from_file(lora_name, multiplier, diffusion_backend, lora_tensor_filter);
                 if (lora && !lora->lora_tensors.empty()) {
                     lora->preprocess_lora_tensors(tensors);
                     diffusion_lora_models.push_back(lora);

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -665,7 +665,7 @@ public:
                                                                     version,
                                                                     sd_ctx_params->qwen_image_zero_cond_t);
             } else if (sd_version_is_anima(version)) {
-                cond_stage_model = std::make_shared<AnimaConditioner>(clip_backend,
+                cond_stage_model = std::make_shared<AnimaConditioner>(clip_backends[0],
                                                                       offload_params_to_cpu,
                                                                       tensor_storage_map);
                 diffusion_model  = std::make_shared<AnimaModel>(backend,

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -24,6 +24,10 @@
 #include "latent-preview.h"
 #include "name_conversion.h"
 
+#if SD_USE_RPC
+#include "ggml-rpc.h"
+#endif
+
 const char* model_version_to_str[] = {
     "SD 1.x",
     "SD 1.x Inpaint",
@@ -863,7 +867,13 @@ public:
                     }
                     return false;
                 };
-                if (!pmid_lora->load_from_file(n_threads, lora_tensor_filter)) {
+                int n_th = n_threads;
+#ifdef SD_USE_RPC
+                if (ggml_backend_is_rpc(diffusion_backend)) {
+                    n_th = 1;  // avoid multi-thread for loading to remote
+                }
+#endif
+                if (!pmid_lora->load_from_file(n_th, lora_tensor_filter)) {
                     LOG_WARN("load photomaker lora tensors from %s failed", sd_ctx_params->photo_maker_path);
                     return false;
                 }
@@ -955,7 +965,22 @@ public:
         if (version == VERSION_SVD) {
             ignore_tensors.insert("conditioner.embedders.3");
         }
-        bool success = model_loader.load_tensors(tensors, ignore_tensors, n_threads, sd_ctx_params->enable_mmap);
+        int n_th = n_threads;
+#ifdef SD_USE_RPC
+        // TODO: maybe set it to 1 threads only for model parts that are on remote?
+        bool is_any_clip_rpc = false;
+        for (auto& backend : clip_backends) {
+            if (ggml_backend_is_rpc(backend)) {
+                is_any_clip_rpc = true;
+            }
+        }
+        // I think those are all the backends that should get sent data to when calling model_loader.load_tensors()
+        if (is_any_clip_rpc || ggml_backend_is_rpc(diffusion_backend) || ggml_backend_is_rpc(vae_backend) || ggml_backend_is_rpc(vision_backend) || ggml_backend_is_rpc(pmid_backend)) {
+            LOG_DEBUG("Using single-thread for tensor loading because RPC backend is used");
+            n_th = 1;  // avoid multi-thread for loading to remote
+        }
+#endif
+        bool success = model_loader.load_tensors(tensors, ignore_tensors, n_th, sd_ctx_params->enable_mmap);
         if (!success) {
             LOG_ERROR("load tensors from model loader failed");
             ggml_free(ctx);
@@ -977,7 +1002,13 @@ public:
             }
             size_t control_net_params_mem_size = 0;
             if (control_net) {
-                if (!control_net->load_from_file(SAFE_STR(sd_ctx_params->control_net_path), n_threads)) {
+                int n_th = n_threads;
+#ifdef SD_USE_RPC
+                if (ggml_backend_is_rpc(control_net_backend)) {
+                    n_th = 1;  // avoid multi-thread for loading to remote
+                }
+#endif
+                if (!control_net->load_from_file(SAFE_STR(sd_ctx_params->control_net_path), n_th)) {
                     return false;
                 }
                 control_net_params_mem_size = control_net->get_params_buffer_size();
@@ -1174,7 +1205,13 @@ public:
             LOG_DEBUG("high noise lora: %s", lora_path.c_str());
         }
         auto lora = std::make_shared<LoraModel>(lora_id, backend, lora_path, is_high_noise ? "model.high_noise_" : "", version);
-        if (!lora->load_from_file(n_threads, lora_tensor_filter)) {
+        int n_th  = n_threads;
+#ifdef SD_USE_RPC
+        if (ggml_backend_is_rpc(backend)) {
+            n_th = 1;  // avoid multi-thread for loading to remote
+        }
+#endif
+        if (!lora->load_from_file(n_th, lora_tensor_filter)) {
             LOG_WARN("load lora tensors from %s failed", lora_path.c_str());
             return nullptr;
         }

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1263,6 +1263,8 @@ public:
                 }
                 return false;
             };
+
+            LOG_INFO("applying lora to diffusion model");
             auto lora = load_lora_model_from_file(kv.first, kv.second, diffusion_backend, lora_tensor_filter_diff);
             if (lora && !lora->lora_tensors.empty()) {
                 lora->apply(tensors, version, n_threads);
@@ -1277,6 +1279,7 @@ public:
                 return false;
             };
             // TODO: split by model
+            LOG_INFO("applying lora to text encoders");
             lora = load_lora_model_from_file(kv.first, kv.second, clip_backends[0], lora_tensor_filter_cond);
             if (lora && !lora->lora_tensors.empty()) {
                 lora->apply(tensors, version, n_threads);
@@ -1290,7 +1293,8 @@ public:
                 }
                 return false;
             };
-            auto first_stage_backend = use_tiny_autoencoder ? tae_backend : vae_backend;
+            LOG_INFO("applying lora to first stage model"); 
+            auto first_stage_backend = first_stage_model->get_params_backend();
             lora                     = load_lora_model_from_file(kv.first, kv.second, first_stage_backend, lora_tensor_filter_first);
             if (lora && !lora->lora_tensors.empty()) {
                 lora->apply(tensors, version, n_threads);

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -273,42 +273,6 @@ public:
         }
     }
 
-    bool backend_name_exists(std::string name) {
-        const int device_count = ggml_backend_dev_count();
-        for (int i = 0; i < device_count; i++) {
-            if (name == ggml_backend_dev_name(ggml_backend_dev_get(i))) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    std::string sanitize_backend_name(std::string name) {
-        if (name == "" || backend_name_exists(name)) {
-            return name;
-        } else {
-            LOG_WARN("Backend %s not found, using default backend", name.c_str());
-            return "";
-        }
-    }
-
-    std::string get_default_backend_name() {
-        // should pick the same backend as ggml_backend_init_best
-        ggml_backend_dev_t dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_GPU);
-        dev                    = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_IGPU);
-        dev                    = dev ? dev : ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
-        return ggml_backend_dev_name(dev);
-    }
-
-    ggml_backend_t init_named_backend(std::string name = "") {
-        LOG_DEBUG("Initializing backend: %s", name.c_str());
-        if (name.empty()) {
-            return ggml_backend_init_best();
-        } else {
-            return ggml_backend_init_by_name(name.c_str(), nullptr);
-        }
-    }
-
     std::shared_ptr<RNG> get_rng(rng_type_t rng_type) {
         if (rng_type == STD_DEFAULT_RNG) {
             return std::make_shared<STDDefaultRNG>();

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -181,7 +181,8 @@ public:
         // TODO: expose via C API and fill a cstr
         const int device_count = ggml_backend_dev_count();
         for (int i = 0; i < device_count; i++) {
-            LOG_INFO("%s", ggml_backend_dev_name(ggml_backend_dev_get(i)));
+            auto dev = ggml_backend_dev_get(i);
+            LOG_INFO("%s (%s)", ggml_backend_dev_name(dev), ggml_backend_dev_description(dev));
         }
     }
 

--- a/src/upscaler.cpp
+++ b/src/upscaler.cpp
@@ -23,37 +23,20 @@ struct UpscalerGGML {
 
     bool load_from_file(const std::string& esrgan_path,
                         bool offload_params_to_cpu,
-                        int n_threads) {
+                        int n_threads,
+                        std::string device = "") {
         ggml_log_set(ggml_log_callback_default, nullptr);
-#ifdef SD_USE_CUDA
-        LOG_DEBUG("Using CUDA backend");
-        backend = ggml_backend_cuda_init(0);
-#endif
-#ifdef SD_USE_METAL
-        LOG_DEBUG("Using Metal backend");
-        backend = ggml_backend_metal_init();
-#endif
-#ifdef SD_USE_VULKAN
-        LOG_DEBUG("Using Vulkan backend");
-        backend = ggml_backend_vk_init(0);
-#endif
-#ifdef SD_USE_OPENCL
-        LOG_DEBUG("Using OpenCL backend");
-        backend = ggml_backend_opencl_init();
-#endif
-#ifdef SD_USE_SYCL
-        LOG_DEBUG("Using SYCL backend");
-        backend = ggml_backend_sycl_init(0);
-#endif
+        device = sanitize_backend_name(device);
+        backend = init_named_backend(device);
         ModelLoader model_loader;
         if (!model_loader.init_from_file_and_convert_name(esrgan_path)) {
             LOG_ERROR("init model loader from file failed: '%s'", esrgan_path.c_str());
         }
         model_loader.set_wtype_override(model_data_type);
-        if (!backend) {
-            LOG_DEBUG("Using CPU backend");
-            backend = ggml_backend_cpu_init();
-        }
+        // if (!backend) {
+        //     LOG_DEBUG("Using CPU backend");
+        //     backend = ggml_backend_cpu_init();
+        // }
         LOG_INFO("Upscaler weight type: %s", ggml_type_name(model_data_type));
         esrgan_upscaler = std::make_shared<ESRGAN>(backend, offload_params_to_cpu, tile_size, model_loader.get_tensor_storage_map());
         if (direct) {
@@ -129,7 +112,8 @@ upscaler_ctx_t* new_upscaler_ctx(const char* esrgan_path_c_str,
                                  bool offload_params_to_cpu,
                                  bool direct,
                                  int n_threads,
-                                 int tile_size) {
+                                 int tile_size,
+                                 const char* device) {
     upscaler_ctx_t* upscaler_ctx = (upscaler_ctx_t*)malloc(sizeof(upscaler_ctx_t));
     if (upscaler_ctx == nullptr) {
         return nullptr;
@@ -141,7 +125,7 @@ upscaler_ctx_t* new_upscaler_ctx(const char* esrgan_path_c_str,
         return nullptr;
     }
 
-    if (!upscaler_ctx->upscaler->load_from_file(esrgan_path, offload_params_to_cpu, n_threads)) {
+    if (!upscaler_ctx->upscaler->load_from_file(esrgan_path, offload_params_to_cpu, n_threads, SAFE_STR(device))) {
         delete upscaler_ctx->upscaler;
         upscaler_ctx->upscaler = nullptr;
         free(upscaler_ctx);

--- a/src/z_image.hpp
+++ b/src/z_image.hpp
@@ -7,6 +7,14 @@
 #include "ggml_extend.hpp"
 #include "mmdit.hpp"
 
+#ifdef SD_USE_VULKAN
+#include "ggml-vulkan.h"
+#endif
+
+#if GGML_USE_HIP
+#include "ggml-cuda.h"
+#endif
+
 // Ref: https://github.com/Alpha-VLLM/Lumina-Image-2.0/blob/main/models/model.py
 // Ref: https://github.com/huggingface/diffusers/pull/12703
 

--- a/src/z_image.hpp
+++ b/src/z_image.hpp
@@ -138,7 +138,7 @@ namespace ZImage {
             auto w3 = std::dynamic_pointer_cast<Linear>(blocks["w3"]);
 #ifdef SD_USE_VULKAN
             if(ggml_backend_is_vk(ctx->backend)){
-                w2->set_force_prec_32(true);
+                w2->set_force_prec_f32(true);
             }
 #endif
 


### PR DESCRIPTION
The main goal of this PR is to improve user experience in multi-gpu setups, allowing to chose which model part gets sent to which device.

Cli changes: 
- Adds the `--main-backend-device [device_name]` argument to set the default backend
- remove `--clip-on-cpu`, `--vae-on-cpu` and `--control-net-cpu` arguments 
- replace them respectively with the new `--clip_backend_device [device_name]`, `--vae-backend-device [device_name]`, `--control-net-backend-device [device_name]` arguments 
- add the `--diffusion_backend_device` (control the device used for the diffusion/flow models) and the `--tae-backend-device`
- add `--upscaler-backend-device`, `--photomaker-backend-device`, and `--vision-backend-device`
- add `--list-devices` argument to print the list of available ggml devices and exit.
- add `--rpc` argument to connect to a compatible GGML rpc server

C API changes (stable-diffusion.h):
-  Change the content of the `sd_ctx_params_t` struct. 
- `void list_backends_to_buffer(char* buffer, size_t buffer_size)` to write the details of the available buffers to a null-terminated char array. Devices are separated by newline characters (`\n`), and the name and description of the device are separated by `\t` character.
- `size_t backend_list_size()` to get the size of the buffer needed for void list_backends_to_buffer
- `void add_rpc_device(const char* address);` connect to a ggml RPC backend ([from llama.cpp](https://github.com/ggml-org/llama.cpp/tree/master/tools/rpc))

The default device selection should now consistently prioritize discrete GPUs over iGPUs.  

For example if you want to run the text encoders on CPU, you'd need to use `--clip_backend_device CPU` instead of `--clip-on-cpu`

TODO:
  - Clean up logs
  
Important: to use RPC, you need to add `-DSD_RPC=ON` to the build. Additionally it requires ~~either sd.cpp to be built with `-DSD_USE_SYSTEM_GGML` flag (I haven't tested that one), or~~ the RPC server to be built with `-DCMAKE_C_FLAGS="-DGGML_MAX_NAME=128" -DCMAKE_CXX_FLAGS="-DGGML_MAX_NAME=128"` ([default is 64](https://github.com/ggml-org/ggml/pull/682))
  
  Fixes #1116