### PR TITLE
display server url with "http://" prefix.

### DIFF
--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -145,7 +145,7 @@ int main(int argc, const char** argv) {
     register_sdapi_endpoints(svr, runtime);
     register_sdcpp_api_endpoints(svr, runtime);
 
-    LOG_INFO("listening on: %s:%d\n", svr_params.listen_ip.c_str(), svr_params.listen_port);
+    LOG_INFO("listening on: http://%s:%d\n", svr_params.listen_ip.c_str(), svr_params.listen_port);
     svr.listen(svr_params.listen_ip, svr_params.listen_port);
 
     {


### PR DESCRIPTION
display the "http://" prefix when starting the server for two
reasons:
- clarifies to the user this is running on HTTP, and not something
 HTTPS
- in many terminals, including the "http://" prefix will create a
 clickable hyperlink, which will make it easier for users to launch
 the UI frontend directly from the terminal.
