### PR TITLE
fix: SD3 conditioning crash when clip_l text encoder is missing

### DIFF
--- a/src/conditioning/conditioner.hpp
+++ b/src/conditioning/conditioner.hpp
@@ -853,7 +853,7 @@ struct SD3CLIPEmbedder : public Conditioner {
             } else {
                 chunk_hidden_states_l = sd::Tensor<float>::zeros({768, static_cast<int64_t>(chunk_len), 1});
                 if (chunk_idx == 0) {
-                    pooled = sd::Tensor<float>::zeros({768, 1});
+                    pooled_l = sd::Tensor<float>::zeros({768, 1});
                 }
             }
 


### PR DESCRIPTION
(Fixes #1631)

Running an SD3/SD3.5 model without text encoders (e.g. `sd-cli -m sd3.5_large.gguf --steps 1`) crashes during conditioning. It's supposed to fall back to a zero conditioning and still generate, and that's why SDXL and the others are fine and this is SD3-specific.

In `get_learned_condition_common`, the zero-fill branch for a missing `clip_l` writes to `pooled` instead of `pooled_l`:

```cpp
pooled = sd::Tensor<float>::zeros({768, 1});   // should be pooled_l
```

The `clip_g` branch right below it correctly sets `pooled_g`, so `clip_l` was the odd one out. Because `pooled_l` never gets set, the later `pooled = concat(pooled_l, pooled_g)` concatenates an empty tensor and crashes. (The write to `pooled` was dead anyway, that concat overwrites it.)

Literal one-line fix: `pooled` → `pooled_l`.

Introduced by #1373, which the reporter confirmed with a bisect. Compiles cleanly. I didn't do a full generation run since that needs the ~5GB SD3.5 weights, and wasn't tryna do that, but the fix just restores the intended zero-fallback and matches the working `clip_g` branch beside it.
