### PR TITLE
LoRA: Optimise LoKr at runtime

### DIFF
--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -2665,11 +2665,16 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_lokr_forward(
         } else {
             hb = ggml_mul_mat(ctx, w2b, ggml_mul_mat(ctx, w2a, h_split));
         }
-        hb = ggml_reshape_3d(ctx, hb, vp, uq, batch);
+        
+        if(batch > 1){
+            hb = ggml_reshape_3d(ctx, hb, vp, uq, batch);
+        }
 
         struct ggml_tensor* hb_t = ggml_cont(ctx, ggml_transpose(ctx, hb));
         
-        hb_t = ggml_reshape_2d(ctx, hb_t, uq, vp * batch);
+        if(batch > 1){
+            hb_t = ggml_reshape_2d(ctx, hb_t, uq, vp * batch);
+        }
 
         struct ggml_tensor* hc_t;
         if (w1 != NULL) {
@@ -2677,7 +2682,10 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_lokr_forward(
         } else {
             hc_t = ggml_mul_mat(ctx, w1b, ggml_mul_mat(ctx, w1a, hb_t));
         }
-        hc_t = ggml_reshape_3d(ctx, hc_t, up, vp, batch);
+        
+        if(batch > 1){
+            hc_t = ggml_reshape_3d(ctx, hc_t, up, vp, batch);
+        }
 
         struct ggml_tensor* hc = ggml_transpose(ctx, hc_t);
         struct ggml_tensor* out  = ggml_reshape_2d(ctx, ggml_cont(ctx, hc), up * vp, batch);

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -2659,14 +2659,17 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_lokr_forward(
 
     if (!is_conv) {
         int batch                   = (int)h->ne[1];
-        struct ggml_tensor* h_split = ggml_reshape_3d(ctx, h, vq, uq, batch);
-
+        struct ggml_tensor* h_split = ggml_reshape_2d(ctx, h, vq, uq * batch);
         if (w2 != NULL) {
             hb = ggml_mul_mat(ctx, w2, h_split);
         } else {
             hb = ggml_mul_mat(ctx, w2b, ggml_mul_mat(ctx, w2a, h_split));
         }
+        hb = ggml_reshape_3d(ctx, hb, vp, uq, batch);
+
         struct ggml_tensor* hb_t = ggml_cont(ctx, ggml_transpose(ctx, hb));
+        
+        hb_t = ggml_reshape_2d(ctx, hb_t, uq, vp * batch);
 
         struct ggml_tensor* hc_t;
         if (w1 != NULL) {
@@ -2674,6 +2677,7 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_lokr_forward(
         } else {
             hc_t = ggml_mul_mat(ctx, w1b, ggml_mul_mat(ctx, w1a, hb_t));
         }
+        hc_t = ggml_reshape_3d(ctx, hc_t, up, vp, batch);
 
         struct ggml_tensor* hc = ggml_transpose(ctx, hc_t);
         struct ggml_tensor* out  = ggml_reshape_2d(ctx, ggml_cont(ctx, hc), up * vp, batch);

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -2662,24 +2662,26 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_lokr_forward(
         int merge_batch_uq = batch;
         int merge_batch_vp = batch;
 
-#if SD_VULKAN
-    // no access to backend here, worst case is slightly worse perfs for other backends when built alongside Vulkan backend
-        int max_batch    = 65535;
-        int max_batch_uq = max_batch / uq;
-        merge_batch_uq   = 1;
-        for (int i = max_batch_uq; i > 0; i--) {
-            if (batch % i == 0) {
-                merge_batch_uq = i;
-                break;
+#if SD_USE_VULKAN
+        if (batch > 1) {
+            // no access to backend here, worst case is slightly worse perfs for other backends when built alongside Vulkan backend
+            int max_batch    = 65535;
+            int max_batch_uq = max_batch / uq;
+            merge_batch_uq   = 1;
+            for (int i = max_batch_uq; i > 0; i--) {
+                if (batch % i == 0) {
+                    merge_batch_uq = i;
+                    break;
+                }
             }
-        }
 
-        int max_batch_vp = max_batch / vp;
-        merge_batch_vp   = 1;
-        for (int i = max_batch_vp; i > 0; i--) {
-            if (batch % i == 0) {
-                merge_batch_vp = i;
-                break;
+            int max_batch_vp = max_batch / vp;
+            merge_batch_vp   = 1;
+            for (int i = max_batch_vp; i > 0; i--) {
+                if (batch % i == 0) {
+                    merge_batch_vp = i;
+                    break;
+                }
             }
         }
 #endif

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -2737,11 +2737,11 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_lokr_forward(
 
             // unpack conv2d weights if needed
             if (ggml_n_dims(a) < 4) {
-                int k = sqrt(a->ne[0] / h_split->ne[2]);
+                int k = (int)sqrt(a->ne[0] / h_split->ne[2]);
                 GGML_ASSERT(k * k * h_split->ne[2] == a->ne[0]);
                 a = ggml_reshape_4d(ctx, a, k, k, a->ne[0] / (k * k), a->ne[1]);
             } else if (a->ne[2] != h_split->ne[2]) {
-                int k = sqrt(a->ne[2] / h_split->ne[2]);
+                int k = (int)sqrt(a->ne[2] / h_split->ne[2]);
                 GGML_ASSERT(k * k * h_split->ne[2] == a->ne[2]);
                 a = ggml_reshape_4d(ctx, a, a->ne[0] * k, a->ne[1] * k, a->ne[2] / (k * k), a->ne[3]);
             }

--- a/ggml_extend.hpp
+++ b/ggml_extend.hpp
@@ -2658,27 +2658,25 @@ __STATIC_INLINE__ struct ggml_tensor* ggml_ext_lokr_forward(
     struct ggml_tensor* hb;
 
     if (!is_conv) {
-        int batch                 = (int)h->ne[1];
-        struct ggml_tensor* h_split = ggml_reshape_2d(ctx, h, vq, uq * batch);
+        int batch                   = (int)h->ne[1];
+        struct ggml_tensor* h_split = ggml_reshape_3d(ctx, h, vq, uq, batch);
 
         if (w2 != NULL) {
             hb = ggml_mul_mat(ctx, w2, h_split);
         } else {
             hb = ggml_mul_mat(ctx, w2b, ggml_mul_mat(ctx, w2a, h_split));
         }
+        struct ggml_tensor* hb_t = ggml_cont(ctx, ggml_transpose(ctx, hb));
 
-        struct ggml_tensor* hb_cat = ggml_reshape_3d(ctx, hb, vp, uq, batch);
-        struct ggml_tensor* hb_t         = ggml_cont(ctx, ggml_transpose(ctx, hb_cat));
-
-        struct ggml_tensor* hc;
+        struct ggml_tensor* hc_t;
         if (w1 != NULL) {
-            hc = ggml_mul_mat(ctx, w1, hb_t);
+            hc_t = ggml_mul_mat(ctx, w1, hb_t);
         } else {
-            hc = ggml_mul_mat(ctx, w1b, ggml_mul_mat(ctx, w1a, hb_t));
+            hc_t = ggml_mul_mat(ctx, w1b, ggml_mul_mat(ctx, w1a, hb_t));
         }
 
-        struct ggml_tensor* hc_t = ggml_transpose(ctx, hc);
-        struct ggml_tensor* out  = ggml_reshape_2d(ctx, ggml_cont(ctx, hc_t), up * vp, batch);
+        struct ggml_tensor* hc = ggml_transpose(ctx, hc_t);
+        struct ggml_tensor* out  = ggml_reshape_2d(ctx, ggml_cont(ctx, hc), up * vp, batch);
         return ggml_scale(ctx, out, scale);
 
     } else {

--- a/lora.hpp
+++ b/lora.hpp
@@ -483,7 +483,7 @@ struct LoraModel : public GGMLRunner {
             diff = get_loha_weight_diff(model_tensor_name, ctx);
         }
         // lokr
-        if (diff == nullptr) {
+        if (diff == nullptr && with_lora) {
             diff = get_lokr_weight_diff(model_tensor_name, ctx);
         }
         if (diff != nullptr) {
@@ -501,6 +501,8 @@ struct LoraModel : public GGMLRunner {
         return diff;
     }
 
+
+    
     ggml_tensor* get_out_diff(ggml_context* ctx,
                               ggml_tensor* x,
                               WeightAdapter::ForwardParams forward_params,
@@ -514,6 +516,115 @@ struct LoraModel : public GGMLRunner {
             } else {
                 key = model_tensor_name + "." + std::to_string(index);
             }
+            bool is_conv2d = forward_params.op_type == WeightAdapter::ForwardParams::op_type_t::OP_CONV2D;
+
+
+            std::string lokr_w1_name   = "lora." + key + ".lokr_w1";
+            std::string lokr_w1_a_name = "lora." + key + ".lokr_w1_a";
+            // if either of these is found, then we have a lokr lora
+            auto iter = lora_tensors.find(lokr_w1_name);
+            auto iter_a = lora_tensors.find(lokr_w1_a_name);
+            if (iter != lora_tensors.end() || iter_a != lora_tensors.end()) {
+                std::string lokr_w1_b_name = "lora." + key + ".lokr_w1_b";
+                std::string lokr_w2_name   = "lora." + key + ".lokr_w2";
+                std::string lokr_w2_a_name = "lora." + key + ".lokr_w2_a";
+                std::string lokr_w2_b_name = "lora." + key + ".lokr_w2_b";
+                std::string alpha_name     = "lora." + key + ".alpha";
+
+                ggml_tensor* lokr_w1   = nullptr;
+                ggml_tensor* lokr_w1_a = nullptr;
+                ggml_tensor* lokr_w1_b = nullptr;
+                ggml_tensor* lokr_w2   = nullptr;
+                ggml_tensor* lokr_w2_a = nullptr;
+                ggml_tensor* lokr_w2_b = nullptr;
+
+                if (iter != lora_tensors.end()) {
+                    lokr_w1 = iter->second;
+                    if (is_conv2d && lokr_w1->type != GGML_TYPE_F16) {
+                        lokr_w1 = ggml_cast(ctx, lokr_w1, GGML_TYPE_F16);
+                    }
+                }
+                iter = iter_a;
+                if (iter != lora_tensors.end()) {
+                    lokr_w1_a = iter->second;
+                    if (is_conv2d && lokr_w1_a->type != GGML_TYPE_F16) {
+                        lokr_w1_a = ggml_cast(ctx, lokr_w1_a, GGML_TYPE_F16);
+                    }
+                }
+                iter = lora_tensors.find(lokr_w1_b_name);
+                if (iter != lora_tensors.end()) {
+                    lokr_w1_b = iter->second;
+                    if (is_conv2d && lokr_w1_b->type != GGML_TYPE_F16) {
+                        lokr_w1_b = ggml_cast(ctx, lokr_w1_b, GGML_TYPE_F16);
+                    }
+                }
+
+                iter = lora_tensors.find(lokr_w2_name);
+                if (iter != lora_tensors.end()) {
+                    lokr_w2 = iter->second;
+                    if (is_conv2d && lokr_w2->type != GGML_TYPE_F16) {
+                        lokr_w2 = ggml_cast(ctx, lokr_w2, GGML_TYPE_F16);
+                    }
+                }
+                iter = lora_tensors.find(lokr_w2_a_name);
+                if (iter != lora_tensors.end()) {
+                    lokr_w2_a = iter->second;
+                    if (is_conv2d && lokr_w2_a->type != GGML_TYPE_F16) {
+                        lokr_w2_a = ggml_cast(ctx, lokr_w2_a, GGML_TYPE_F16);
+                    }
+                }
+                iter = lora_tensors.find(lokr_w2_b_name);
+                if (iter != lora_tensors.end()) {
+                    lokr_w2_b = iter->second;
+                    if (is_conv2d && lokr_w2_b->type != GGML_TYPE_F16) {
+                        lokr_w2_b = ggml_cast(ctx, lokr_w2_b, GGML_TYPE_F16);
+                    }
+                }
+
+                int rank = 1;
+                if (lokr_w1_b) {
+                    rank = lokr_w1_b->ne[ggml_n_dims(lokr_w1_b) - 1];
+                }
+                if (lokr_w2_b) {
+                    rank = lokr_w2_b->ne[ggml_n_dims(lokr_w2_b) - 1];
+                }
+
+                float scale_value = 1.0f;
+                iter              = lora_tensors.find(alpha_name);
+                if (iter != lora_tensors.end()) {
+                    float alpha = ggml_ext_backend_tensor_get_f32(iter->second);
+                    scale_value = alpha / rank;
+                    applied_lora_tensors.insert(alpha_name);
+                }
+
+                if (rank == 1) {
+                    scale_value = 1.0f;
+                }
+                scale_value *= multiplier;
+
+                auto curr_out_diff = ggml_ext_lokr_forward(ctx, x, lokr_w1, lokr_w1_a, lokr_w1_b, lokr_w2, lokr_w2_a, lokr_w2_b, is_conv2d, forward_params.conv2d, scale_value);
+                if (out_diff == nullptr) {
+                    out_diff = curr_out_diff;
+                } else {
+                    out_diff = ggml_concat(ctx, out_diff, curr_out_diff, 0);
+                }
+
+                if(lokr_w1) applied_lora_tensors.insert(lokr_w1_name);
+                if(lokr_w1_a) applied_lora_tensors.insert(lokr_w1_a_name);
+                if(lokr_w1_b) applied_lora_tensors.insert(lokr_w1_b_name);
+                if(lokr_w2) applied_lora_tensors.insert(lokr_w2_name);
+                if(lokr_w2_a) applied_lora_tensors.insert(lokr_w2_name);
+                if(lokr_w2_b) applied_lora_tensors.insert(lokr_w2_b_name);
+                applied_lora_tensors.insert(alpha_name);
+
+
+                index++;
+                continue;
+            }
+            
+            // not a lork, normal lora path
+
+
 
             std::string lora_down_name = "lora." + key + ".lora_down";
             std::string lora_up_name   = "lora." + key + ".lora_up";
@@ -525,9 +636,8 @@ struct LoraModel : public GGMLRunner {
             ggml_tensor* lora_mid  = nullptr;
             ggml_tensor* lora_down = nullptr;
 
-            bool is_conv2d = forward_params.op_type == WeightAdapter::ForwardParams::op_type_t::OP_CONV2D;
 
-            auto iter = lora_tensors.find(lora_up_name);
+            iter = lora_tensors.find(lora_up_name);
             if (iter != lora_tensors.end()) {
                 lora_up = iter->second;
                 if (is_conv2d && lora_up->type != GGML_TYPE_F16) {

--- a/lora.hpp
+++ b/lora.hpp
@@ -540,23 +540,14 @@ struct LoraModel : public GGMLRunner {
 
                 if (iter != lora_tensors.end()) {
                     lokr_w1 = iter->second;
-                    if (is_conv2d && lokr_w1->type != GGML_TYPE_F16) {
-                        lokr_w1 = ggml_cast(ctx, lokr_w1, GGML_TYPE_F16);
-                    }
                 }
                 iter = iter_a;
                 if (iter != lora_tensors.end()) {
                     lokr_w1_a = iter->second;
-                    if (is_conv2d && lokr_w1_a->type != GGML_TYPE_F16) {
-                        lokr_w1_a = ggml_cast(ctx, lokr_w1_a, GGML_TYPE_F16);
-                    }
                 }
                 iter = lora_tensors.find(lokr_w1_b_name);
                 if (iter != lora_tensors.end()) {
                     lokr_w1_b = iter->second;
-                    if (is_conv2d && lokr_w1_b->type != GGML_TYPE_F16) {
-                        lokr_w1_b = ggml_cast(ctx, lokr_w1_b, GGML_TYPE_F16);
-                    }
                 }
 
                 iter = lora_tensors.find(lokr_w2_name);

--- a/lora.hpp
+++ b/lora.hpp
@@ -468,10 +468,10 @@ struct LoraModel : public GGMLRunner {
         return updown;
     }
 
-    ggml_tensor* get_weight_diff(const std::string& model_tensor_name, ggml_context* ctx, ggml_tensor* model_tensor, bool with_lora = true) {
+    ggml_tensor* get_weight_diff(const std::string& model_tensor_name, ggml_context* ctx, ggml_tensor* model_tensor, bool with_lora_and_lokr = true) {
         // lora
         ggml_tensor* diff = nullptr;
-        if (with_lora) {
+        if (with_lora_and_lokr) {
             diff = get_lora_weight_diff(model_tensor_name, ctx);
         }
         // diff
@@ -483,7 +483,7 @@ struct LoraModel : public GGMLRunner {
             diff = get_loha_weight_diff(model_tensor_name, ctx);
         }
         // lokr
-        if (diff == nullptr && with_lora) {
+        if (diff == nullptr && with_lora_and_lokr) {
             diff = get_lokr_weight_diff(model_tensor_name, ctx);
         }
         if (diff != nullptr) {
@@ -841,9 +841,9 @@ public:
         : lora_models(lora_models) {
     }
 
-    ggml_tensor* patch_weight(ggml_context* ctx, ggml_tensor* weight, const std::string& weight_name, bool with_lora) {
+    ggml_tensor* patch_weight(ggml_context* ctx, ggml_tensor* weight, const std::string& weight_name, bool with_lora_and_lokr) {
         for (auto& lora_model : lora_models) {
-            ggml_tensor* diff = lora_model->get_weight_diff(weight_name, ctx, weight, with_lora);
+            ggml_tensor* diff = lora_model->get_weight_diff(weight_name, ctx, weight, with_lora_and_lokr);
             if (diff == nullptr) {
                 continue;
             }

--- a/lora.hpp
+++ b/lora.hpp
@@ -501,8 +501,6 @@ struct LoraModel : public GGMLRunner {
         return diff;
     }
 
-
-    
     ggml_tensor* get_out_diff(ggml_context* ctx,
                               ggml_tensor* x,
                               WeightAdapter::ForwardParams forward_params,
@@ -518,11 +516,10 @@ struct LoraModel : public GGMLRunner {
             }
             bool is_conv2d = forward_params.op_type == WeightAdapter::ForwardParams::op_type_t::OP_CONV2D;
 
-
             std::string lokr_w1_name   = "lora." + key + ".lokr_w1";
             std::string lokr_w1_a_name = "lora." + key + ".lokr_w1_a";
             // if either of these is found, then we have a lokr lora
-            auto iter = lora_tensors.find(lokr_w1_name);
+            auto iter   = lora_tensors.find(lokr_w1_name);
             auto iter_a = lora_tensors.find(lokr_w1_a_name);
             if (iter != lora_tensors.end() || iter_a != lora_tensors.end()) {
                 std::string lokr_w1_b_name = "lora." + key + ".lokr_w1_b";
@@ -600,22 +597,25 @@ struct LoraModel : public GGMLRunner {
                     out_diff = ggml_concat(ctx, out_diff, curr_out_diff, 0);
                 }
 
-                if(lokr_w1) applied_lora_tensors.insert(lokr_w1_name);
-                if(lokr_w1_a) applied_lora_tensors.insert(lokr_w1_a_name);
-                if(lokr_w1_b) applied_lora_tensors.insert(lokr_w1_b_name);
-                if(lokr_w2) applied_lora_tensors.insert(lokr_w2_name);
-                if(lokr_w2_a) applied_lora_tensors.insert(lokr_w2_name);
-                if(lokr_w2_b) applied_lora_tensors.insert(lokr_w2_b_name);
+                if (lokr_w1)
+                    applied_lora_tensors.insert(lokr_w1_name);
+                if (lokr_w1_a)
+                    applied_lora_tensors.insert(lokr_w1_a_name);
+                if (lokr_w1_b)
+                    applied_lora_tensors.insert(lokr_w1_b_name);
+                if (lokr_w2)
+                    applied_lora_tensors.insert(lokr_w2_name);
+                if (lokr_w2_a)
+                    applied_lora_tensors.insert(lokr_w2_name);
+                if (lokr_w2_b)
+                    applied_lora_tensors.insert(lokr_w2_b_name);
                 applied_lora_tensors.insert(alpha_name);
-
 
                 index++;
                 continue;
             }
-            
+
             // not a lork, normal lora path
-
-
 
             std::string lora_down_name = "lora." + key + ".lora_down";
             std::string lora_up_name   = "lora." + key + ".lora_up";
@@ -626,7 +626,6 @@ struct LoraModel : public GGMLRunner {
             ggml_tensor* lora_up   = nullptr;
             ggml_tensor* lora_mid  = nullptr;
             ggml_tensor* lora_down = nullptr;
-
 
             iter = lora_tensors.find(lora_up_name);
             if (iter != lora_tensors.end()) {

--- a/lora.hpp
+++ b/lora.hpp
@@ -571,10 +571,10 @@ struct LoraModel : public GGMLRunner {
 
                 int rank = 1;
                 if (lokr_w1_b) {
-                    rank = lokr_w1_b->ne[ggml_n_dims(lokr_w1_b) - 1];
+                    rank = (int)lokr_w1_b->ne[ggml_n_dims(lokr_w1_b) - 1];
                 }
                 if (lokr_w2_b) {
-                    rank = lokr_w2_b->ne[ggml_n_dims(lokr_w2_b) - 1];
+                    rank = (int)lokr_w2_b->ne[ggml_n_dims(lokr_w2_b) - 1];
                 }
 
                 float scale_value = 1.0f;
@@ -615,7 +615,7 @@ struct LoraModel : public GGMLRunner {
                 continue;
             }
 
-            // not a lork, normal lora path
+            // not a lokr, normal lora path
 
             std::string lora_down_name = "lora." + key + ".lora_down";
             std::string lora_up_name   = "lora." + key + ".lora_up";


### PR DESCRIPTION
Tested with https://civitai.green/models/344873/plana-blue-archivelokr

## Hip (ROCm 6.2)
### Master: 

| | 512x512 | 1024x1024 | 1024x1536 |
| -- | -- | -- | -- |
| Unet compute buffer | 3 295.83MB | 3 993.52MB | 4 860.33MB |
| Average time per step | 0.89s | 2.14s | 3.2s |

### PR: 

| | 512x512 | 1024x1024 | 1024x1536 |
| -- | -- | -- | -- |
| Unet compute buffer | 137.05MB | 830.86MB | 1 701.55MB |
| Average time per step | <del>1.3s</del> | <del>4.8s</del> | <del>7.44s</del> 3.84s |

## Vulkan (AMD propreitary driver):
###Master: 

| | 512x512 | 1024x1024 | 1024x1536 |
| -- | -- | -- | -- |
| Unet compute buffer | 3 363.80MB | 4056.49MB | 4986.61MB |
| Average time per step | 1.02s | 2.38s | 3.57s |

### PR: 

| | 512x512 | 1024x1024 | 1024x1536 |
| -- | -- | -- | -- |
| Unet compute buffer | 137.05MB |  830.86MB | 1 746.55MB |
| Average time per step | <del>0.92s</del> | <del>2.98s</del> | <del>4.5s</del> 4.04s |

TLDR: significant VRAM savings across the board. Somehow a big performance hit across all resolutions on ROCm backend (that needs some more investigation), Vulkan backend going faster at smaller resolutions, but slower at high res. 


### EDIT:
 Not long after doing these measurments I found a way to massively reduce the performance gap (with the same compute buffer size). It's now consistently better than master on Vulkan, 
 I'm too lazy to do the all tests again for now, but for example,1024x1536 now takes 3.84s per step on ROCm, and 3.07s on Vulkan