### PR TITLE
fix: skip permission denied errors in recursive_directory_iterator

### DIFF
--- a/examples/server/runtime.cpp
+++ b/examples/server/runtime.cpp
@@ -254,7 +254,7 @@ void refresh_lora_cache(ServerRuntime& rt) {
 
     fs::path lora_dir = rt.ctx_params->lora_model_dir;
     if (fs::exists(lora_dir) && fs::is_directory(lora_dir)) {
-        for (auto& entry : fs::recursive_directory_iterator(lora_dir)) {
+        for (auto& entry : fs::recursive_directory_iterator(lora_dir, fs::directory_options::skip_permission_denied)) {
             if (!entry.is_regular_file()) {
                 continue;
             }


### PR DESCRIPTION
## Summary

This PR prevents `sdcpp-webui` from error `Service Unavailable` when scanning directories with restricted system folders (like `lost+found`) by adding `fs::directory_options::skip_permission_denied` to the `recursive_directory_iterator`.

## Additional Information

When `lora_model_dir` defaults to the current working directory (`.`) and the server is executed from specific directory, `fs::recursive_directory_iterator` attempts to scan system folders like `lost+found`.

Since regular users lack read permissions for these directories, the iterator throws a fatal `std::filesystem::filesystem_error` (`Permission denied`), resulting in an `EXCEPTION_WHAT` crash and partially breaking the web server routing (leading to Service Unavailable errors in the UI).

### How to reproduce

1. `cd /`
2. Run `sd-server` as a non-root user
3. Observe the `Service Unavailable` in web (`filesystem error: cannot increment recursive directory iterator: Permission denied` crash upon UI initialization).