### PR TITLE
fix: correct tae for models that use the flux2 vae

### DIFF
--- a/src/tae.hpp
+++ b/src/tae.hpp
@@ -584,7 +584,7 @@ public:
     TAESD(bool decode_only = true, SDVersion version = VERSION_SD1)
         : decode_only(decode_only) {
         bool use_midblock_gn = false;
-        taef2                = sd_version_is_flux2(version);
+        taef2                = sd_version_uses_flux2_vae(version);
 
         if (sd_version_is_dit(version)) {
             z_channels = 16;


### PR DESCRIPTION
## Summary

Fix TAE parameters for non-Flux.2 models that use the Flux.2 VAE.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
