### PR TITLE
feat: use image and command-line dimensions by default on server

### DIFF
--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -405,7 +405,7 @@ int main(int argc, const char** argv) {
             std::string output_format = j.value("output_format", "png");
             int output_compression    = j.value("output_compression", 100);
             int width                 = default_gen_params.width > 0 ? default_gen_params.width : 512;
-            int height                = default_gen_params.width > 0 ? default_gen_params.height: 512;
+            int height                = default_gen_params.width > 0 ? default_gen_params.height : 512;
             if (!size.empty()) {
                 auto pos = size.find('x');
                 if (pos != std::string::npos) {
@@ -988,7 +988,6 @@ int main(int argc, const char** argv) {
             };
 
             if (img2img) {
-
                 if (j.contains("init_images") && j["init_images"].is_array() && !j["init_images"].empty()) {
                     std::string encoded = j["init_images"][0].get<std::string>();
                     decode_image(init_image, encoded);


### PR DESCRIPTION
When image dimensions are not provided, get them first from any input images, replicating the `sd-cli` approach. For plain txt2img, get the default dimensions from the server command-line.

~~This is on top of #1260 because it conflicts with it, and I tested both together; I can rebase it onto master if needed. And if the logic is sound, I'll extend it to the openai endpoints.~~

Edit: Now on top of another bugfix: #1268 . Also extended the logic to the openai api, but wasn't able to test it.

Should fix #1248 . Supersedes #1255 .