### PR TITLE
perf: stabilize streaming budget across sampling steps (+ log noise cleanup)

### DIFF
--- a/src/ggml_extend.hpp
+++ b/src/ggml_extend.hpp
@@ -1706,8 +1706,9 @@ protected:
     std::unordered_set<ggml_tensor*> resident_param_set;
     uint64_t resident_state_token = 0;
 
-    size_t max_graph_vram_bytes = 0;
-    bool stream_layers_enabled  = false;
+    size_t max_graph_vram_bytes           = 0;
+    bool   stream_layers_enabled          = false;
+    size_t observed_max_effective_budget_ = 0;
 
     sd::layer_registry::LayerRegistry layer_registry_;
 
@@ -2446,12 +2447,22 @@ protected:
                 constexpr size_t safety_margin = 512ull * 1024 * 1024;
                 size_t free_clamp              = (free_vram > safety_margin) ? (free_vram - safety_margin) : 0;
                 if (free_clamp < effective_budget) {
-                    LOG_INFO("%s clamping streaming budget: actual free VRAM %.2f MB < user cap %.2f MB",
-                             get_desc().c_str(),
-                             free_clamp / (1024.0 * 1024.0),
-                             effective_budget / (1024.0 * 1024.0));
+                    LOG_DEBUG("%s clamping streaming budget: actual free VRAM %.2f MB < user cap %.2f MB",
+                              get_desc().c_str(),
+                              free_clamp / (1024.0 * 1024.0),
+                              effective_budget / (1024.0 * 1024.0));
                     effective_budget = free_clamp;
                 }
+            }
+        }
+
+        bool budget_increased = false;
+        if (stream_layers_enabled) {
+            if (effective_budget > observed_max_effective_budget_) {
+                observed_max_effective_budget_ = effective_budget;
+                budget_increased               = true;
+            } else {
+                effective_budget = observed_max_effective_budget_;
             }
         }
 
@@ -2466,9 +2477,15 @@ protected:
                                                      params_tensor_set_,
                                                      get_desc().c_str());
         if (stream_layers_enabled) {
-            LOG_INFO("%s streaming budget = %.2f MB",
-                     get_desc().c_str(),
-                     effective_budget / (1024.0 * 1024.0));
+            if (budget_increased) {
+                LOG_INFO("%s streaming budget = %.2f MB",
+                         get_desc().c_str(),
+                         effective_budget / (1024.0 * 1024.0));
+            } else {
+                LOG_DEBUG("%s streaming budget = %.2f MB",
+                          get_desc().c_str(),
+                          effective_budget / (1024.0 * 1024.0));
+            }
         }
         return true;
     }
@@ -3042,6 +3059,7 @@ public:
             ggml_backend_buffer_free(params_buffer);
             params_buffer = nullptr;
         }
+        observed_max_effective_budget_ = 0;
     }
 
     size_t get_params_buffer_size() {

--- a/src/ggml_graph_cut.cpp
+++ b/src/ggml_graph_cut.cpp
@@ -699,9 +699,9 @@ namespace sd::ggml_graph_cut {
         }
 
         if (log_desc != nullptr) {
-            LOG_INFO("%s graph cut max_vram budget merge took %lld ms",
-                     log_desc,
-                     ggml_time_ms() - t_budget_begin);
+            LOG_DEBUG("%s graph cut max_vram budget merge took %lld ms",
+                      log_desc,
+                      ggml_time_ms() - t_budget_begin);
         }
 
         return merged_plan;


### PR DESCRIPTION
## Summary

Two related changes: stabilize the streaming budget across sampling steps, and demote the per-step budget logs that the old behavior produced.

When `--stream-layers` is active, the per-call `effective_budget` re-measured free VRAM at every compute() call. Free VRAM oscillates step-to-step (dips while a partial-offload buffer + compute buffer are live, recovers when freed), so the clamped budget swung between values like 8541 MB and 3354 MB on every step. The planner cache is keyed on the budget, so a different budget triggered a full re-merge of the base segments (150-230 ms per call on SDXL), and the chunk-K residency token could change forcing a resident-set reload.

This PR:
- Ratchets `effective_budget` to the maximum value ever observed; subsequent clamping to a lower live free-VRAM value is reverted before reaching the planner. Reset to 0 in `free_params_buffer`.
- Adjusts log levels so per-step budget noise no longer floods INFO: `clamping streaming budget` and `graph cut budget merge took X ms` are DEBUG, and `streaming budget = X MB` only logs at INFO when the budget actually ratchets up.

## Related Issue / Discussion

Follow-up to #1598.

## Additional Information

SDXL 896x1152, 40 steps, dpm++2m karras, `--offload-to-cpu --stream-layers --max-vram -1` on RTX 3060:

| | Before | After |
|---|---|---|
| generate_image | 1m 18s | 47s |

Side effect of stable budget: planner now merges to 1 segment for SDXL and keeps it across steps, so the UNet `offload_params` runs once per generation instead of per step.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).