### PR TITLE
docs: add gosd (pure Go bindings) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ These projects wrap `stable-diffusion.cpp` for easier use in other languages/fra
 
 * Golang (non-cgo): [seasonjs/stable-diffusion](https://github.com/seasonjs/stable-diffusion)
 * Golang (cgo): [Binozo/GoStableDiffusion](https://github.com/Binozo/GoStableDiffusion)
+* Golang (non-cgo): [l8bloom/gosd](https://github.com/l8bloom/gosd)
 * C#: [DarthAffe/StableDiffusion.NET](https://github.com/DarthAffe/StableDiffusion.NET)
 * Python: [william-murray1204/stable-diffusion-cpp-python](https://github.com/william-murray1204/stable-diffusion-cpp-python)
 * Rust: [newfla/diffusion-rs](https://github.com/newfla/diffusion-rs)


### PR DESCRIPTION
Hello,

I've developed gosd, a set of pure Go (no CGO) bindings for stable-diffusion.cpp. I noticed that existing Go implementations in the README are currently out of sync with the latest upstream APIs, so I built this to provide a modern alternative.

Key features:

- Pure Go: Uses FFI (no CGO), making cross-platform builds seamless.
- Up-to-date: 100% stable-diffusion.cpp API coverage with CI/CD that tracks upstream changes to ensure compatibility.
- Cross-platform: Regularly tested on Windows, Linux, and macOS.
- Versioning: Clearly maps gosd releases to specific sd.cpp versions.

I believe this would be a valuable addition for Go developers looking to integrate this project.
Thank you for all the work on this engine!