### PR TITLE
fix: correct double increment on flow denoisers sigma calculations

### DIFF
--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -662,8 +662,8 @@ struct DiscreteFlowDenoiser : public Denoiser {
     }
 
     void set_parameters() {
-        for (int i = 1; i < TIMESTEPS + 1; i++) {
-            sigmas[i - 1] = t_to_sigma(static_cast<float>(i));
+        for (int i = 0; i < TIMESTEPS; i++) {
+            sigmas[i] = t_to_sigma(static_cast<float>(i));
         }
     }
 


### PR DESCRIPTION
t_to_sigma already increments t, so it ends up generating wrong values for sigma_max (1.00033) and sigma_min. This affects schedulers that rely on those values: exponential, karras, bong_tangent and kl_optimal.

bong_tangent 8 steps, before:
1.00033, 0.971839, 0.930154, 0.863995, 0.746076, 0.503155, 0.217895, 0.0752291, 0

after:
1, 0.97143, 0.929634, 0.863298, 0.745065, 0.501497, 0.215478, 0.0724315, 0