### PR TITLE
fix: build web UI for Windows ROCm server releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -471,6 +471,16 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+
       - name: Cache ROCm Installation
         id: cache-rocm
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- Add node/pnpm setup so `sd-server` can generate and embed the frontend HTML during ROCm release builds.

## Related Issue / Discussion

https://github.com/leejet/stable-diffusion.cpp/issues/1521

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
