### PR TITLE
refactor: apg: normalize diff_norm calculation by tensor size

### DIFF
--- a/src/runtime/guidance.cpp
+++ b/src/runtime/guidance.cpp
@@ -173,8 +173,9 @@ namespace sd::guidance {
         }
 
         float diff_norm = 0.0f;
+        const int standard_res = 2 * 1024 / 8; // Use SDXL as the standard resolution (1024x1024, 8x8 patches, 4=2x2 channels)
         if (params_.norm_threshold > 0.0f) {
-            diff_norm = std::sqrt((deltas * deltas).sum());
+            diff_norm = std::sqrt((deltas * deltas).sum()) * standard_res / std::sqrt(static_cast<float>(deltas.numel()));
         }
 
         float apg_scale_factor = 1.0f;


### PR DESCRIPTION
## Summary

I've noticed a small flaw in the APG paper (that was implemented in https://github.com/leejet/stable-diffusion.cpp/pull/593). 

The norm threshold for the APG update uses the L2 norm of the whole latent image diff, but since this norm scales with the square root of the size, the effect of the norm threshold will depend on the image resolution and number of latent channels.

This PR re-normalizes the L2 norm so the effect of the norm_threshold always match the effect it would have on a standard SDXL 1024x1024 generation.

## Related Issue / Discussion

N/A

## Additional Information

Technically, this is no longer a proper implementation of the original APG paper, but it is an overall improvement.

It's also technically a breaking change, the effect of  `apg_norm_threshold` is changed, except in the specific case of images that have exactly 128x128x4 elements in their latent representations.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
