### PR TITLE
feat: add free_sd_images function to manage memory for C API

### DIFF
--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -491,6 +491,10 @@ SD_API bool preprocess_canny(sd_image_t image,
 SD_API const char* sd_commit(void);
 SD_API const char* sd_version(void);
 
+// for C API, caller needs to call free_sd_images to free the memory after use
+// This helps avoid CRT problems on Windows when memory is allocated in the library but freed in the caller, which may use a different CRT.
+SD_API void free_sd_images(sd_image_t* result_images, int num_images);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -5570,3 +5570,18 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
     }
     return true;
 }
+
+SD_API void free_sd_images(sd_image_t* result_images, int num_images) {
+    if (result_images == nullptr) {
+        return;
+    }
+
+    for (int i = 0; i < num_images; ++i) {
+        if (result_images[i].data != nullptr) {
+            free(result_images[i].data);
+            result_images[i].data = nullptr;
+        }
+    }
+
+    free(result_images);
+}


### PR DESCRIPTION
## Summary
This is part of https://github.com/leejet/stable-diffusion.cpp/pull/1368.
This pull request introduces a new memory management function to the C API for handling image arrays, which is especially important for Windows compatibility. The main change is the addition of a `free_sd_images` function to safely free memory allocated for image arrays, preventing issues related to mismatched C runtime libraries.

### Memory management improvements

* Added a new API function `free_sd_images` to both the `stable-diffusion.h` header and the implementation in `stable-diffusion.cpp`. This function ensures that memory allocated for image arrays (`sd_image_t*`) is properly freed, addressing potential CRT (C Runtime) issues on Windows when memory is allocated in the library but freed in the caller. 

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
