### PR TITLE
chore: clarify warning about missing model files

### DIFF
--- a/model.cpp
+++ b/model.cpp
@@ -376,7 +376,11 @@ bool ModelLoader::init_from_file(const std::string& file_path, const std::string
         LOG_INFO("load %s using checkpoint format", file_path.c_str());
         return init_from_ckpt_file(file_path, prefix);
     } else {
-        LOG_WARN("unknown format %s", file_path.c_str());
+        if (file_exists(file_path)) {
+            LOG_WARN("unknown format %s", file_path.c_str());
+        } else {
+            LOG_WARN("file %s not found", file_path.c_str());
+        }
         return false;
     }
 }


### PR DESCRIPTION
An incorrect file path could be misinterpreted as an incompatible or unsupported file format.