### PR TITLE
chore: do not report the fake VAE "allocation" as an error

### DIFF
--- a/src/ggml_extend.hpp
+++ b/src/ggml_extend.hpp
@@ -2732,6 +2732,9 @@ public:
                 rebuild_params_tensor_set();
                 return true;
             }
+        } else {
+            LOG_DEBUG("%s skipping params allocation (no tensors)", get_desc().c_str());
+            return true;
         }
         params_buffer = ggml_backend_alloc_ctx_tensors(params_ctx, params_backend);
         if (params_buffer == nullptr) {


### PR DESCRIPTION
## Summary

The VAE allocation code triggered an error log for models without a VAE. I believe missing tensors due to a model error are dealt with before this point anyway, so treat the "no tensors" case as a correct path.

## Additional Information

> [DEBUG] ggml_extend.hpp:2746 - hidream_o1 params backend buffer size =  9485.23 MB(VRAM) (407 tensors)
[ERROR] ggml_extend.hpp:2738 - fake_vae alloc params backend buffer failed, num_tensors = 0

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
