### PR TITLE
fix: correct image to image DDIM and TCD

### DIFF
--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -1290,27 +1290,12 @@ static sd::Tensor<float> sample_ddim_trailing(denoise_cb_t model,
                                               const std::vector<float>& sigmas,
                                               std::shared_ptr<RNG> rng,
                                               float eta) {
-    float beta_start = 0.00085f;
-    float beta_end   = 0.0120f;
-    std::vector<double> alphas_cumprod(TIMESTEPS);
-    std::vector<double> compvis_sigmas(TIMESTEPS);
-    for (int i = 0; i < TIMESTEPS; i++) {
-        alphas_cumprod[i] =
-            (i == 0 ? 1.0f : alphas_cumprod[i - 1]) *
-            (1.0f -
-             std::pow(sqrtf(beta_start) +
-                          (sqrtf(beta_end) - sqrtf(beta_start)) *
-                              ((float)i / (TIMESTEPS - 1)),
-                      2));
-        compvis_sigmas[i] =
-            std::sqrt((1 - alphas_cumprod[i]) / alphas_cumprod[i]);
-    }
 
     int steps = static_cast<int>(sigmas.size()) - 1;
     for (int i = 0; i < steps; i++) {
-        int timestep      = static_cast<int>(roundf(TIMESTEPS - i * ((float)TIMESTEPS / steps))) - 1;
-        int prev_timestep = timestep - TIMESTEPS / steps;
-        float sigma       = static_cast<float>(compvis_sigmas[timestep]);
+
+        float sigma       = sigmas[i];
+        float sigma_to    = sigmas[i + 1];
 
         auto model_output_opt = model(x, sigma, i + 1);
         if (model_output_opt.empty()) {
@@ -1319,8 +1304,8 @@ static sd::Tensor<float> sample_ddim_trailing(denoise_cb_t model,
         sd::Tensor<float> model_output = std::move(model_output_opt);
         model_output                   = (x - model_output) * (1.0f / sigma);
 
-        float alpha_prod_t      = static_cast<float>(alphas_cumprod[timestep]);
-        float alpha_prod_t_prev = prev_timestep >= 0 ? static_cast<float>(alphas_cumprod[prev_timestep]) : 1.0f;
+        float alpha_prod_t      = 1.0f / (sigma * sigma + 1.0f);
+        float alpha_prod_t_prev = 1.0f / (sigma_to * sigma_to + 1.0f);
         float beta_prod_t       = 1.0f - alpha_prod_t;
 
         sd::Tensor<float> pred_original_sample = ((x / std::sqrt(sigma * sigma + 1)) -

--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -1311,9 +1311,6 @@ static sd::Tensor<float> sample_ddim_trailing(denoise_cb_t model,
         int timestep      = static_cast<int>(roundf(TIMESTEPS - i * ((float)TIMESTEPS / steps))) - 1;
         int prev_timestep = timestep - TIMESTEPS / steps;
         float sigma       = static_cast<float>(compvis_sigmas[timestep]);
-        if (i > 0) {
-            x *= std::sqrt(sigma * sigma + 1);
-        }
 
         auto model_output_opt = model(x, sigma, i + 1);
         if (model_output_opt.empty()) {
@@ -1340,6 +1337,11 @@ static sd::Tensor<float> sample_ddim_trailing(denoise_cb_t model,
 
         if (eta > 0) {
             x += std_dev_t * sd::Tensor<float>::randn_like(x, rng);
+        }
+
+        if (prev_timestep >= 0) {
+            // sigma_prev * sigma_prev + 1 = (1 - alpha_prod_t_prev) / alpha_prod_t_prev + 1
+            x *= std::sqrt(1 / alpha_prod_t_prev);
         }
     }
     return x;
@@ -1374,10 +1376,6 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
         int timestep_s    = (int)floor((1 - eta) * prev_timestep);
         float sigma       = static_cast<float>(compvis_sigmas[timestep]);
 
-        if (i > 0) {
-            x *= std::sqrt(sigma * sigma + 1);
-        }
-
         auto model_output_opt = model(x, sigma, i + 1);
         if (model_output_opt.empty()) {
             return {};
@@ -1401,6 +1399,11 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
         if (eta > 0 && i != steps - 1) {
             x = std::sqrt(alpha_prod_t_prev / alpha_prod_s) * x +
                 std::sqrt(1.0f - alpha_prod_t_prev / alpha_prod_s) * sd::Tensor<float>::randn_like(x, rng);
+        }
+
+        if (prev_timestep >= 0) {
+            // sigma_prev * sigma_prev + 1 = (1 - alpha_prod_t_prev) / alpha_prod_t_prev + 1
+            x *= std::sqrt(1 / alpha_prod_t_prev);
         }
     }
     return x;

--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -1350,13 +1350,25 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
             std::sqrt((1 - alphas_cumprod[i]) / alphas_cumprod[i]);
     }
 
-    int original_steps = 50;
-    int steps          = static_cast<int>(sigmas.size()) - 1;
+    auto get_timestep_from_sigma = [&](float s) -> int {
+        auto it = std::lower_bound(compvis_sigmas.begin(), compvis_sigmas.end(), s);
+        if (it == compvis_sigmas.begin()) return 0;
+        if (it == compvis_sigmas.end()) return TIMESTEPS - 1;
+        int idx_high = static_cast<int>(std::distance(compvis_sigmas.begin(), it));
+        int idx_low  = idx_high - 1;
+        if (std::abs(compvis_sigmas[idx_high] - s) < std::abs(compvis_sigmas[idx_low] - s)) {
+            return idx_high;
+        }
+        return idx_low;
+    };
+
+    int steps = static_cast<int>(sigmas.size()) - 1;
     for (int i = 0; i < steps; i++) {
-        int timestep      = TIMESTEPS - 1 - (TIMESTEPS / original_steps) * (int)floor(i * ((float)original_steps / steps));
-        int prev_timestep = i >= steps - 1 ? 0 : TIMESTEPS - 1 - (TIMESTEPS / original_steps) * (int)floor((i + 1) * ((float)original_steps / steps));
+
+        float sigma_to    = sigmas[i + 1];
+        int prev_timestep = get_timestep_from_sigma(sigma_to);
         int timestep_s    = (int)floor((1 - eta) * prev_timestep);
-        float sigma       = static_cast<float>(compvis_sigmas[timestep]);
+        float sigma       = sigmas[i];
 
         auto model_output_opt = model(x, sigma, i + 1);
         if (model_output_opt.empty()) {
@@ -1365,9 +1377,9 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
         sd::Tensor<float> model_output = std::move(model_output_opt);
         model_output                   = (x - model_output) * (1.0f / sigma);
 
-        float alpha_prod_t      = static_cast<float>(alphas_cumprod[timestep]);
+        float alpha_prod_t      = 1.0f / (sigma * sigma + 1.0f);
         float beta_prod_t       = 1.0f - alpha_prod_t;
-        float alpha_prod_t_prev = prev_timestep >= 0 ? static_cast<float>(alphas_cumprod[prev_timestep]) : 1.0f;
+        float alpha_prod_t_prev = 1.0f / (sigma_to * sigma_to + 1.0f);
         float alpha_prod_s      = static_cast<float>(alphas_cumprod[timestep_s]);
         float beta_prod_s       = 1.0f - alpha_prod_s;
 
@@ -1378,7 +1390,7 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
         x = std::sqrt(alpha_prod_s) * pred_original_sample +
             std::sqrt(beta_prod_s) * model_output;
 
-        if (eta > 0 && i != steps - 1) {
+        if (eta > 0 && sigma_to > 0.0f) {
             x = std::sqrt(alpha_prod_t_prev / alpha_prod_s) * x +
                 std::sqrt(1.0f - alpha_prod_t_prev / alpha_prod_s) * sd::Tensor<float>::randn_like(x, rng);
         }

--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -1311,9 +1311,7 @@ static sd::Tensor<float> sample_ddim_trailing(denoise_cb_t model,
         int timestep      = static_cast<int>(roundf(TIMESTEPS - i * ((float)TIMESTEPS / steps))) - 1;
         int prev_timestep = timestep - TIMESTEPS / steps;
         float sigma       = static_cast<float>(compvis_sigmas[timestep]);
-        if (i == 0) {
-            x *= std::sqrt(sigma * sigma + 1) / sigma;
-        } else {
+        if (i > 0) {
             x *= std::sqrt(sigma * sigma + 1);
         }
 
@@ -1376,9 +1374,7 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
         int timestep_s    = (int)floor((1 - eta) * prev_timestep);
         float sigma       = static_cast<float>(compvis_sigmas[timestep]);
 
-        if (i == 0) {
-            x *= std::sqrt(sigma * sigma + 1) / sigma;
-        } else {
+        if (i > 0) {
             x *= std::sqrt(sigma * sigma + 1);
         }
 

--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -1317,14 +1317,13 @@ static sd::Tensor<float> sample_ddim_trailing(denoise_cb_t model,
                          (1.0f - alpha_prod_t / alpha_prod_t_prev);
         float std_dev_t = eta * std::sqrt(variance);
 
-        x = std::sqrt(alpha_prod_t_prev) * pred_original_sample +
-            std::sqrt(1.0f - alpha_prod_t_prev - std::pow(std_dev_t, 2)) * model_output;
+        x = pred_original_sample +
+            std::sqrt((1.0f - alpha_prod_t_prev - std::pow(std_dev_t, 2))/ alpha_prod_t_prev) * model_output;
 
         if (eta > 0) {
-            x += std_dev_t * sd::Tensor<float>::randn_like(x, rng);
+            x+= std_dev_t / std::sqrt(alpha_prod_t_prev) * sd::Tensor<float>::randn_like(x, rng);
         }
 
-        x *= std::sqrt(1 / alpha_prod_t_prev);
     }
     return x;
 }
@@ -1387,15 +1386,14 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
                                                   std::sqrt(beta_prod_t) * model_output) *
                                                  (1.0f / std::sqrt(alpha_prod_t));
 
-        x = std::sqrt(alpha_prod_s) * pred_original_sample +
-            std::sqrt(beta_prod_s) * model_output;
+        x = std::sqrt(alpha_prod_s / alpha_prod_t_prev) * pred_original_sample +
+            std::sqrt(beta_prod_s / alpha_prod_t_prev) * model_output;
 
         if (eta > 0 && sigma_to > 0.0f) {
             x = std::sqrt(alpha_prod_t_prev / alpha_prod_s) * x +
-                std::sqrt(1.0f - alpha_prod_t_prev / alpha_prod_s) * sd::Tensor<float>::randn_like(x, rng);
+                std::sqrt(1.0f / alpha_prod_t_prev - 1.0f / alpha_prod_s) * sd::Tensor<float>::randn_like(x, rng);
         }
 
-        x *= std::sqrt(1 / alpha_prod_t_prev);
     }
     return x;
 }

--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -1320,7 +1320,7 @@ static sd::Tensor<float> sample_ddim_trailing(denoise_cb_t model,
         model_output                   = (x - model_output) * (1.0f / sigma);
 
         float alpha_prod_t      = static_cast<float>(alphas_cumprod[timestep]);
-        float alpha_prod_t_prev = static_cast<float>(prev_timestep >= 0 ? alphas_cumprod[prev_timestep] : alphas_cumprod[0]);
+        float alpha_prod_t_prev = prev_timestep >= 0 ? static_cast<float>(alphas_cumprod[prev_timestep]) : 1.0f;
         float beta_prod_t       = 1.0f - alpha_prod_t;
 
         sd::Tensor<float> pred_original_sample = ((x / std::sqrt(sigma * sigma + 1)) -
@@ -1339,10 +1339,7 @@ static sd::Tensor<float> sample_ddim_trailing(denoise_cb_t model,
             x += std_dev_t * sd::Tensor<float>::randn_like(x, rng);
         }
 
-        if (prev_timestep >= 0) {
-            // sigma_prev * sigma_prev + 1 = (1 - alpha_prod_t_prev) / alpha_prod_t_prev + 1
-            x *= std::sqrt(1 / alpha_prod_t_prev);
-        }
+        x *= std::sqrt(1 / alpha_prod_t_prev);
     }
     return x;
 }
@@ -1385,7 +1382,7 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
 
         float alpha_prod_t      = static_cast<float>(alphas_cumprod[timestep]);
         float beta_prod_t       = 1.0f - alpha_prod_t;
-        float alpha_prod_t_prev = static_cast<float>(prev_timestep >= 0 ? alphas_cumprod[prev_timestep] : alphas_cumprod[0]);
+        float alpha_prod_t_prev = prev_timestep >= 0 ? static_cast<float>(alphas_cumprod[prev_timestep]) : 1.0f;
         float alpha_prod_s      = static_cast<float>(alphas_cumprod[timestep_s]);
         float beta_prod_s       = 1.0f - alpha_prod_s;
 
@@ -1401,10 +1398,7 @@ static sd::Tensor<float> sample_tcd(denoise_cb_t model,
                 std::sqrt(1.0f - alpha_prod_t_prev / alpha_prod_s) * sd::Tensor<float>::randn_like(x, rng);
         }
 
-        if (prev_timestep >= 0) {
-            // sigma_prev * sigma_prev + 1 = (1 - alpha_prod_t_prev) / alpha_prod_t_prev + 1
-            x *= std::sqrt(1 / alpha_prod_t_prev);
-        }
+        x *= std::sqrt(1 / alpha_prod_t_prev);
     }
     return x;
 }

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1619,8 +1619,15 @@ public:
         }
 
         int64_t t0                   = ggml_time_us();
+
+        // scales the initial noise for DDIM and TCD
+        // NOTE: may not be strictly needed, since with the initial
+        // ~14.6 sigma, its value is very close to 1 (~1.002)
+        float ddim_noise_scale       = ((method == DDIM_TRAILING_SAMPLE_METHOD || method == TCD_SAMPLE_METHOD)
+                                           ? std::sqrt(sigmas[0] * sigmas[0] + 1) / sigmas[0]
+                                           : 1.0);
         sd::Tensor<float> x_t        = !noise.empty()
-                                           ? denoiser->noise_scaling(sigmas[0], noise, init_latent)
+                                           ? denoiser->noise_scaling(sigmas[0] * ddim_noise_scale, noise, init_latent)
                                            : init_latent;
         sd::Tensor<float> denoised   = x_t;
         SamplePreviewContext preview = prepare_sample_preview_context();

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1619,15 +1619,8 @@ public:
         }
 
         int64_t t0                   = ggml_time_us();
-
-        // scales the initial noise for DDIM and TCD
-        // NOTE: may not be strictly needed, since with the initial
-        // ~14.6 sigma, its value is very close to 1 (~1.002)
-        float ddim_noise_scale       = ((method == DDIM_TRAILING_SAMPLE_METHOD || method == TCD_SAMPLE_METHOD)
-                                           ? std::sqrt(sigmas[0] * sigmas[0] + 1) / sigmas[0]
-                                           : 1.0);
         sd::Tensor<float> x_t        = !noise.empty()
-                                           ? denoiser->noise_scaling(sigmas[0] * ddim_noise_scale, noise, init_latent)
+                                           ? denoiser->noise_scaling(sigmas[0], noise, init_latent)
                                            : init_latent;
         sd::Tensor<float> denoised   = x_t;
         SamplePreviewContext preview = prepare_sample_preview_context();

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -2422,7 +2422,7 @@ enum scheduler_t sd_get_default_scheduler(const sd_ctx_t* sd_ctx, enum sample_me
             return EXPONENTIAL_SCHEDULER;
         }
     }
-    if (sample_method == LCM_SAMPLE_METHOD) {
+    if (sample_method == LCM_SAMPLE_METHOD || sample_method == TCD_SAMPLE_METHOD) {
         return LCM_SCHEDULER;
     } else if (sample_method == DDIM_TRAILING_SAMPLE_METHOD) {
         return SIMPLE_SCHEDULER;

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -2424,6 +2424,8 @@ enum scheduler_t sd_get_default_scheduler(const sd_ctx_t* sd_ctx, enum sample_me
     }
     if (sample_method == LCM_SAMPLE_METHOD) {
         return LCM_SCHEDULER;
+    } else if (sample_method == DDIM_TRAILING_SAMPLE_METHOD) {
+        return SIMPLE_SCHEDULER;
     }
     return DISCRETE_SCHEDULER;
 }


### PR DESCRIPTION
This supersedes my initial attempt at #665 , and has a much better chance of actually being correct 🙂

In a nutshell, there are two issues with DDIM and TCD:
* they assume the initial image is pure noise, and apply a noise scaling which happens to be _inversely_ proportional to the initial sigma value. This factor gets very close to 1 for the typical initial sigma for text to image, but it throws lower noise levels (e.g. in low-strength image to image) completely out of scale;
* they have their own internal sigma schedules, but we rely on the input sigmas vector to set the right values for image to image.

This series remove that initial noise scaling, adapt the samplers to follow the provided sigma vectors, and sets appropriate default sigma schedulers: simple for DDIM, and LCM for TCD. I've tried to keep each commit self-contained, to be easier to follow and test.

Fixes #663 .