### PR TITLE
set tensor names on block params (so weights aren't unnamed leaf_N)

### DIFF
--- a/src/core/ggml_extend.hpp
+++ b/src/core/ggml_extend.hpp
@@ -3327,6 +3327,10 @@ public:
         for (auto& pair : params) {
             ggml_tensor* param           = pair.second;
             tensors[prefix + pair.first] = pair.second;
+            // Also set the tensor's own name to its full hierarchical name. Without this the param
+            // tensors are unnamed and show up as "leaf_N" in graph dumps / profiling output and to
+            // any tooling that inspects weights by name (e.g. importance-matrix collection).
+            ggml_set_name(param, (prefix + pair.first).c_str());
         }
     }
 

--- a/src/core/ggml_extend.hpp
+++ b/src/core/ggml_extend.hpp
@@ -3327,9 +3327,6 @@ public:
         for (auto& pair : params) {
             ggml_tensor* param           = pair.second;
             tensors[prefix + pair.first] = pair.second;
-            // Also set the tensor's own name to its full hierarchical name. Without this the param
-            // tensors are unnamed and show up as "leaf_N" in graph dumps / profiling output and to
-            // any tooling that inspects weights by name (e.g. importance-matrix collection).
             ggml_set_name(param, (prefix + pair.first).c_str());
         }
     }


### PR DESCRIPTION
`GGMLBlock::get_param_tensors` already builds each weight's full hierarchical name (e.g. `double_blocks.0.img_attn.qkv.weight`) but only uses it as the map **key** — the ggml tensor's own name is never set, so in the compute graph the weight tensors are unnamed and ggml auto-assigns `leaf_N`.

That makes a couple of things harder than they need to be:
- **Graph dumps / profiling** show `leaf_N` instead of the layer name, so you can't tell which weight a node belongs to.
- **Tooling that inspects weights by name** can't — e.g. importance-matrix / quantization calibration that keys per-weight statistics by the weight name.

The fix is one line, where the full name is already in hand:

```cpp
for (auto& pair : params) {
    ggml_tensor* param           = pair.second;
    tensors[prefix + pair.first] = pair.second;
    ggml_set_name(param, (prefix + pair.first).c_str());   // added
}
```

Pure metadata — `ggml_set_name` only sets the tensor's `name` field, so there's no change to data, shapes, or the compute graph; generation output is unchanged. Names are bounded by `GGML_MAX_NAME` as elsewhere. All blocks route their leaf params through this base method, so every weight gets named.

Tested: clean Vulkan build; a Flux (Krea Q4) generation runs and produces a normal image.
