### PR TITLE
perf: allocate CPU-offloaded params from runtime device pinned host buffer

### DIFF
--- a/src/ggml_extend.hpp
+++ b/src/ggml_extend.hpp
@@ -3017,7 +3017,18 @@ public:
             LOG_DEBUG("%s skipping params allocation (no tensors)", get_desc().c_str());
             return true;
         }
-        params_buffer = ggml_backend_alloc_ctx_tensors(params_ctx, params_backend);
+        // Pinned host buffer when CPU-offloaded for DMA-direct H2D.
+        ggml_backend_buffer_type_t params_buft = nullptr;
+        if (params_backend != runtime_backend) {
+            ggml_backend_dev_t runtime_dev = ggml_backend_get_device(runtime_backend);
+            if (runtime_dev != nullptr) {
+                params_buft = ggml_backend_dev_host_buffer_type(runtime_dev);
+            }
+        }
+        if (params_buft == nullptr) {
+            params_buft = ggml_backend_get_default_buffer_type(params_backend);
+        }
+        params_buffer = ggml_backend_alloc_ctx_tensors_from_buft(params_ctx, params_buft);
         if (params_buffer == nullptr) {
             LOG_ERROR("%s alloc params backend buffer failed, num_tensors = %i",
                       get_desc().c_str(),


### PR DESCRIPTION
## Summary

When `params_backend != runtime_backend` (i.e. `--offload-to-cpu`), allocate the runner's params buffer from the runtime device's host buffer type (`ggml_backend_dev_host_buffer_type`) instead of the regular CPU buffer type. For the CUDA backend this is the pinned (page-locked) host buffer, so subsequent H2D transfers are DMA-direct instead of going through the driver's pageable staging copy. Backends that don't implement `get_host_buffer_type` fall back to the existing path.

## Related Issue / Discussion

Independent perf win on top of #1598 (now merged as `a7f2e03`).

## Additional Information

Z-Image bf16, 512x512, 8 steps, `--offload-to-cpu --stream-layers --max-vram 8` on RTX 3060:

| Config | Before | After | Delta |
|---|---|---|---|
| no LoRA | 34.72 s | 22.06 s | -36% |
| LoRA 0.8 | 37.75 s | 24.36 s | -35% |
| LoRA 1.5 | 37.14 s | 24.47 s | -34% |

LoRA multiplier scaling identical (0.8 vs 1.5 mean pixel diff 26.05 -> 26.05, bit-exact output preserved).

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).