### PR TITLE
Add docstrings to RNG and STDDefaultRNG classes

### DIFF
--- a/src/core/rng.hpp
+++ b/src/core/rng.hpp
@@ -4,12 +4,30 @@
 #include <random>
 #include <vector>
 
+/**
+ * @brief Abstract base class for random number generators (RNG).
+ *
+ * This class defines the interface for random number generation
+ * that is required by the stable diffusion framework. All RNG
+ * implementations must inherit from this class and implement
+ * the pure virtual methods.
+ */
 class RNG {
 public:
     virtual void manual_seed(uint64_t seed)      = 0;
     virtual std::vector<float> randn(uint32_t n) = 0;
 };
 
+/**
+ * @brief Default random number generator implementation using C++ standard library.
+ *
+ * This class provides a concrete implementation of the RNG interface
+ * using the standard library's default random engine. It generates
+ * random numbers with a normal distribution (mean=0, stddev=1) which
+ * is commonly used in diffusion models.
+ *
+ * @see RNG
+ */
 class STDDefaultRNG : public RNG {
 private:
     std::default_random_engine generator;


### PR DESCRIPTION
### Problem Background
The `RNG` and `STDDefaultRNG` classes in `src/core/rng.hpp` lacked documentation comments, making it difficult for developers and users to understand their purpose and usage. This could reduce code readability and hinder onboarding of new contributors in the stable-diffusion.cpp project.

### Changes
- Added Doxygen-style docstrings to the `RNG` abstract base class, clarifying its role as an interface for random number generation required by the framework.
- Added Doxygen-style docstrings to the `STDDefaultRNG` class, explaining it as the default implementation using the C++ standard library with a normal distribution (mean=0, stddev=1).

### Verification
- The changes are minimal and only add documentation; they do not alter the class behavior or API, ensuring backward compatibility.
- The docstrings adhere to Doxygen conventions, which can be verified using Doxygen tools if needed.
- Reviewers can confirm accuracy by checking that the descriptions align with the class implementations in the code.