### PR TITLE
z-image: use fused swiglu kernel

### DIFF
--- a/src/z_image.hpp
+++ b/src/z_image.hpp
@@ -131,7 +131,7 @@ namespace ZImage {
 
             auto x1 = w1->forward(ctx, x);
             auto x3 = w3->forward(ctx, x);
-            x       = ggml_mul(ctx->ggml_ctx, ggml_silu(ctx->ggml_ctx, x1), x3);
+            x       = ggml_swiglu_split(ctx->ggml_ctx, x1, x3);
             x       = w2->forward(ctx, x);
 
             return x;


### PR DESCRIPTION
Use a fused kernel for the swiglu operation in the FFN instead of separate silu and mul operations to improve performance.

## Timing

Test command

```
./build/cuda/bin/Release/sd-cli \
  --diffusion-model ~/code/ComfyUI/models/diffusion_models/z_image_turbo-Q5_K_S.gguf \
  --vae ~/code/ComfyUI/models/vae/ae.safetensors \
  --llm ~/code/ComfyUI/models/text_encoders/Qwen3-4B.i1-Q5_K_S.gguf \
  -p "A cinematic photograph of a solitary hooded figure walking through a rain-slicked city at night, neon reflections on wet asphalt, moody atmospheric" \
  --cfg-scale 1.0 --diffusion-fa -v \
  -H 1024 -W 512 \
  --steps 8 \
  --output output%03d.png
```

Timing on RTX 2080ti

Run | Original (s) | Fused SwiGLU (s)
-- | -- | --
1 | 8.55 | 8.52
2 | 8.60 | 8.58
3 | 8.74 | 8.62
4 | 8.67 | 8.65
5 | 8.70 | 8.66
Mean | 8.652 | 8.606

Not statistically significant (p-value = 0.07), but still an improvement nevertheless.