### PR TITLE
fix: mark LoKR w2_a tensor as applied

### DIFF
--- a/src/model/adapter/lora.hpp
+++ b/src/model/adapter/lora.hpp
@@ -658,7 +658,7 @@ struct LoraModel : public GGMLRunner {
                 if (lokr_w2)
                     applied_lora_tensors.insert(lokr_w2_name);
                 if (lokr_w2_a)
-                    applied_lora_tensors.insert(lokr_w2_name);
+                    applied_lora_tensors.insert(lokr_w2_a_name);
                 if (lokr_w2_b)
                     applied_lora_tensors.insert(lokr_w2_b_name);
                 applied_lora_tensors.insert(alpha_name);


### PR DESCRIPTION
## Summary

- Fix LoKR tensor bookkeeping so `lokr_w2_a` is recorded with its own tensor name.

## Related Issue / Discussion

Fix https://github.com/leejet/stable-diffusion.cpp/issues/1643.

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
