### PR TITLE
feat: optional sequential component loading (--sequential-load)

### DIFF
--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -474,6 +474,10 @@ ArgOptions SDContextParams::get_options() {
          "keep vae in cpu (for low vram)",
          true, &vae_on_cpu},
         {"",
+         "--sequential-load",
+         "load the conditioner, run it, free it, then load the diffusion model; lowers peak device memory so the text-encoder-on-GPU path fits smaller cards (single diffusion model only)",
+         true, &sequential_load},
+        {"",
          "--fa",
          "use flash attention",
          true, &flash_attn},
@@ -817,6 +821,7 @@ sd_ctx_params_t SDContextParams::to_sd_ctx_params_t(bool vae_decode_only, bool f
         stream_layers,
         backend.c_str(),
         params_backend.c_str(),
+        sequential_load,
     };
     return sd_ctx_params;
 }

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -152,6 +152,7 @@ struct SDContextParams {
     bool control_net_cpu       = false;
     bool clip_on_cpu           = false;
     bool vae_on_cpu            = false;
+    bool sequential_load       = false;
     bool flash_attn            = false;
     bool diffusion_flash_attn  = false;
     bool diffusion_conv_direct = false;

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -226,6 +226,7 @@ typedef struct {
     bool stream_layers;  // Enable residency+prefetch streaming on top of --max-vram (no effect without --max-vram)
     const char* backend;
     const char* params_backend;
+    bool sequential_load;  // load conditioner -> run -> free -> then load the diffusion model (lowers peak device memory)
 } sd_ctx_params_t;
 
 typedef struct {

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -200,6 +200,18 @@ public:
 
     std::map<std::string, ggml_tensor*> tensors;
 
+    // --- Sequential (lazy) component loading -------------------------------
+    // Load the conditioner, run it, free it, THEN allocate + load the diffusion
+    // model. Cuts peak device memory from sum(cond, DiT, VAE) to ~max(cond,
+    // DiT+VAE), so the fast text-encoder-on-GPU recipe fits cards that can't
+    // hold all three at once. Opt-in (--sequential-load), single diffusion model
+    // only, and backend-agnostic (Vulkan/CPU/CUDA).
+    bool                  seq_load_requested = false;  // requested via --sequential-load
+    bool                  seq_load           = false;  // effective (requested && single DiT)
+    bool                  dit_params_loaded = true;   // false while DiT load is deferred
+    std::set<std::string> deferred_dit_keys;          // diffusion-model tensor keys to load later
+    ModelLoader           model_loader;               // retained so the deferred DiT load can read the file
+
     // lora_name => multiplier
     std::unordered_map<std::string, float> curr_lora_state;
 
@@ -293,7 +305,9 @@ public:
         }
         max_vram = sd::ggml_graph_cut::resolve_max_vram_gib(max_vram, backend_for(SDBackendModule::DIFFUSION));
 
-        ModelLoader model_loader;
+        // model_loader is retained as a member so the deferred diffusion-model
+        // load can read the file after the conditioner has run + been freed.
+        seq_load_requested = sd_ctx_params->sequential_load;
 
         if (strlen(SAFE_STR(sd_ctx_params->model_path)) > 0) {
             LOG_INFO("loading model from '%s'", sd_ctx_params->model_path);
@@ -774,6 +788,21 @@ public:
                 get_param_tensors(high_noise_diffusion_model, module_can_mmap(SDBackendModule::DIFFUSION));
             }
 
+            // Sequential load only applies to the single-diffusion-model case (no
+            // high-noise model). Capture the DiT tensor keys so we can skip its
+            // up-front alloc/load and bring it in after the conditioner is freed.
+            seq_load = seq_load_requested && diffusion_model && !high_noise_diffusion_model;
+            if (seq_load) {
+                std::map<std::string, ggml_tensor*> dit_temp;
+                diffusion_model->get_param_tensors(dit_temp);
+                for (const auto& [k, t] : dit_temp) {
+                    deferred_dit_keys.insert(k);
+                }
+                dit_params_loaded = false;
+                LOG_INFO("sequential load: deferring %zu diffusion-model tensors until after conditioning",
+                         deferred_dit_keys.size());
+            }
+
             if (!ensure_backend_pair(SDBackendModule::VAE)) {
                 return false;
             }
@@ -1048,7 +1077,7 @@ public:
             ggml_free(ctx);
             return false;
         }
-        if (diffusion_model && !diffusion_model->alloc_params_buffer()) {
+        if (!seq_load && diffusion_model && !diffusion_model->alloc_params_buffer()) {
             LOG_ERROR("Diffusion model params buffer allocation failed");
             ggml_free(ctx);
             return false;
@@ -1081,7 +1110,19 @@ public:
             }
         }
 
-        bool success = model_loader.load_tensors(tensors, ignore_tensors, n_threads, sd_ctx_params->enable_mmap);
+        bool success;
+        if (seq_load) {
+            // First pass: load everything except the deferred diffusion-model tensors.
+            std::map<std::string, ggml_tensor*> first_tensors = tensors;
+            for (const auto& k : deferred_dit_keys) {
+                first_tensors.erase(k);
+            }
+            std::set<std::string> first_ignore = ignore_tensors;
+            first_ignore.insert("model.diffusion_model.");  // deferred — loaded after conditioning
+            success = model_loader.load_tensors(first_tensors, first_ignore, n_threads, sd_ctx_params->enable_mmap);
+        } else {
+            success = model_loader.load_tensors(tensors, ignore_tensors, n_threads, sd_ctx_params->enable_mmap);
+        }
         if (!success) {
             LOG_ERROR("load tensors from model loader failed");
             ggml_free(ctx);
@@ -1890,6 +1931,40 @@ public:
         *controls = std::move(*control_result);
     }
 
+    // Allocate + load the diffusion-model params that sequential loading deferred.
+    // No-op unless seq_load deferred them. Reads the retained model_loader, so the
+    // model file(s) are re-opened for the DiT tensors only (conditioner/VAE ignored).
+    bool ensure_diffusion_model_loaded() {
+        if (dit_params_loaded) {
+            return true;
+        }
+        int64_t t0 = ggml_time_ms();
+        if (!diffusion_model->alloc_params_buffer()) {
+            LOG_ERROR("sequential load: diffusion model params buffer allocation failed");
+            return false;
+        }
+        std::map<std::string, ggml_tensor*> dit_tensors;
+        for (const auto& k : deferred_dit_keys) {
+            auto it = tensors.find(k);
+            if (it != tensors.end()) {
+                dit_tensors[k] = it->second;
+            }
+        }
+        // Ignore the (already-loaded) non-DiT components so they don't log as unknown.
+        std::set<std::string> ignore = {
+            "text_encoders.", "cond_stage_model.", "first_stage_model.",
+            "vae.", "audio_vae", "alphas_cumprod",
+        };
+        if (!model_loader.load_tensors(dit_tensors, ignore, n_threads, false)) {
+            LOG_ERROR("sequential load: deferred diffusion model tensor load failed");
+            return false;
+        }
+        dit_params_loaded = true;
+        LOG_INFO("sequential load: diffusion model allocated + loaded in %.2fs",
+                 (ggml_time_ms() - t0) * 1.0f / 1000);
+        return true;
+    }
+
     sd::Tensor<float> sample(const std::shared_ptr<DiffusionModelRunner>& work_diffusion_model,
                              bool inverse_noise_scaling,
                              const sd::Tensor<float>& init_latent,
@@ -1915,6 +1990,12 @@ public:
                              float frame_rate,
                              const sd_cache_params_t* cache_params,
                              const sd::Tensor<float>& video_positions = {}) {
+        // Sequential load: bring in the diffusion model now (after the conditioner
+        // has run and freed its buffer), just before the first denoise step.
+        if (work_diffusion_model == diffusion_model && !ensure_diffusion_model_loaded()) {
+            LOG_ERROR("sequential load: diffusion model not available for sampling");
+            return {};
+        }
         std::vector<int> skip_layers(guidance.slg.layers, guidance.slg.layers + guidance.slg.layer_count);
         float cfg_scale     = guidance.txt_cfg;
         float img_cfg_scale = guidance.img_cfg;
@@ -2703,6 +2784,7 @@ void sd_ctx_params_init(sd_ctx_params_t* sd_ctx_params) {
     sd_ctx_params->vae_format              = SD_VAE_FORMAT_AUTO;
     sd_ctx_params->backend                 = nullptr;
     sd_ctx_params->params_backend          = nullptr;
+    sd_ctx_params->sequential_load         = false;
 }
 
 char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {


### PR DESCRIPTION
# feat: optional sequential component loading to cut peak device memory

## Summary

Adds an opt-in **sequential load** path: instead of allocating and loading the
conditioner, diffusion model, and VAE all up front, load the **conditioner
first, run it, free it, and only then allocate + load the diffusion model**.

This lowers peak device memory from roughly

```
sum(conditioner, diffusion, VAE)   ->   ~max(conditioner, diffusion + VAE)
```

For pipelines with a large text encoder this is significant. On LTX-2 (Gemma-3
12B text encoder + a ~16.5 GB DiT + video VAE), it drops peak device memory from
~30 GB to ~18 GB, which lets the **fast "text-encoder-on-GPU" path fit on cards
that otherwise can't hold all three modules at once** — without falling back to
running the text encoder on CPU.

Default **off**; no behavior change unless explicitly enabled.

## Motivation

On a memory-constrained GPU the choice today is binary:

- Run the text encoder on the GPU → fast, but requires *all* modules resident
  simultaneously (often won't fit), or
- Run the text encoder on CPU (`--clip-on-cpu` / backend override) → fits, but
  the text-encode step is dramatically slower.

Measured on a Strix Halo 8060S iGPU (Vulkan, LTX-2, 768×512 / 25 frames / 8
steps), the conditioning (text-encode) stage alone:

| Text encoder placement | Conditioning time |
|------------------------|-------------------|
| CPU                    | **65.4 s**        |
| GPU                    | **7.2 s**         |

That ~58 s delta is paid on *every* generation. Sequential loading makes the
GPU path reachable on hardware that can hold `max(encoder, diffusion+VAE)` but
not their sum — you free the encoder before the diffusion model is resident, so
its memory window doesn't overlap the diffusion model's.

## What it does

1. At load time, when sequential load is enabled and there is a single diffusion
   model, the diffusion-model param buffer is **not** allocated and its tensors
   are **excluded** from the initial tensor load. The model loader is retained.
2. The conditioner (and VAE) load normally and the conditioner runs.
3. After conditioning — and after the existing "free params immediately" path
   frees the conditioner — the diffusion model is **allocated and loaded on
   demand**, just before the first denoise step.

The deferred load is wired in at the top of the common `sample()` path, so it
covers txt2img / img2img / video uniformly and is a no-op when not enabled.

## Interface

`--sequential-load` (default off), with a matching `sd_ctx_params` field. It
only engages when there is a single diffusion model (skipped when a
high-noise/refiner model is also present, to keep this change small).

## Scope / limitations

- **Single diffusion model only** for now (no high-noise/refiner second model).
- Backend-agnostic — implemented entirely in `stable-diffusion.cpp` using
  existing `alloc_params_buffer()` / `ModelLoader::load_tensors()`; **no backend
  patches**, works on CPU/Vulkan/CUDA alike.
- The deferred load re-reads the diffusion-model file once after conditioning
  (the conditioner/VAE storages are ignored on that pass), costing a few seconds
  of load time that previously happened up front. On hardware where everything
  already fits, this is pure overhead with no benefit — the win is specifically
  for memory-constrained devices.

## Validation

**Correctness (Strix Halo 8060S, Vulkan, LTX-2, seed-fixed):**
- Output is **bit-identical** to the non-sequential path at the same seed
  (max |Δpixel| = 0 across frames). The deferred diffusion-model load does not
  alter results.
- With the flag **off**, output is bit-identical to the pre-change binary — the
  default path is unchanged.

**Peak device memory (same config):**
- Load/conditioning phase: ~13.7 GB (diffusion model deferred), vs ~30 GB.
- Sampling phase (conditioner freed): ~18 GB, vs ~30 GB.

**Cross-arch (RDNA2 RX 6700 XT, 12 GB, Vulkan, no matrix cores; Flux Schnell Q4, 512², seed 42):**
- Default: peak **9.78 GB**, 16.5 s wall.
- `--sequential-load`: deferred 776 diffusion-model tensors; first-load 3.3 GB
  (DiT deferred), DiT allocated + loaded 3.19 s after the conditioner freed;
  peak **7.22 GB**, 15.1 s wall.
- Output **sha256 bit-identical** to default; no perf regression.
- Composes cleanly with the existing VAE auto-tiling fallback on the same card.

So the peak-memory reduction (~2.5 GB here; ~12 GB on LTX-2) and bit-identical
output are confirmed on a second GPU architecture (RDNA2, no matrix cores), not
just the iGPU it was developed on.

## How to test

```
# Baseline (encoder on CPU): slow conditioning, low peak memory
sd ... --clip-on-cpu

# Sequential load (encoder on GPU, freed before diffusion model loads):
sd ... --sequential-load
```

Compare conditioning time, peak device memory, and output (identical at a fixed
seed).

## Related work

#1470 also defers diffusion-model loading, but as one piece of a larger,
CUDA-focused multi-GPU autofit (it ships a `ggml-cuda.cu` patch and a row/tensor
split mechanism). This PR is the minimal, backend-agnostic slice of that idea: a
single-device sequential load that needs no backend patch and benefits every
backend today. Offered standalone so the peak-memory win isn't gated on the
larger multi-GPU work.
