### PR TITLE
fix: restore singleton dims for LLM outputs

### DIFF
--- a/src/llm.hpp
+++ b/src/llm.hpp
@@ -1403,7 +1403,8 @@ namespace LLM {
                                    out_layers,
                                    return_all_hidden_states);
             };
-            return take_or_empty(GGMLRunner::compute<float>(get_graph, n_threads, true));
+            return restore_trailing_singleton_dims(GGMLRunner::compute<float>(get_graph, n_threads, true),
+                                                   input_ids.dim() + 1);
         }
 
         int64_t get_num_image_tokens(int64_t t, int64_t h, int64_t w) {


### PR DESCRIPTION
## Summary

 - Restore trailing singleton dimensions on LLM compute outputs.
 - Fix single-token conditioning paths where ggml may drop the token dimension and make `hidden_states.shape()[1]`
  invalid.

## Related Issue / Discussion

N/A

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
