### PR TITLE
CUDA Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,7 @@ jobs:
 
     strategy:
       matrix:
-        variant: [musa, sycl, vulkan]
+        variant: [musa, sycl, vulkan, cuda]
 
     env:
       REGISTRY: ghcr.io

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -1,0 +1,25 @@
+ARG CUDA_VERSION=12.6.3
+ARG UBUNTU_VERSION=24.04
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-devel-ubuntu${UBUNTU_VERSION} AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential git ccache cmake
+
+WORKDIR /sd.cpp
+
+COPY . .
+
+ARG CUDACXX=/usr/local/cuda/bin/nvcc
+RUN cmake . -B ./build -DSD_CUDA=ON
+RUN cmake --build ./build --config Release --parallel
+
+FROM nvidia/cuda:${CUDA_VERSION}-cudnn-runtime-ubuntu${UBUNTU_VERSION} AS runtime
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends libgomp1 && \
+    apt-get clean
+
+COPY --from=build /sd.cpp/build/bin/sd-cli /sd-cli
+COPY --from=build /sd.cpp/build/bin/sd-server /sd-server
+
+ENTRYPOINT [ "/sd-cli" ]


### PR DESCRIPTION
This PR adds a cuda variant to the github workflows `build.yml`.
Version `12.6.3` was used as it is still currently maintained and supports more devices.

This was tested locally using `podman` on Fedora Silverblue with the following commands:

```sh
podman build -f Dockerfile.cuda -t stable-diffusion.cpp:master-cuda  .
podman run --rm --userns=keep-id --security-opt=label=type=nvidia_container_t --device nvidia.com/gpu=all localhost/stable-diffusion.cpp:master-cuda --version
```

Thanks for all your efforts on stable-diffusion.cpp!