### PR TITLE
fix: update sycl docker image to oneapi 2025.3

### DIFF
--- a/Dockerfile.sycl
+++ b/Dockerfile.sycl
@@ -1,4 +1,5 @@
-ARG SYCL_VERSION=2025.1.0-0
+# ggml SYCL hardware detection uses BMG G31/WCL architecture enums added in oneAPI 2025.3.
+ARG SYCL_VERSION=2025.3.2-0
 
 FROM intel/oneapi-basekit:${SYCL_VERSION}-devel-ubuntu24.04 AS build
 


### PR DESCRIPTION
## Summary

 - Update the SYCL Docker image from oneAPI 2025.1 to 2025.3.2.

## Related Issue / Discussion

N/A

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
