### PR TITLE
Implement LoRA tag extraction in `/sdapi/v1/txt2img` and `/sdapi/v1/img2img` API endpoints.

### DIFF
--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -805,6 +805,11 @@ int main(int argc, const char** argv) {
             gen_params.seed                       = seed;
             gen_params.sample_params.sample_steps = steps;
             gen_params.batch_count                = batch_size;
+            // Extract and process LoRA tags from the prompt
+            gen_params.lora_vec.clear();
+            gen_params.lora_map.clear();
+            gen_params.high_noise_lora_map.clear();
+            gen_params.extract_and_remove_lora(ctx_params.lora_model_dir);
 
             if (clip_skip > 0) {
                 gen_params.clip_skip = clip_skip;


### PR DESCRIPTION
## Problem

The sd-server ignores `<lora:name:weight>` tags in prompts sent via the `/sdapi/v1/txt2img` and `/sdapi/v1/img2img` API endpoints.

LoRA tags work correctly in the CLI (`sd-cli`) because it calls `extract_and_remove_lora()` on every generation. However, the server only calls this function once at startup when parsing command-line arguments. When handling API requests, the server copies `default_gen_params`, updates the prompt, but never re-parses the new prompt for LoRA tags.

## Solution

This patch adds `extract_and_remove_lora()` to the `sdapi_any2img` handler function, which services both txt2img and img2img endpoints. The fix clears any pre-existing LoRA data and extracts LoRA tags from the incoming prompt, matching the behavior of the CLI.