### PR TITLE
ltx2.3: fix sd_audio stereo format

### DIFF
--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -2575,7 +2575,20 @@ static sd_audio_t* waveform_to_sd_audio(const StableDiffusionGGML* sd,
         free(audio);
         return nullptr;
     }
-    std::memcpy(audio->data, waveform.data(), sample_bytes);
+
+    const float* src = waveform.data();
+    float* dst       = audio->data;
+
+    if (channels == 1) {
+        std::memcpy(dst, src, sample_bytes);
+    } else {
+        for (int64_t t = 0; t < sample_count; ++t) {
+            for (int64_t c = 0; c < channels; ++c) {
+                dst[t * channels + c] = src[c * sample_count + t];
+            }
+        }
+    }
+
     return audio;
 }
 

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -2576,18 +2576,8 @@ static sd_audio_t* waveform_to_sd_audio(const StableDiffusionGGML* sd,
         return nullptr;
     }
 
-    const float* src = waveform.data();
-    float* dst       = audio->data;
-
-    if (channels == 1) {
-        std::memcpy(dst, src, sample_bytes);
-    } else {
-        for (int64_t t = 0; t < sample_count; ++t) {
-            for (int64_t c = 0; c < channels; ++c) {
-                dst[t * channels + c] = src[c * sample_count + t];
-            }
-        }
-    }
+    auto wavaform_t = waveform.permute({1, 0, 2, 3});
+    std::memcpy(audio->data, wavaform_t.data(), sample_bytes);
 
     return audio;
 }


### PR DESCRIPTION
targets https://github.com/leejet/stable-diffusion.cpp/pull/1463

https://github.com/leejet/stable-diffusion.cpp/pull/1463#issuecomment-4426081199

If changing the format of sd_audio's data is undesirable, we could alternatively interleave the audio samples just before saving to webm or avi, but it was easier for me to implement it like that. 