### PR TITLE
Fix: always load runtime lora params on runtime backend

### DIFF
--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1211,7 +1211,7 @@ public:
         }
         auto lora = std::make_shared<LoraModel>(lora_id,
                                                 backend_for(module),
-                                                params_backend_for(module),
+                                                backend_for(module),
                                                 lora_path,
                                                 is_high_noise ? "model.high_noise_" : "",
                                                 version);


### PR DESCRIPTION
## Summary

When running LoRAs at runtime, the LoRA params have to be loaded from param backend to runtime backend for every linear or conv operation, at every step. This performance overhead can cause very significant slowdown if the params are offloaded to a different device.

This PR ensures the lora weights are never offloaded, fixing the performance issue for a minimal cost of constant VRAM usage.

## Related Issue / Discussion

[#1463 (hidden comment)](https://github.com/leejet/stable-diffusion.cpp/pull/1463#:~:text=Edit2%3A%20it%20was%20because%20I%20was%20using%20at_runtime%20LoRA%20with%20CPU%20offloading.%20That%27s%20an%20issue.%20Maybe%20It%20would%20make%20sense%20to%20load%20the%20LoRA%20to%20the%20compute%20backend%20regardless%3F)

## Additional Information

In some extreme cases, this change helped me go from ~190s/it to 7.3s/it for LTX2.3 with distill LoRA.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
