### PR TITLE
Fix : gguf download link in anima.md

### DIFF
--- a/docs/anima.md
+++ b/docs/anima.md
@@ -4,7 +4,7 @@
 
 - Download Anima
     - safetensors: https://huggingface.co/circlestone-labs/Anima/tree/main/split_files/diffusion_models
-    - gguf: https://huggingface.co/Bedovyy/Anima-GGUF/tree/main
+    - gguf: https://huggingface.co/JusteLeo/Anima-GGUF/tree/main
 - Download vae
     - safetensors: https://huggingface.co/circlestone-labs/Anima/tree/main/split_files/vae
 - Download Qwen3-0.6B-Base


### PR DESCRIPTION
The GGUF models currently linked in the documentation were quantized for ComfyUI-GGUF. They are incompatible with this repository and cause the following error:

`[ERROR] stable-diffusion.cpp:335 - get sd version from file failed: ''`

I have updated the links to a repository containing GGUF files specifically quantized for `stable-diffusion.cpp`. I have tested them on the `main` branch and they work correctly.

I can add more quantization levels if there is a need for them :)