### PR TITLE
reset weight adapter for models if no loras in request (fix 'sticky loras')

### DIFF
--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1098,6 +1098,18 @@ public:
         cond_stage_lora_models.clear();
         diffusion_lora_models.clear();
         first_stage_lora_models.clear();
+        if (cond_stage_model) {
+            cond_stage_model->set_weight_adapter(nullptr);
+        }
+        if (diffusion_model) {
+            diffusion_model->set_weight_adapter(nullptr);
+        }
+        if (high_noise_diffusion_model) {
+            high_noise_diffusion_model->set_weight_adapter(nullptr);
+        }
+        if (first_stage_model) {
+            first_stage_model->set_weight_adapter(nullptr);
+        }
         if (lora_state.empty()) {
             return;
         }


### PR DESCRIPTION
Currently, weight_adapter remains unchanged if there are no loras in the query.
Therefore, after a calculation with a given loras, all subsequent queries without a loras specified will use the last specified loras.