### PR TITLE
feat(sdapi): report generation parameters through the info field

### DIFF
--- a/examples/server/routes_sdapi.cpp
+++ b/examples/server/routes_sdapi.cpp
@@ -236,6 +236,48 @@ static bool build_sdapi_img_gen_request(const json& j,
     return true;
 }
 
+static nlohmann::json prepare_info_field(const SDContextParams& ctx_params,
+                                         const SDGenerationParams& gen_params,
+                                         bool img2img) {
+    nlohmann::json jsoninfo = nlohmann::json::object();
+    jsoninfo["prompt"]      = gen_params.prompt;
+    if (!gen_params.negative_prompt.empty()) {
+        jsoninfo["negative_prompt"] = gen_params.negative_prompt;
+    }
+    jsoninfo["seed"]         = gen_params.seed;
+    jsoninfo["cfg_scale"]    = gen_params.sample_params.guidance.txt_cfg;
+    jsoninfo["width"]        = gen_params.get_resolved_width();
+    jsoninfo["height"]       = gen_params.get_resolved_height();
+    jsoninfo["steps"]        = gen_params.sample_params.sample_steps;
+    jsoninfo["sampler_name"] = sd_sample_method_name(gen_params.sample_params.sample_method);
+    if (gen_params.clip_skip != -1) {
+        jsoninfo["clip_skip"] = gen_params.clip_skip;
+    }
+    if (gen_params.sample_params.scheduler != scheduler_t::SCHEDULER_COUNT) {
+        jsoninfo["extra_generation_params"] = nlohmann::json::object();
+        jsoninfo["extra_generation_params"]["Schedule type"] = sd_scheduler_name(gen_params.sample_params.scheduler);
+    }
+    if (img2img) {
+        jsoninfo["denoising_strength"] = gen_params.strength;
+    }
+    // not clear what should happen if we have both model and diffusion_model
+    if (!ctx_params.diffusion_model_path.empty()) {
+        jsoninfo["sd_model_name"] = sd_basename(ctx_params.diffusion_model_path);
+    } else if (!ctx_params.model_path.empty()) {
+        jsoninfo["sd_model_name"] = sd_basename(ctx_params.model_path);
+    }
+    if (!ctx_params.vae_path.empty()) {
+        jsoninfo["sd_vae_name"] = sd_basename(ctx_params.vae_path);
+    }
+    jsoninfo["version"] = "stable-diffusion.cpp";
+
+    jsoninfo["infotexts"]            = nlohmann::json::array();
+    jsoninfo["all_prompts"]          = nlohmann::json::array();
+    jsoninfo["all_negative_prompts"] = nlohmann::json::array();
+    jsoninfo["all_seeds"]            = nlohmann::json::array();
+    return jsoninfo;
+}
+
 void register_sdapi_endpoints(httplib::Server& svr, ServerRuntime& rt) {
     ServerRuntime* runtime = &rt;
 
@@ -278,24 +320,25 @@ void register_sdapi_endpoints(httplib::Server& svr, ServerRuntime& rt) {
             json out;
             out["images"]     = json::array();
             out["parameters"] = j;
-            out["info"]       = "";
+            json jsoninfo     = prepare_info_field(*runtime->ctx_params, request.gen_params, img2img);
 
             for (int i = 0; i < num_results; ++i) {
                 if (results[i].data == nullptr) {
                     continue;
                 }
 
-                std::string params = request.gen_params.embed_image_metadata
-                                         ? get_image_params(*runtime->ctx_params,
-                                                            request.gen_params,
-                                                            request.gen_params.seed + i)
-                                         : "";
+                bool embed_meta    = request.gen_params.embed_image_metadata;
+
+                std::string params = get_image_params(*runtime->ctx_params,
+                                                      request.gen_params,
+                                                      request.gen_params.seed + i);
+
                 auto image_bytes   = encode_image_to_vector(EncodedImageFormat::PNG,
                                                             results[i].data,
                                                             results[i].width,
                                                             results[i].height,
                                                             results[i].channel,
-                                                            params);
+                                                            embed_meta ? params : "");
 
                 if (image_bytes.empty()) {
                     LOG_ERROR("write image to mem failed");
@@ -303,7 +346,15 @@ void register_sdapi_endpoints(httplib::Server& svr, ServerRuntime& rt) {
                 }
 
                 out["images"].push_back(base64_encode(image_bytes));
+
+                jsoninfo["infotexts"][i]            = params;
+                jsoninfo["all_seeds"][i]            = request.gen_params.seed + i;
+                jsoninfo["all_prompts"][i]          = request.gen_params.prompt;
+                jsoninfo["all_negative_prompts"][i] = request.gen_params.negative_prompt;
             }
+
+            // not a mistake: it is supposed to be a string in json format
+            out["info"] = jsoninfo.dump();
 
             res.set_content(out.dump(), "application/json");
             res.status = 200;

--- a/examples/server/routes_sdapi.cpp
+++ b/examples/server/routes_sdapi.cpp
@@ -259,6 +259,48 @@ static bool build_sdapi_img_gen_request(const json& j,
     return true;
 }
 
+static nlohmann::json prepare_info_field(const SDContextParams& ctx_params,
+                                         const SDGenerationParams& gen_params,
+                                         bool img2img) {
+    nlohmann::json jsoninfo = nlohmann::json::object();
+    jsoninfo["prompt"]      = gen_params.prompt;
+    if (!gen_params.negative_prompt.empty()) {
+        jsoninfo["negative_prompt"] = gen_params.negative_prompt;
+    }
+    jsoninfo["seed"]         = gen_params.seed;
+    jsoninfo["cfg_scale"]    = gen_params.sample_params.guidance.txt_cfg;
+    jsoninfo["width"]        = gen_params.get_resolved_width();
+    jsoninfo["height"]       = gen_params.get_resolved_height();
+    jsoninfo["steps"]        = gen_params.sample_params.sample_steps;
+    jsoninfo["sampler_name"] = sd_sample_method_name(gen_params.sample_params.sample_method);
+    if (gen_params.clip_skip != -1) {
+        jsoninfo["clip_skip"] = gen_params.clip_skip;
+    }
+    if (gen_params.sample_params.scheduler != scheduler_t::SCHEDULER_COUNT) {
+        jsoninfo["extra_generation_params"] = nlohmann::json::object();
+        jsoninfo["extra_generation_params"]["Schedule type"] = sd_scheduler_name(gen_params.sample_params.scheduler);
+    }
+    if (img2img) {
+        jsoninfo["denoising_strength"] = gen_params.strength;
+    }
+    // not clear what should happen if we have both model and diffusion_model
+    if (!ctx_params.diffusion_model_path.empty()) {
+        jsoninfo["sd_model_name"] = sd_basename(ctx_params.diffusion_model_path);
+    } else if (!ctx_params.model_path.empty()) {
+        jsoninfo["sd_model_name"] = sd_basename(ctx_params.model_path);
+    }
+    if (!ctx_params.vae_path.empty()) {
+        jsoninfo["sd_vae_name"] = sd_basename(ctx_params.vae_path);
+    }
+    jsoninfo["version"] = "stable-diffusion.cpp";
+
+    jsoninfo["infotexts"]            = nlohmann::json::array();
+    jsoninfo["all_prompts"]          = nlohmann::json::array();
+    jsoninfo["all_negative_prompts"] = nlohmann::json::array();
+    jsoninfo["all_seeds"]            = nlohmann::json::array();
+    return jsoninfo;
+}
+
 void register_sdapi_endpoints(httplib::Server& svr, ServerRuntime& rt) {
     ServerRuntime* runtime = &rt;
 
@@ -309,7 +351,7 @@ void register_sdapi_endpoints(httplib::Server& svr, ServerRuntime& rt) {
             json out;
             out["images"]     = json::array();
             out["parameters"] = j;
-            out["info"]       = "";
+            json jsoninfo     = prepare_info_field(*runtime->ctx_params, request.gen_params, img2img);
 
             int images_per_batch = request.gen_params.batch_count > 0 ? std::max(1, num_results / request.gen_params.batch_count) : 1;
             for (int i = 0; i < num_results; ++i) {
@@ -317,17 +359,18 @@ void register_sdapi_endpoints(httplib::Server& svr, ServerRuntime& rt) {
                     continue;
                 }
 
-                std::string params = request.gen_params.embed_image_metadata
-                                         ? get_image_params(*runtime->ctx_params,
-                                                            request.gen_params,
-                                                            request.gen_params.seed + i / images_per_batch)
-                                         : "";
+                bool embed_meta    = request.gen_params.embed_image_metadata;
+
+                std::string params = get_image_params(*runtime->ctx_params,
+                                                      request.gen_params,
+                                                      request.gen_params.seed + i / images_per_batch);
+
                 auto image_bytes   = encode_image_to_vector(EncodedImageFormat::PNG,
                                                             results[i].data,
                                                             results[i].width,
                                                             results[i].height,
                                                             results[i].channel,
-                                                            params);
+                                                            embed_meta ? params : "");
 
                 if (image_bytes.empty()) {
                     LOG_ERROR("write image to mem failed");
@@ -335,7 +378,15 @@ void register_sdapi_endpoints(httplib::Server& svr, ServerRuntime& rt) {
                 }
 
                 out["images"].push_back(base64_encode(image_bytes));
+
+                jsoninfo["infotexts"][i]            = params;
+                jsoninfo["all_seeds"][i]            = request.gen_params.seed + i;
+                jsoninfo["all_prompts"][i]          = request.gen_params.prompt;
+                jsoninfo["all_negative_prompts"][i] = request.gen_params.negative_prompt;
             }
+
+            // not a mistake: it is supposed to be a string in json format
+            out["info"] = jsoninfo.dump();
 
             res.set_content(out.dump(), "application/json");
             res.status = 200;


### PR DESCRIPTION
This field provides both a copy of the image metadata and structured generation parameters. It's similar to 'parameters', but while 'parameters' is mostly a copy of the request, 'info' reports what actually went into the generation, including defaults, adjusted sizes, etc.