### PR TITLE
fix: avoid repeated T5 EOS tokens in Anima prompt weights

### DIFF
--- a/src/conditioner.hpp
+++ b/src/conditioner.hpp
@@ -1625,10 +1625,11 @@ struct AnimaConditioner : public Conditioner {
         for (const auto& item : parsed_attention) {
             const std::string& curr_text = item.first;
             float curr_weight            = item.second;
-            std::vector<int> curr_tokens = t5_tokenizer.tokenize(curr_text, nullptr, true);
+            std::vector<int> curr_tokens = t5_tokenizer.encode(curr_text);
             t5_tokens.insert(t5_tokens.end(), curr_tokens.begin(), curr_tokens.end());
             t5_weights.insert(t5_weights.end(), curr_tokens.size(), curr_weight);
         }
+        t5_tokenizer.pad_tokens(t5_tokens, &t5_weights, nullptr);
 
         return {qwen_tokens, qwen_weights, t5_tokens, t5_weights};
     }


### PR DESCRIPTION
## Summary

 Fixes Anima prompt weighting when prompts contain parenthesized weight syntax.

  Anima tokenization split weighted prompts into multiple attention segments, then called T5 tokenization with padding
  enabled for each segment. That inserted a T5 EOS token after every segment. The resulting `t5_ids` sequence was then
  passed into the Anima LLM adapter, causing poor/broken generations for weighted prompts.

  This changes Anima T5 token handling to:

  - encode each weighted segment without adding special tokens
  - add special tokens once after all segments are concatenated

## Related Issue / Discussion

This addresses the broken weighted prompt behavior reported in #1492.

## Additional Information

```
.\bin\Release\sd-cli.exe --diffusion-model  ..\..\ComfyUI\models\diffusion_models\anima-preview.safetensors --vae ..\..\ComfyUI\models\vae\qwen_image_vae.safetensors  --llm ..\..\ComfyUI\models\text_encoders\qwen_3_06b_base.safetensors  -p "a (lovely) cat holding a sign says 'anima.cpp'" --cfg-scale 6.0 --sampling-method euler -v --offload-to-cpu
```

before:

<img width="512" height="512" alt="output" src="https://github.com/user-attachments/assets/8b2152a5-7bbd-4d67-ac33-b7269169a6fb" />

after:

<img width="512" height="512" alt="output" src="https://github.com/user-attachments/assets/1d4153b2-3205-4531-9664-9aae9f0f5962" />

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
