### PR TITLE
ideogram4: support circular RoPE

### DIFF
--- a/src/model/common/rope.hpp
+++ b/src/model/common/rope.hpp
@@ -253,7 +253,8 @@ namespace Rope {
                                                                  int bs,
                                                                  float theta,
                                                                  int head_dim,
-                                                                 const std::vector<int>& mrope_section) {
+                                                                 const std::vector<int>& mrope_section,
+                                                                 const std::vector<std::vector<int>>& axis_wrap_dims = {}) {
         GGML_ASSERT(bs > 0);
         GGML_ASSERT(head_dim % 2 == 0);
         GGML_ASSERT(mrope_section.size() >= 3);
@@ -265,7 +266,11 @@ namespace Rope {
         std::vector<std::vector<std::vector<float>>> axis_embs;
         axis_embs.reserve(3);
         for (int axis = 0; axis < 3; ++axis) {
-            axis_embs.push_back(rope(trans_ids[axis], head_dim, theta));
+            std::vector<int> axis_wrap;
+            if (axis < static_cast<int>(axis_wrap_dims.size())) {
+                axis_wrap = axis_wrap_dims[axis];
+            }
+            axis_embs.push_back(rope(trans_ids[axis], head_dim, theta, axis_wrap));
         }
 
         std::vector<std::vector<float>> emb = axis_embs[0];

--- a/src/model/diffusion/ideogram4.hpp
+++ b/src/model/diffusion/ideogram4.hpp
@@ -151,7 +151,9 @@ namespace Ideogram4 {
                                                           int context_len,
                                                           int head_dim,
                                                           int rope_theta,
-                                                          const std::vector<int>& mrope_section) {
+                                                          const std::vector<int>& mrope_section,
+                                                          bool circular_x = false,
+                                                          bool circular_y = false) {
         GGML_ASSERT(bs == 1);
         std::vector<std::vector<float>> ids(static_cast<size_t>(bs) * (context_len + grid_h * grid_w),
                                             std::vector<float>(3, 0.f));
@@ -169,7 +171,29 @@ namespace Ideogram4 {
             }
         }
 
-        return Rope::embed_interleaved_mrope(ids, bs, static_cast<float>(rope_theta), head_dim, mrope_section);
+        std::vector<std::vector<int>> axis_wrap_dims(3);
+        if (circular_y || circular_x) {
+            size_t total_len = static_cast<size_t>(bs) * (context_len + grid_h * grid_w);
+            axis_wrap_dims[1].assign(total_len, 0);
+            axis_wrap_dims[2].assign(total_len, 0);
+            if (circular_y) {
+                for (size_t idx = static_cast<size_t>(context_len); idx < total_len; ++idx) {
+                    axis_wrap_dims[1][idx] = grid_h;
+                }
+            }
+            if (circular_x) {
+                for (size_t idx = static_cast<size_t>(context_len); idx < total_len; ++idx) {
+                    axis_wrap_dims[2][idx] = grid_w;
+                }
+            }
+        }
+
+        return Rope::embed_interleaved_mrope(ids,
+                                            bs,
+                                            static_cast<float>(rope_theta),
+                                            head_dim,
+                                            mrope_section,
+                                            axis_wrap_dims);
     }
 
     class Ideogram4Attention : public GGMLBlock {
@@ -480,13 +504,16 @@ namespace Ideogram4 {
             int64_t pos_len  = context_len + grid_h * grid_w;
             int64_t head_dim = config.emb_dim / config.num_heads;
 
+            auto runner_ctx = get_context();
             pe_vec  = gen_ideogram4_pe(static_cast<int>(grid_h),
                                        static_cast<int>(grid_w),
                                        static_cast<int>(x->ne[3]),
                                        static_cast<int>(context_len),
                                        static_cast<int>(head_dim),
                                        static_cast<int>(config.rope_theta),
-                                       config.mrope_section);
+                                       config.mrope_section,
+                                       runner_ctx.circular_x_enabled,
+                                       runner_ctx.circular_y_enabled);
             auto pe = ggml_new_tensor_4d(compute_ctx, GGML_TYPE_F32, 2, 2, head_dim / 2, pos_len);
             set_backend_tensor_data(pe, pe_vec.data());
 
@@ -497,7 +524,6 @@ namespace Ideogram4 {
             auto indicator = ggml_new_tensor_2d(compute_ctx, GGML_TYPE_I32, pos_len, x->ne[3]);
             set_backend_tensor_data(indicator, image_indicator_vec.data());
 
-            auto runner_ctx  = get_context();
             ggml_tensor* out = active_model.forward(&runner_ctx, x, timesteps, context, pe, indicator);
             ggml_build_forward_expand(gf, out);
             return gf;


### PR DESCRIPTION
## Summary

Ideogram4 Ropes Id were not affected by `circular_x_enabled`or `circular_y_enabled`, causing it to generate identical latents with or without the `--circular`flag (only the VAE decoding is tiled).

This PR enables circular RoPE ids for Ideogram4 DiT.

## Related Issue / Discussion

N/A 

## Additional Information

`{"high_level_description":"A majestic 360-degree equirectangular HDRI panorama of a grand concert hall interior, designed for VR immersion with a centered horizon and seamless wrapping.","style_description":{"aesthetics":"Opulent, cinematic, and awe-inspiring. The atmosphere is one of grandeur, featuring dramatic highlights and soft ambient glows.","lighting":"High Dynamic Range (HDR) lighting with warm spotlights illuminating the stage, flickering candlelight from chandeliers, and soft reflected light from gold leaf surfaces.","medium":"","art_style":"Photorealistic architecture"},"compositional_deconstruction":{"background":"A vast, symmetrical concert hall with a polished dark wood floor and marble accents. The walls are lined with ornate acoustic panels and gold-trimmed balconies. The ceiling features a complex coffered design with integrated gold leafing.","elements":[{"type":"obj","bbox":[400,300,600,700],"desc":"A wide, polished wooden stage at the center of the hall, slightly elevated, featuring a few empty chairs and a grand piano.","color_palette":["#4E352F","#2C1E1B"]},{"type":"obj","bbox":[500,0,900,400],"desc":"Rows of tiered seating with plush red velvet chairs and brass railings on the left side of the hall.","color_palette":["#8B0000","#D4AF37"]},{"type":"obj","bbox":[500,600,900,1000],"desc":"Rows of tiered seating with plush red velvet chairs and brass railings on the right side of the hall, mirroring the left.","color_palette":["#8B0000","#D4AF37"]},{"type":"obj","bbox":[0,300,300,700],"desc":"An ornate ceiling featuring a massive crystal chandelier and intricate gold leaf carvings, showing the characteristic vertical stretching of an equirectangular projection.","color_palette":["#FFF5E1","#D4AF37"]},{"type":"obj","bbox":[0,0,1000,1000],"desc":"The 360-degree seam where the image wraps horizontally, maintaining a consistent horizon line at the vertical midpoint."}]}}`

| no circular | circularx (master) | circularx (PR) |
| --- | --- | --- |
| <img width="1536" height="768" alt="output - Copy (315)" src="https://github.com/user-attachments/assets/a0f56494-5353-43f9-9908-55af7f611fe2" /> | <img width="1536" height="768" alt="output - Copy (313)" src="https://github.com/user-attachments/assets/b018bed2-5cd0-46cf-9dab-4b3db00a490e" /> | <img width="1536" height="768" alt="output - Copy (314)" src="https://github.com/user-attachments/assets/941cccf0-9694-4600-a6b9-a28532876b81" /> |
| <img width="1536" height="768" alt="rolled" src="https://github.com/user-attachments/assets/9369955a-bf25-40d3-afaf-9c523a863bb9" /> | <img width="1536" height="768" alt="rolled" src="https://github.com/user-attachments/assets/a731b446-77bc-4167-a643-23ed78a3f67c" /> | <img width="1536" height="768" alt="rolled" src="https://github.com/user-attachments/assets/2e348d8a-2334-4f08-b377-d4153c5f0b87" /> |

`{"high_level_description":"A sprawling, dense metropolis captured from a high-altitude isometric perspective, showcasing a labyrinth of skyscrapers, neon-lit highways, and organized urban greenery.","style_description":{"aesthetics":"Cinematic, vibrant, and highly detailed with a sense of immense scale.","lighting":"Golden hour sunlight casting long, soft shadows and a warm glow across the glass facades.","medium":"","art_style":"Stylized architectural visualization with a distinct isometric tilt."},"compositional_deconstruction":{"background":"A hazy, atmospheric horizon where the urban sprawl meets a distant coastal bay and soft mountain peaks.","elements":[{"type":"obj","bbox":[100,200,900,800],"desc":"A dense cluster of glass and steel skyscrapers of varying heights, featuring intricate architectural details and lit windows.","color_palette":["#bdc3c7","#34495e"]},{"type":"obj","bbox":[400,0,700,1000],"desc":"A network of multi-lane highways and winding roads weaving through the city blocks, populated by thousands of tiny, colorful vehicles.","color_palette":["#2c3e50","#e67e22"]},{"type":"obj","bbox":[350,300,650,700],"desc":"Lush green urban parks and public plazas interspersed between the buildings, featuring small trees and walking paths.","color_palette":["#27ae60","#2ecc71"]},{"type":"obj","bbox":[0,0,300,1000],"desc":"A shimmering blue bay at the edge of the city, with small docks and white foam near the shoreline.","color_palette":["#3498db","#aed6f1"]}]}}`

| no circular | circular (master) | circular (PR) |
| --- | --- | --- |
| <img width="1024" height="576" alt="output - Copy (316)" src="https://github.com/user-attachments/assets/6f989b46-8461-4ed9-b07f-5efcdb5e04e7" /> | <img width="1024" height="576" alt="output" src="https://github.com/user-attachments/assets/3ed8ab51-21f7-4b91-8124-9c9ef01d283e" /> | <img width="1024" height="576" alt="output - Copy (317)" src="https://github.com/user-attachments/assets/5cac9dcc-2e1c-41f8-aa90-b999598fd9de" /> |
| <img width="1024" height="576" alt="rolled" src="https://github.com/user-attachments/assets/ac0a0644-15d5-423b-94d2-6aeb790be95e" /> | <img width="1024" height="576" alt="rolled" src="https://github.com/user-attachments/assets/c35a2857-d1c2-44c8-9f56-86a90614e3b1" /> | <img width="1024" height="576" alt="rolled" src="https://github.com/user-attachments/assets/f561b63b-e985-4e05-84df-e510556c4caf" /> |


## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
