### PR TITLE
feat: use sdcpp-webui as embedded webui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ on:
         "**/*.c",
         "**/*.cpp",
         "**/*.cu",
+        "examples/server/frontend",
         "examples/server/frontend/**",
       ]
   pull_request:
@@ -35,6 +36,7 @@ on:
         "**/*.c",
         "**/*.cpp",
         "**/*.cu",
+        "examples/server/frontend",
         "examples/server/frontend/**",
       ]
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/ggml-org/ggml.git
 [submodule "examples/server/frontend"]
 	path = examples/server/frontend
-	url = https://github.com/leejet/stable-ui.git
+	url = https://github.com/leejet/sdcpp-webui.git
 [submodule "thirdparty/libwebp"]
 	path = thirdparty/libwebp
 	url = https://github.com/webmproject/libwebp.git

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -8,7 +8,7 @@ The server can optionally build the web frontend and embed it into the binary as
 
 Install the following tools:
 
-* **Node.js** ≥ 22.18
+* **Node.js** ≥ 20
   https://nodejs.org/
 
 * **pnpm** ≥ 10
@@ -54,7 +54,7 @@ and embed the generated frontend into the server binary.
 
 ## Frontend Repository
 
-The web frontend is maintained in a **separate repository**, https://github.com/leejet/stable-ui.
+The web frontend is maintained in a **separate repository**, https://github.com/leejet/sdcpp-webui.
 
 If you want to modify the UI or frontend logic, please submit pull requests to the **frontend repository**.
 


### PR DESCRIPTION
```
.\bin\Release\sd-server.exe --diffusion-model  ..\models\diffusion_models\z_image_turbo_bf16.safetensors --vae ..\models\vae\ae.sft  --llm ..\models\text_encoders\qwen_3_4b.safetensors --diffusion-fa --offload-to-cpu -v --cfg-scale 1.0
```

Visit http://127.0.0.1:1234/


<img width="1606" height="1274" alt="image" src="https://github.com/user-attachments/assets/a66152d8-0eb1-42fd-9e78-c3d439c09374" />
