### PR TITLE
Add a github action to generate a Linux ROCm artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -491,6 +491,7 @@ jobs:
 
     env:
       ROCM_VERSION: "7.2"
+      UBUNTU_VERSION: "24.04"
       GPU_TARGETS: "gfx1151;gfx1150;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201"
 
     steps:
@@ -519,11 +520,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt install -y \
-            rocm-dev \
+            cmake \
             hip-dev \
             hipblas-dev \
-            cmake \
-            ninja-build
+            ninja-build \
+            rocm-dev \
+            zip
           # Clean apt caches to recover disk space
           sudo apt clean
           sudo rm -rf /var/lib/apt/lists/* || true
@@ -606,12 +608,29 @@ jobs:
           cp /opt/rocm/lib/rocblas/library/* ./build/bin/rocblas/library/ || true
           cp /opt/rocm/lib/hipblaslt/library/* ./build/bin/hipblaslt/library/ || true
 
+      - name: Fetch system info
+        id: system-info
+        run: |
+          echo "CPU_ARCH=`uname -m`" >> "$GITHUB_OUTPUT"
+          echo "OS_NAME=`lsb_release -s -i`" >> "$GITHUB_OUTPUT"
+          echo "OS_VERSION=`lsb_release -s -r`" >> "$GITHUB_OUTPUT"
+          echo "OS_TYPE=`uname -s`" >> "$GITHUB_OUTPUT"
+
+      - name: Pack artifacts
+        id: pack_artifacts
+        if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
+        run: |
+          cp ggml/LICENSE ./build/bin/ggml.txt
+          cp LICENSE ./build/bin/stable-diffusion.cpp.txt
+          zip -j sd-${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}-bin-${{ steps.system-info.outputs.OS_TYPE }}-Ubuntu-${{ env.UBUNTU_VERSION }}-${{ steps.system-info.outputs.CPU_ARCH }}-rocm.zip ./build/bin/*
+
       - name: Upload artifacts
         if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: sd-${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}-bin-linux-rocm-x64
-          path: build/bin
+          name: sd-${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}-bin-${{ steps.system-info.outputs.OS_TYPE }}-Ubuntu-${{ env.UBUNTU_VERSION }}-${{ steps.system-info.outputs.CPU_ARCH }}-rocm.zip
+          path: |
+            sd-${{ env.BRANCH_NAME }}-${{ steps.commit.outputs.short }}-bin-${{ steps.system-info.outputs.OS_TYPE }}-Ubuntu-${{ env.UBUNTU_VERSION }}-${{ steps.system-info.outputs.CPU_ARCH }}-rocm.zip
 
   release:
     if: ${{ ( github.event_name == 'push' && github.ref == 'refs/heads/master' ) || github.event.inputs.create_release == 'true' }}


### PR DESCRIPTION
This uses the current stable release, ROCm 7.2.
The following GPU ISA architectures are supported:
 * gfx1151
 * gfx1150
 * gfx1100
 * gfx1101
 * gfx1102
 * gfx1200
 * gfx1201