### PR TITLE
feat: add lazy load eager eviction

### DIFF
--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -430,6 +430,10 @@ ArgOptions SDContextParams::get_options() {
          "--mmap",
          "whether to memory-map model",
          true, &enable_mmap},
+        {"-ll",
+         "--lazy-load",
+         "lazy load/eager evict: stage model components with mmap; SD_MMAP_FLAGS=dontneed evicts pages after each stage",
+         true, &lazy_loading},
         {"",
          "--control-net-cpu",
          "keep controlnet in cpu (for low vram)",
@@ -697,6 +701,7 @@ std::string SDContextParams::to_string() const {
         << "  backend: \"" << backend << "\",\n"
         << "  params_backend: \"" << params_backend << "\",\n"
         << "  enable_mmap: " << (enable_mmap ? "true" : "false") << ",\n"
+        << "  lazy_loading: " << (lazy_loading ? "true" : "false") << ",\n"
         << "  control_net_cpu: " << (control_net_cpu ? "true" : "false") << ",\n"
         << "  clip_on_cpu: " << (clip_on_cpu ? "true" : "false") << ",\n"
         << "  vae_on_cpu: " << (vae_on_cpu ? "true" : "false") << ",\n"
@@ -773,6 +778,7 @@ sd_ctx_params_t SDContextParams::to_sd_ctx_params_t(bool vae_decode_only, bool f
         chroma_t5_mask_pad,
         qwen_image_zero_cond_t,
         max_vram,
+        lazy_loading,
         backend.c_str(),
         params_backend.c_str(),
     };

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -115,6 +115,7 @@ struct SDContextParams {
     std::string backend;
     std::string params_backend;
     bool enable_mmap           = false;
+    bool lazy_loading          = false;
     bool control_net_cpu       = false;
     bool clip_on_cpu           = false;
     bool vae_on_cpu            = false;

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -212,7 +212,8 @@ typedef struct {
     bool chroma_use_t5_mask;
     int chroma_t5_mask_pad;
     bool qwen_image_zero_cond_t;
-    float max_vram;  // GiB budget for graph-cut segmented param offload (0 = disabled, -1 = auto free VRAM minus 1 GiB)
+    float max_vram;     // GiB budget for graph-cut segmented param offload (0 = disabled, -1 = auto free VRAM minus 1 GiB)
+    bool lazy_loading;  // staged load: encode text, evict text encoder, load diffusion, evict, load VAE, decode
     const char* backend;
     const char* params_backend;
 } sd_ctx_params_t;

--- a/src/conditioner.hpp
+++ b/src/conditioner.hpp
@@ -115,6 +115,7 @@ public:
                                               const ConditionerParams& conditioner_params) = 0;
     virtual void alloc_params_buffer()                                                     = 0;
     virtual void free_params_buffer()                                                      = 0;
+    virtual void free_compute_buffer() {}
     virtual void get_param_tensors(std::map<std::string, ggml_tensor*>& tensors)           = 0;
     virtual size_t get_params_buffer_size()                                                = 0;
     virtual void set_max_graph_vram_bytes(size_t max_vram_bytes) {}
@@ -802,6 +803,18 @@ struct SD3CLIPEmbedder : public Conditioner {
         }
         if (t5) {
             t5->free_params_buffer();
+        }
+    }
+
+    void free_compute_buffer() override {
+        if (clip_l) {
+            clip_l->free_compute_buffer();
+        }
+        if (clip_g) {
+            clip_g->free_compute_buffer();
+        }
+        if (t5) {
+            t5->free_compute_buffer();
         }
     }
 

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -138,6 +138,7 @@ public:
     bool vae_decode_only         = false;
     bool external_vae_is_invalid = false;
     bool free_params_immediately = false;
+    bool lazy_loading            = false;
 
     bool circular_x = false;
     bool circular_y = false;
@@ -208,6 +209,52 @@ public:
         return params_backend_for(module) != nullptr;
     }
 
+    bool tensor_is_mmap_backed(const ggml_tensor* tensor) const {
+        if (tensor == nullptr || tensor->data == nullptr || tensor->view_src != nullptr) {
+            return false;
+        }
+        const uint8_t* data = static_cast<const uint8_t*>(tensor->data);
+        const size_t size   = ggml_nbytes(tensor);
+        for (const auto& store : mmap_tensor_store) {
+            if (!store.mmapped) {
+                continue;
+            }
+            const uint8_t* base   = store.mmapped->data();
+            const size_t map_size = store.mmapped->size();
+            if (data >= base && size <= map_size && data - base <= map_size - size) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void evict_component_from_ram(const std::string& prefix) {
+        for (auto& [name, tensor] : tensors) {
+            if (!starts_with(name, prefix) || !tensor_is_mmap_backed(tensor)) {
+                continue;
+            }
+            evict_memory(tensor->data, ggml_nbytes(tensor));
+        }
+    }
+
+    void evict_text_encoder_from_ram() {
+        evict_component_from_ram("conditioner.");
+        evict_component_from_ram("cond_stage_model.");
+        evict_component_from_ram("text_encoders.");
+    }
+
+    void evict_diffusion_from_ram() {
+        evict_component_from_ram("model.diffusion_model.");
+        evict_component_from_ram("model.high_noise_diffusion_model.");
+    }
+
+    void evict_vae_from_ram() {
+        evict_component_from_ram("first_stage_model.");
+        evict_component_from_ram("vae.");
+        evict_component_from_ram("tae.");
+        evict_component_from_ram("audio_vae.");
+    }
+
     bool init_backend(const sd_ctx_params_t* sd_ctx_params) {
         std::string error;
         if (!backend_manager.init(sd_ctx_params->backend,
@@ -237,8 +284,13 @@ public:
         n_threads               = sd_ctx_params->n_threads;
         vae_decode_only         = sd_ctx_params->vae_decode_only;
         free_params_immediately = sd_ctx_params->free_params_immediately;
+        lazy_loading            = sd_ctx_params->lazy_loading;
         offload_params_to_cpu   = sd_ctx_params->offload_params_to_cpu;
         max_vram                = sd_ctx_params->max_vram;
+        if (lazy_loading) {
+            free_params_immediately = true;
+            LOG_INFO("lazy load/eager evict enabled: mmap and free_params_immediately forced on");
+        }
         backend_spec            = SAFE_STR(sd_ctx_params->backend);
         params_backend_spec     = SAFE_STR(sd_ctx_params->params_backend);
 
@@ -433,7 +485,7 @@ public:
         std::map<std::string, ggml_tensor*> mmap_able_tensors;
         bool enable_mmap_tensors = false;
         bool needs_writable_mmap = false;
-        if (sd_ctx_params->enable_mmap) {
+        if (sd_ctx_params->enable_mmap || lazy_loading) {
             if (apply_lora_immediately) {
                 needs_writable_mmap = true;
                 LOG_WARN("in mode 'immediately', LoRAs will cause extra memory usage with mmap");
@@ -1014,7 +1066,7 @@ public:
             return false;
         }
 
-        bool success = model_loader.load_tensors(tensors, ignore_tensors, n_threads, sd_ctx_params->enable_mmap);
+        bool success = model_loader.load_tensors(tensors, ignore_tensors, n_threads, sd_ctx_params->enable_mmap || lazy_loading);
         if (!success) {
             LOG_ERROR("load tensors from model loader failed");
             ggml_free(ctx);
@@ -2593,6 +2645,7 @@ void sd_ctx_params_init(sd_ctx_params_t* sd_ctx_params) {
     sd_ctx_params->offload_params_to_cpu   = false;
     sd_ctx_params->max_vram                = 0.f;
     sd_ctx_params->enable_mmap             = false;
+    sd_ctx_params->lazy_loading            = false;
     sd_ctx_params->keep_clip_on_cpu        = false;
     sd_ctx_params->keep_control_net_on_cpu = false;
     sd_ctx_params->keep_vae_on_cpu         = false;
@@ -4019,6 +4072,10 @@ static std::optional<ImageGenerationEmbeds> prepare_image_generation_embeds(sd_c
 
     if (sd_ctx->sd->free_params_immediately) {
         sd_ctx->sd->cond_stage_model->free_params_buffer();
+        if (sd_ctx->sd->lazy_loading) {
+            sd_ctx->sd->cond_stage_model->free_compute_buffer();
+        }
+        sd_ctx->sd->evict_text_encoder_from_ram();
     }
 
     ImageGenerationEmbeds embeds;
@@ -4050,6 +4107,7 @@ static sd_image_t* decode_image_outputs(sd_ctx_t* sd_ctx,
             LOG_ERROR("decode_first_stage failed for latent %" PRId64, i + 1);
             if (sd_ctx->sd->free_params_immediately) {
                 sd_ctx->sd->first_stage_model->free_params_buffer();
+                sd_ctx->sd->evict_vae_from_ram();
             }
             return nullptr;
         }
@@ -4062,6 +4120,7 @@ static sd_image_t* decode_image_outputs(sd_ctx_t* sd_ctx,
     LOG_INFO("decode_first_stage completed, taking %.2fs", (t4 - t0) * 1.0f / 1000);
     if (sd_ctx->sd->free_params_immediately) {
         sd_ctx->sd->first_stage_model->free_params_buffer();
+        sd_ctx->sd->evict_vae_from_ram();
     }
 
     sd_image_t* result_images = (sd_image_t*)calloc(request.batch_count, sizeof(sd_image_t));
@@ -4260,6 +4319,10 @@ SD_API sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* s
 
     int64_t t0                    = ggml_time_ms();
     sd_ctx->sd->vae_tiling_params = sd_img_gen_params->vae_tiling_params;
+    if (sd_ctx->sd->lazy_loading && !sd_ctx->sd->vae_tiling_params.enabled) {
+        sd_ctx->sd->vae_tiling_params.enabled = true;
+        LOG_INFO("lazy_loading: auto-enabling VAE tiling to reduce peak VRAM");
+    }
     GenerationRequest request(sd_ctx, sd_img_gen_params);
     LOG_INFO("generate_image %dx%d", request.width, request.height);
 
@@ -4340,11 +4403,19 @@ SD_API sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* s
                   (sampling_end - sampling_start) * 1.0f / 1000);
         if (sd_ctx->sd->free_params_immediately) {
             sd_ctx->sd->diffusion_model->free_params_buffer();
+            if (sd_ctx->sd->lazy_loading) {
+                sd_ctx->sd->diffusion_model->free_compute_buffer();
+            }
+            sd_ctx->sd->evict_diffusion_from_ram();
         }
         return nullptr;
     }
     if (sd_ctx->sd->free_params_immediately && !request.hires.enabled) {
         sd_ctx->sd->diffusion_model->free_params_buffer();
+        if (sd_ctx->sd->lazy_loading) {
+            sd_ctx->sd->diffusion_model->free_compute_buffer();
+        }
+        sd_ctx->sd->evict_diffusion_from_ram();
     }
     int64_t denoise_end = ggml_time_ms();
     LOG_INFO("generating %zu latent images completed, taking %.2fs",
@@ -4370,6 +4441,7 @@ SD_API sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* s
                 LOG_ERROR("load hires model upscaler failed");
                 if (sd_ctx->sd->free_params_immediately) {
                     sd_ctx->sd->diffusion_model->free_params_buffer();
+                    sd_ctx->sd->evict_diffusion_from_ram();
                 }
                 return nullptr;
             }
@@ -4404,6 +4476,7 @@ SD_API sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* s
             if (upscaled.empty()) {
                 if (sd_ctx->sd->free_params_immediately) {
                     sd_ctx->sd->diffusion_model->free_params_buffer();
+                    sd_ctx->sd->evict_diffusion_from_ram();
                 }
                 return nullptr;
             }
@@ -4463,11 +4536,13 @@ SD_API sd_image_t* generate_image(sd_ctx_t* sd_ctx, const sd_img_gen_params_t* s
                       (hires_sample_end - hires_sample_start) * 1.0f / 1000);
             if (sd_ctx->sd->free_params_immediately) {
                 sd_ctx->sd->diffusion_model->free_params_buffer();
+                sd_ctx->sd->evict_diffusion_from_ram();
             }
             return nullptr;
         }
         if (sd_ctx->sd->free_params_immediately) {
             sd_ctx->sd->diffusion_model->free_params_buffer();
+            sd_ctx->sd->evict_diffusion_from_ram();
         }
         int64_t hires_denoise_end = ggml_time_ms();
         LOG_INFO("hires fix completed, taking %.2fs", (hires_denoise_end - hires_denoise_start) * 1.0f / 1000);
@@ -4817,6 +4892,10 @@ static ImageGenerationEmbeds prepare_video_generation_embeds(sd_ctx_t* sd_ctx,
 
     if (sd_ctx->sd->free_params_immediately) {
         sd_ctx->sd->cond_stage_model->free_params_buffer();
+        if (sd_ctx->sd->lazy_loading) {
+            sd_ctx->sd->cond_stage_model->free_compute_buffer();
+        }
+        sd_ctx->sd->evict_text_encoder_from_ram();
     }
     return embeds;
 }
@@ -4846,6 +4925,7 @@ static sd_image_t* decode_video_outputs(sd_ctx_t* sd_ctx,
     LOG_INFO("decode_first_stage completed, taking %.2fs", (t5 - t4) * 1.0f / 1000);
     if (sd_ctx->sd->free_params_immediately) {
         sd_ctx->sd->first_stage_model->free_params_buffer();
+        sd_ctx->sd->evict_vae_from_ram();
     }
     if (vid.empty()) {
         LOG_ERROR("decode_first_stage failed for video");
@@ -5064,6 +5144,10 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
     }
     int64_t t0                    = ggml_time_ms();
     sd_ctx->sd->vae_tiling_params = sd_vid_gen_params->vae_tiling_params;
+    if (sd_ctx->sd->lazy_loading && !sd_ctx->sd->vae_tiling_params.enabled) {
+        sd_ctx->sd->vae_tiling_params.enabled = true;
+        LOG_INFO("lazy_loading: auto-enabling VAE tiling to reduce peak VRAM");
+    }
     GenerationRequest request(sd_ctx, sd_vid_gen_params);
     bool latent_upscale_enabled     = request.hires.enabled;
     GenerationRequest hires_request = request;
@@ -5157,6 +5241,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
             LOG_ERROR("sampling(high noise) failed after %.2fs", (sampling_end - sampling_start) * 1.0f / 1000);
             if (sd_ctx->sd->free_params_immediately) {
                 sd_ctx->sd->high_noise_diffusion_model->free_params_buffer();
+                sd_ctx->sd->evict_diffusion_from_ram();
             }
             return false;
         }
@@ -5166,6 +5251,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
         LOG_INFO("sampling(high noise) completed, taking %.2fs", (sampling_end - sampling_start) * 1.0f / 1000);
         if (sd_ctx->sd->free_params_immediately) {
             sd_ctx->sd->high_noise_diffusion_model->free_params_buffer();
+            sd_ctx->sd->evict_diffusion_from_ram();
         }
     }
 
@@ -5203,6 +5289,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
     if (final_latent.empty()) {
         if (sd_ctx->sd->free_params_immediately) {
             sd_ctx->sd->diffusion_model->free_params_buffer();
+            sd_ctx->sd->evict_diffusion_from_ram();
         }
         LOG_ERROR("sampling failed after %.2fs", (sampling_end - sampling_start) * 1.0f / 1000);
         return false;
@@ -5219,6 +5306,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
         if (upscaled_latent.empty()) {
             if (sd_ctx->sd->free_params_immediately) {
                 sd_ctx->sd->diffusion_model->free_params_buffer();
+                sd_ctx->sd->evict_diffusion_from_ram();
             }
             return false;
         }
@@ -5254,6 +5342,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
                               target_audio_length);
                     if (sd_ctx->sd->free_params_immediately) {
                         sd_ctx->sd->diffusion_model->free_params_buffer();
+                        sd_ctx->sd->evict_diffusion_from_ram();
                     }
                     return false;
                 }
@@ -5284,6 +5373,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
                                                   &hires_video_positions)) {
             if (sd_ctx->sd->free_params_immediately) {
                 sd_ctx->sd->diffusion_model->free_params_buffer();
+                sd_ctx->sd->evict_diffusion_from_ram();
             }
             return false;
         }
@@ -5345,6 +5435,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
         sampling_end   = ggml_time_ms();
         if (sd_ctx->sd->free_params_immediately) {
             sd_ctx->sd->diffusion_model->free_params_buffer();
+            sd_ctx->sd->evict_diffusion_from_ram();
         }
         if (final_latent.empty()) {
             LOG_ERROR("sampling(latent upscale) failed after %.2fs",
@@ -5355,6 +5446,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
                  (sampling_end - sampling_start) * 1.0f / 1000);
     } else if (sd_ctx->sd->free_params_immediately) {
         sd_ctx->sd->diffusion_model->free_params_buffer();
+        sd_ctx->sd->evict_diffusion_from_ram();
     }
 
     int64_t latent_end = ggml_time_ms();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <codecvt>
 #include <cstdarg>
+#include <cstdint>
 #include <exception>
 #include <fstream>
 #include <locale>
@@ -291,6 +292,32 @@ std::unique_ptr<MmapWrapper> MmapWrapper::create(const std::string& filename, bo
 }
 
 #endif
+
+void evict_memory(const void* data, size_t size) {
+#if defined(__linux__)
+    if (data == nullptr || size == 0) {
+        return;
+    }
+    auto cfg_flags = get_mmap_flags();
+    if (!cfg_flags.dontneed) {
+        return;
+    }
+    long page_size = sysconf(_SC_PAGESIZE);
+    if (page_size <= 0) {
+        return;
+    }
+    const uintptr_t page_mask = static_cast<uintptr_t>(page_size - 1);
+    const uintptr_t start     = reinterpret_cast<uintptr_t>(data) & ~page_mask;
+    const uintptr_t end       = (reinterpret_cast<uintptr_t>(data) + size + page_mask) & ~page_mask;
+    if (end <= start) {
+        return;
+    }
+    madvise(reinterpret_cast<void*>(start), end - start, MADV_DONTNEED);
+#else
+    (void)data;
+    (void)size;
+#endif
+}
 
 bool MmapWrapper::copy_data(void* buf, size_t n, size_t offset) const {
     if (offset >= size_ || n > (size_ - offset)) {

--- a/src/util.h
+++ b/src/util.h
@@ -64,6 +64,8 @@ protected:
     size_t size_ = 0;
 };
 
+void evict_memory(const void* data, size_t size);
+
 std::string path_join(const std::string& p1, const std::string& p2);
 std::vector<std::string> split_string(const std::string& str, char delimiter);
 


### PR DESCRIPTION
Split out from draft PR #1573: https://github.com/leejet/stable-diffusion.cpp/pull/1573

## Summary

Adds a `-ll` / `--lazy-load` flag for lazy load/eager evict model execution. The goal is to make larger image models practical on limited VRAM systems by loading model tensors through mmap and dropping already-used component pages after each pipeline stage.

This PR intentionally contains only the runtime lazy-load/eager-evict path. The conversion/RMSE/AIO work from #1573 is not included here.

## How it works

- Enables mmap-backed model loading when `--lazy-load` is set.
- Forces `free_params_immediately`, so component backend buffers are released after use.
- Adds a platform-layer `evict_memory()` helper in `util.cpp`.
- Calls eager eviction after text encoder, diffusion, and VAE stages.
- Gates `MADV_DONTNEED` behind `SD_MMAP_FLAGS=dontneed`; without that flag, the helper is a no-op.
- Applies eviction to normal mmap-to-VRAM code paths as well, not just the new flag path.
- Auto-enables VAE tiling with `--lazy-load` to avoid very large single VAE decode allocations. On my Vulkan setup, SD3.5 VAE decode at 1024x1024 would otherwise hit a large VkBuffer allocation that exceeds common Vulkan `maxMemoryAllocationSize` limits.

## Testing

- Built successfully with `cmake --build build -j16`.
- `git diff --check` passes.
- Runtime testing so far is on Vulkan only, on my machine (Arch Linux). That is the main reason this is a draft: it needs testing, and possibly follow-up code, on other GPU backends and operating systems.

## Notes

This addresses the lazy-loading-specific review feedback from #1573 by keeping platform-dependent eviction code in `util.cpp`, making `MADV_DONTNEED` opt-in through `SD_MMAP_FLAGS=dontneed`, and calling eviction for regular mmap-backed load paths too.