### PR TITLE
feat: add script for automatic code formatting

### DIFF
--- a/format-code.ps1
+++ b/format-code.ps1
@@ -1,0 +1,54 @@
+$patterns = @(
+    "src/*.cpp"
+    "src/*.h"
+    "src/*.hpp"
+    "src/conditioning/*.cpp"
+    "src/conditioning/*.h"
+    "src/conditioning/*.hpp"
+    "src/core/*.cpp"
+    "src/core/*.h"
+    "src/core/*.hpp"
+    "src/extensions/*.cpp"
+    "src/extensions/*.h"
+    "src/extensions/*.hpp"
+    "src/runtime/*.cpp"
+    "src/runtime/*.h"
+    "src/runtime/*.hpp"
+    "src/model/*/*.cpp"
+    "src/model/*/*.h"
+    "src/model/*/*.hpp"
+    "src/tokenizers/*.h"
+    "src/tokenizers/*.cpp"
+    "src/tokenizers/vocab/*.h"
+    "src/tokenizers/vocab/*.cpp"
+    "src/model_io/*.h"
+    "src/model_io/*.cpp"
+    "examples/cli/*.cpp"
+    "examples/cli/*.h"
+    "examples/server/*.cpp"
+    "examples/common/*.hpp"
+    "examples/common/*.h"
+    "examples/common/*.cpp"
+)
+
+$root = (Get-Location).Path
+
+foreach ($pattern in $patterns) {
+    $files = Get-ChildItem -Path $pattern -File -ErrorAction SilentlyContinue | Sort-Object FullName
+
+    foreach ($file in $files) {
+        $relativePath = $file.FullName.Substring($root.Length).TrimStart('\', '/') -replace '\\', '/'
+
+        if ($relativePath -like "vocab*") {
+            continue
+        }
+
+        Write-Host "formatting '$relativePath'"
+
+        # if ($relativePath -ne "stable-diffusion.h") {
+        #     clang-tidy -fix -p build_linux/ "$relativePath"
+        # }
+
+        & clang-format -style=file -i $relativePath
+    }
+}


### PR DESCRIPTION
## Summary
This is part of https://github.com/leejet/stable-diffusion.cpp/pull/1368.
This pull request adds a new PowerShell script, `format-code.ps1`, to automate code formatting for the project. The script recursively searches for C++ source and header files across various directories and applies `clang-format` to each file, ensuring consistent code style throughout the codebase.

**Automation of code formatting:**

* Added `format-code.ps1` script that locates `.cpp`, `.h`, and `.hpp` files in key source and example directories, and formats them using `clang-format`. This helps maintain consistent code style across the project.
* 
## Checklist
- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
