### PR TITLE
fix(cmake): set POSITION_INDEPENDENT_CODE for the HIP/ROCm backend (fixes static-lib PIE link error)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,12 @@ endif ()
 if (SD_HIPBLAS)
     message("-- Use HIPBLAS as backend stable-diffusion")
     set(GGML_HIP ON)
+    # ggml-hip's device-stub objects must be position-independent, or the
+    # default-PIE sd-cli link fails with `relocation R_X86_64_32 ... cannot be
+    # used when making a PIE object` on distros that default to PIE
+    # (Ubuntu 24.04, Fedora 40+, Debian 12+). The shared-library branch below
+    # already sets this; the static build (the HIP default) did not.
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 endif ()
 
 if(SD_MUSA)


### PR DESCRIPTION
Building the ROCm/HIP backend (`-DSD_HIPBLAS=ON`) as a **static** library (the default) fails at the final `sd-cli` link on any toolchain that defaults to PIE — i.e. every current mainstream Linux distro (Ubuntu 24.04, Fedora 40+, Debian 12+):

```
ld.lld: error: relocation R_X86_64_32 against `.rodata.str1.1` cannot be
used when making a PIE object; recompile with -fPIE
>>> defined in ggml/src/ggml-hip/CMakeFiles/ggml-hip.dir/.../ggml-cuda.cu.o
collect2: error: ld returned 1 exit status
```

### Root cause

`set(CMAKE_POSITION_INDEPENDENT_CODE ON)` is set **only inside the `if(SD_BUILD_SHARED_LIBS)` branch** of the top-level `CMakeLists.txt`. The HIP backend's default build is a **static** library, so it takes the `else()` branch and PIC is never enabled. hipcc then emits non-PIC objects for `ggml-cuda.cu`, but `sd-cli` is linked as PIE (the distro default), so the non-PIC absolute relocations (`R_X86_64_32`) are rejected.

This bites the HIP path specifically: the CPU/CUDA static builds emit relaxable relocations for the same code, but the hipcc device-stub objects do not.

### Fix

Enable PIC whenever the HIP backend is selected, in the existing `SD_HIPBLAS` block:

```cmake
if (SD_HIPBLAS)
    message("-- Use HIPBLAS as backend stable-diffusion")
    set(GGML_HIP ON)
    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
endif ()
```

One line. No `-no-pie` workaround is needed — keeping `sd-cli` PIE (and its ASLR hardening) is preferable to disabling it; compiling the objects PIC is the correct fix and lets the PIE link succeed.

### Verification

On an AMD Radeon AI PRO R9700 (Navi 48 / RDNA4 / gfx1201) in `rocm/dev-ubuntu-24.04:7.0.2-complete`:

| Configure flags | `sd-cli` link |
|---|:---:|
| `-DSD_HIPBLAS=ON` (before this patch) | ❌ `R_X86_64_32` |
| `-DSD_HIPBLAS=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON` | ✅ links + runs |
| this patch, `-DSD_HIPBLAS=ON` only (no extra flags) | ✅ links + runs |

The resulting `sd-cli` generates correctly (FLUX.1 Q4_K_S, 1024×1024, gfx1201). `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` alone — exactly what this patch sets internally — is sufficient; the otherwise-needed `-DCMAKE_EXE_LINKER_FLAGS=-no-pie` is not.

### Backward compatibility

No effect on the CPU / CUDA / Vulkan / shared-lib paths — PIC was already on for shared builds, and enabling it for the HIP static build changes only codegen flags, not behavior. PIC has negligible performance impact on x86-64.
