### PR TITLE
feat: adapt LCM for flow models

### DIFF
--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -1040,7 +1040,8 @@ static sd::Tensor<float> sample_dpmpp_2m_v2(denoise_cb_t model,
 static sd::Tensor<float> sample_lcm(denoise_cb_t model,
                                     sd::Tensor<float> x,
                                     const std::vector<float>& sigmas,
-                                    std::shared_ptr<RNG> rng) {
+                                    std::shared_ptr<RNG> rng,
+                                    bool is_flow_denoiser) {
     int steps = static_cast<int>(sigmas.size()) - 1;
     for (int i = 0; i < steps; i++) {
         auto denoised_opt = model(x, sigmas[i], i + 1);
@@ -1049,6 +1050,9 @@ static sd::Tensor<float> sample_lcm(denoise_cb_t model,
         }
         x = std::move(denoised_opt);
         if (sigmas[i + 1] > 0) {
+            if (is_flow_denoiser) {
+                x *= (1 - sigmas[i + 1]);
+            }
             x += sd::Tensor<float>::randn_like(x, rng) * sigmas[i + 1];
         }
     }
@@ -1437,7 +1441,7 @@ static sd::Tensor<float> sample_k_diffusion(sample_method_t method,
         case DPMPP2Mv2_SAMPLE_METHOD:
             return sample_dpmpp_2m_v2(model, std::move(x), sigmas);
         case LCM_SAMPLE_METHOD:
-            return sample_lcm(model, std::move(x), sigmas, rng);
+            return sample_lcm(model, std::move(x), sigmas, rng, is_flow_denoiser);
         case IPNDM_SAMPLE_METHOD:
             return sample_ipndm(model, std::move(x), sigmas);
         case IPNDM_V_SAMPLE_METHOD:


### PR DESCRIPTION
This was an experiment I did when working with the samplers code, that turned out to make pretty decent results, instead of a "you are using the wrong sampler" image:

| | master | PR |
|---|---|---|
| Z-Image Turbo, 4 steps | <img width="256" height="256" alt="test_1776016328" src="https://github.com/user-attachments/assets/e0cfe0f3-5a5c-49b6-9c50-adb14aea0f60" /> | <img width="256" height="256" alt="test_1776016351" src="https://github.com/user-attachments/assets/58c4788d-932a-4a92-b255-adb723a06176" /> |
| Flux.2 Klein 4b, 3 steps |<img width="256" height="256" alt="test_1776018448" src="https://github.com/user-attachments/assets/72605ef9-6f55-4406-93b2-28ffde893f2d" /> | <img width="256" height="256" alt="test_1776018296" src="https://github.com/user-attachments/assets/afdf348f-3666-4629-9903-92a4237488f7" /> |

It comes pretty much directly from the flow math, although I couldn't find other LCM implementations doing exactly this.