### PR TITLE
fix: explicitly exclude f8, f64 and i64 tensors from mmap

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -865,8 +865,13 @@ std::vector<MmapTensorStore> ModelLoader::mmap_tensors(std::map<std::string, ggm
             if (dst_tensor == nullptr)
                 continue;
 
-            if (tensor_storage.type != dst_tensor->type)
+            if (tensor_storage.is_f8_e4m3 ||
+                tensor_storage.is_f8_e5m2 ||
+                tensor_storage.is_f64 ||
+                tensor_storage.is_i64 ||
+                tensor_storage.type != dst_tensor->type) {
                 continue;
+            }
 
             size_t tensor_size   = tensor_storage.nbytes();
             size_t tensor_offset = tensor_storage.offset;


### PR DESCRIPTION
## Summary

In these cases, tensor_storage.type is not the type from the file, so the tensors could end up memory-mapped, incorrectly skipping the necessary type conversion.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
