### PR TITLE
fix: detect QWEN_IMAGE version from bare GGUF tensor names

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -437,7 +437,8 @@ SDVersion ModelLoader::get_sd_version() {
         if (tensor_storage.name.find("model.diffusion_model.joint_blocks.") != std::string::npos) {
             return VERSION_SD3;
         }
-        if (tensor_storage.name.find("model.diffusion_model.transformer_blocks.0.img_mod.1.weight") != std::string::npos) {
+        if (tensor_storage.name.find("model.diffusion_model.transformer_blocks.0.img_mod.1.weight") != std::string::npos ||
+            tensor_storage.name.find("transformer_blocks.0.img_mod.1.weight") != std::string::npos) {
             return VERSION_QWEN_IMAGE;
         }
         if (tensor_storage.name.find("llm_adapter.blocks.0.cross_attn.q_proj.weight") != std::string::npos) {

--- a/src/name_conversion.cpp
+++ b/src/name_conversion.cpp
@@ -1093,6 +1093,20 @@ std::string convert_tensor_name(std::string name, SDVersion version) {
 
     replace_with_prefix_map(name, prefix_map);
 
+    // Qwen-Image GGUF (e.g. from unsloth) may store bare tensor names without
+    // the model.diffusion_model. prefix.  Add it so downstream loaders can find
+    // the tensors when they search with the canonical prefix.
+    if (sd_version_is_qwen_image(version)) {
+        if (!starts_with(name, "model.diffusion_model.") &&
+            !starts_with(name, "text_encoders.") &&
+            !starts_with(name, "first_stage_model.") &&
+            !starts_with(name, "vae.") &&
+            !starts_with(name, "cond_stage_model.") &&
+            !starts_with(name, "lora.")) {
+            name = "model.diffusion_model." + name;
+        }
+    }
+
     // diffusion model
     {
         for (const auto& prefix : diffuison_model_prefix_vec) {


### PR DESCRIPTION
## Problem

Some GGUF files (e.g. from [unsloth](https://huggingface.co/unsloth/Qwen-Image-2512-GGUF)) store diffusion model tensors **without** the `model.diffusion_model.` prefix. For example, tensor names look like:

- `transformer_blocks.0.img_mod.1.weight`
- `img_in.bias`
- `proj_out.weight`

Instead of:
- `model.diffusion_model.transformer_blocks.0.img_mod.1.weight`

This causes `get_sd_version()` to fail with `get sd version from file failed`, even though the binary has full Qwen-Image support (the `--llm` flag, `QwenImageModel` class, etc. are all present).

Reference: [lemonade-sdk/lemonade#1874](https://github.com/lemonade-sdk/lemonade/issues/1874) — users hitting this when trying to run `Qwen-Image-2512-GGUF` through `sd-cpp`.

## Fix

Two changes:

### 1. `src/model.cpp` - Version detection

In `get_sd_version()`, match `transformer_blocks.0.img_mod.1.weight` with or without the `model.diffusion_model.` prefix.

### 2. `src/name_conversion.cpp` - Tensor name conversion

After `replace_with_prefix_map()`, add `model.diffusion_model.` prefix to bare Qwen-Image tensor names that don't already have a recognized prefix. This ensures `QwenImageModel` (which uses prefix `model.diffusion_model`) can find the tensors.

## Testing

Verified locally that `sd-server.exe` can now detect Qwen-Image GGUF version and starts loading the model (text encoder + VAE load successfully, main GGUF passes version detection).
