### PR TITLE
fix: correct encoder channels for flux2

### DIFF
--- a/src/auto_encoder_kl.hpp
+++ b/src/auto_encoder_kl.hpp
@@ -613,6 +613,9 @@ public:
 
     int get_encoder_output_channels() {
         int factor = dd_config.double_z ? 2 : 1;
+        if (sd_version_is_flux2(version)) {
+            return dd_config.z_channels * 4;
+        }
         return dd_config.z_channels * factor;
     }
 };


### PR DESCRIPTION
With acc3bf1fdcb682c30b4ff9a80f19b891012d4ebc the encoding for flux2 used 64 instead of the required 128 channels, causing a GGML_ASSERT in `get_latents_mean_std_vec`.

This fixes that issue by correctly handling flux2's encoding.