### PR TITLE
fix: only enable TAE after successful load

### DIFF
--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -327,8 +327,9 @@ public:
             LOG_INFO("loading tae from '%s'", sd_ctx_params->taesd_path);
             if (!model_loader.init_from_file(sd_ctx_params->taesd_path, "tae.")) {
                 LOG_WARN("loading tae from '%s' failed", sd_ctx_params->taesd_path);
+            } else {
+                use_tae = true;
             }
-            use_tae = true;
         }
 
         if (strlen(SAFE_STR(sd_ctx_params->embeddings_connectors_path)) > 0) {


### PR DESCRIPTION
## Summary

 - Only set `use_tae` when the TAE model loader initializes successfully.
 - Prevent failed TAE load attempts from leaving TAE enabled.

## Related Issue / Discussion

N/A

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
