### PR TITLE
feat: add support for init audio allowing Audio to Video (A2V) for LTX2.3

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <time.h>
 #include <cctype>
+#include <cstdlib>
 #include <filesystem>
 #include <functional>
 #include <iostream>
@@ -653,6 +654,21 @@ int main(int argc, const char* argv[]) {
         if (!load_image_and_update_size(gen_params.end_image_path, gen_params.end_image)) {
             return 1;
         }
+    }
+
+    SDAudioPtr input_audio;
+    if (gen_params.init_audio_path.size() > 0) {
+        input_audio.reset(static_cast<sd_audio_t*>(malloc(sizeof(sd_audio_t))));
+        if (input_audio == nullptr) {
+            LOG_ERROR("malloc input audio failed");
+            return 1;
+        }
+        *input_audio = load_pcm_wav_from_file(gen_params.init_audio_path);
+        if (input_audio->data == nullptr || input_audio->sample_count == 0) {
+            LOG_ERROR("load audio from '%s' failed", gen_params.init_audio_path.c_str());
+            return 1;
+        }
+        gen_params.input_audio = input_audio.get();
     }
 
     if (gen_params.ref_image_paths.size() > 0) {

--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -872,7 +872,7 @@ ArgOptions SDGenerationParams::get_options() {
          &end_image_path},
         {"",
          "--init-audio",
-         "path to the init audio WAV, required by audio-to-video models",
+         "path to the init audio WAV, for use with audio-to-video models",
          &init_audio_path},
         {"",
          "--mask",

--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -871,6 +871,10 @@ ArgOptions SDGenerationParams::get_options() {
          "path to the end image, required by flf2v",
          &end_image_path},
         {"",
+         "--init-audio",
+         "path to the init audio WAV, required by audio-to-video models",
+         &init_audio_path},
+        {"",
          "--mask",
          "path to the mask image",
          &mask_image_path},
@@ -2223,6 +2227,11 @@ bool SDGenerationParams::validate(SDMode mode) {
         }
     }
 
+    if (mode != VID_GEN && init_audio_path.length() > 0) {
+        LOG_ERROR("error: init audio (--init-audio) is only supported in vid_gen mode\n");
+        return false;
+    }
+
     return true;
 }
 
@@ -2362,6 +2371,7 @@ sd_vid_gen_params_t SDGenerationParams::to_sd_vid_gen_params_t() {
     params.clip_skip                 = clip_skip;
     params.init_image                = init_image.get();
     params.end_image                 = end_image.get();
+    params.input_audio               = input_audio;
     params.control_frames            = control_frame_views.empty() ? nullptr : control_frame_views.data();
     params.control_frames_size       = static_cast<int>(control_frame_views.size());
     params.width                     = get_resolved_width();
@@ -2431,6 +2441,7 @@ std::string SDGenerationParams::to_string() const {
         << "  batch_count: " << batch_count << ",\n"
         << "  init_image_path: \"" << init_image_path << "\",\n"
         << "  end_image_path: \"" << end_image_path << "\",\n"
+        << "  init_audio_path: \"" << init_audio_path << "\",\n"
         << "  mask_image_path: \"" << mask_image_path << "\",\n"
         << "  control_image_path: \"" << control_image_path << "\",\n"
         << "  ref_image_paths: " << vec_str_to_string(ref_image_paths) << ",\n"

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -204,6 +204,7 @@ struct SDGenerationParams {
 
     std::string init_image_path;
     std::string end_image_path;
+    std::string init_audio_path;
     std::string mask_image_path;
     std::string control_image_path;
     std::vector<std::string> ref_image_paths;
@@ -268,6 +269,7 @@ struct SDGenerationParams {
     SDImageOwner control_image;
     std::vector<SDImageOwner> pm_id_images;
     std::vector<SDImageOwner> control_frames;
+    const sd_audio_t* input_audio = nullptr;
 
     // Backing storage for sd_img_gen_params_t view fields.
     std::vector<sd_image_t> ref_image_views;

--- a/examples/common/media_io.cpp
+++ b/examples/common/media_io.cpp
@@ -191,6 +191,20 @@ uint32_t read_u32_le_bytes(const uint8_t* data) {
            (static_cast<uint32_t>(data[3]) << 24);
 }
 
+uint16_t read_u16_le_bytes(const uint8_t* p) {
+    return static_cast<uint16_t>(p[0]) | (static_cast<uint16_t>(p[1]) << 8);
+}
+
+int32_t read_s24_le_bytes(const uint8_t* p) {
+    int32_t value = static_cast<int32_t>(p[0]) |
+                    (static_cast<int32_t>(p[1]) << 8) |
+                    (static_cast<int32_t>(p[2]) << 16);
+    if (value & 0x00800000) {
+        value |= 0xff000000;
+    }
+    return value;
+}
+
 int stbi_ext_write_png_to_func(stbi_write_func* func,
                                void* context,
                                int x,
@@ -1373,4 +1387,105 @@ bool write_wav_to_file(const std::string& path,
     }
     file.write(reinterpret_cast<const char*>(pcm.data()), static_cast<std::streamsize>(pcm.size() * sizeof(int16_t)));
     return file.good();
+}
+
+sd_audio_t load_pcm_wav_from_file(const std::string& path) {
+    sd_audio_t audio = {0, 0, 0, nullptr};
+    if (path.empty()) {
+        return audio;
+    }
+
+    std::vector<uint8_t> wav;
+    if (!read_binary_file_bytes(path.c_str(), wav)) {
+        LOG_ERROR("load WAV from '%s' failed", path.c_str());
+        return audio;
+    }
+    if (wav.size() < 44 || std::memcmp(wav.data(), "RIFF", 4) != 0 || std::memcmp(wav.data() + 8, "WAVE", 4) != 0) {
+        LOG_ERROR("input audio file '%s' is not a RIFF/WAVE file", path.c_str());
+        return audio;
+    }
+
+    uint16_t format = 0;
+    uint16_t channels = 0;
+    uint32_t sample_rate = 0;
+    uint16_t bits_per_sample = 0;
+    const uint8_t* data = nullptr;
+    uint32_t data_size = 0;
+
+    size_t pos = 12;
+    while (pos + 8 <= wav.size()) {
+        const uint8_t* chunk = wav.data() + pos;
+        uint32_t chunk_size = read_u32_le_bytes(chunk + 4);
+        size_t chunk_data = pos + 8;
+        if (chunk_data + chunk_size > wav.size()) {
+            break;
+        }
+
+        if (std::memcmp(chunk, "fmt ", 4) == 0 && chunk_size >= 16) {
+            format = read_u16_le_bytes(wav.data() + chunk_data);
+            channels = read_u16_le_bytes(wav.data() + chunk_data + 2);
+            sample_rate = read_u32_le_bytes(wav.data() + chunk_data + 4);
+            bits_per_sample = read_u16_le_bytes(wav.data() + chunk_data + 14);
+        } else if (std::memcmp(chunk, "data", 4) == 0) {
+            data = wav.data() + chunk_data;
+            data_size = chunk_size;
+        }
+        pos = chunk_data + chunk_size + (chunk_size & 1);
+    }
+
+    if (data == nullptr || data_size == 0 || channels == 0 || sample_rate == 0) {
+        LOG_ERROR("input WAV '%s' is missing fmt/data chunks", path.c_str());
+        return audio;
+    }
+    if (format != 1 && format != 3) {
+        LOG_ERROR("unsupported WAV format %u in '%s', only PCM and float WAV are supported",
+                  static_cast<unsigned>(format),
+                  path.c_str());
+        return audio;
+    }
+
+    uint16_t bytes_per_sample = static_cast<uint16_t>((bits_per_sample + 7) / 8);
+    uint32_t frame_bytes = static_cast<uint32_t>(bytes_per_sample) * channels;
+    if (bytes_per_sample == 0 || frame_bytes == 0 || data_size < frame_bytes) {
+        LOG_ERROR("invalid WAV sample format in '%s'", path.c_str());
+        return audio;
+    }
+
+    uint64_t sample_count = data_size / frame_bytes;
+    size_t float_count = static_cast<size_t>(sample_count) * channels;
+    float* samples = (float*)malloc(float_count * sizeof(float));
+    if (samples == nullptr) {
+        return audio;
+    }
+
+    for (uint64_t i = 0; i < sample_count; ++i) {
+        for (uint16_t ch = 0; ch < channels; ++ch) {
+            const uint8_t* src = data + i * frame_bytes + ch * bytes_per_sample;
+            float sample = 0.f;
+            if (format == 3 && bits_per_sample == 32) {
+                std::memcpy(&sample, src, sizeof(float));
+            } else if (format == 1 && bits_per_sample == 8) {
+                sample = (static_cast<int>(src[0]) - 128) / 128.f;
+            } else if (format == 1 && bits_per_sample == 16) {
+                sample = static_cast<int16_t>(read_u16_le_bytes(src)) / 32768.f;
+            } else if (format == 1 && bits_per_sample == 24) {
+                sample = read_s24_le_bytes(src) / 8388608.f;
+            } else if (format == 1 && bits_per_sample == 32) {
+                sample = static_cast<int32_t>(read_u32_le_bytes(src)) / 2147483648.f;
+            } else {
+                LOG_ERROR("unsupported WAV bit depth %u in '%s'",
+                          static_cast<unsigned>(bits_per_sample),
+                          path.c_str());
+                free(samples);
+                return audio;
+            }
+            samples[i * channels + ch] = std::clamp(sample, -1.0f, 1.0f);
+        }
+    }
+
+    audio.sample_rate = sample_rate;
+    audio.channels = channels;
+    audio.sample_count = sample_count;
+    audio.data = samples;
+    return audio;
 }

--- a/examples/common/media_io.cpp
+++ b/examples/common/media_io.cpp
@@ -1405,29 +1405,29 @@ sd_audio_t load_pcm_wav_from_file(const std::string& path) {
         return audio;
     }
 
-    uint16_t format = 0;
-    uint16_t channels = 0;
-    uint32_t sample_rate = 0;
+    uint16_t format          = 0;
+    uint16_t channels        = 0;
+    uint32_t sample_rate     = 0;
     uint16_t bits_per_sample = 0;
-    const uint8_t* data = nullptr;
-    uint32_t data_size = 0;
+    const uint8_t* data      = nullptr;
+    uint32_t data_size       = 0;
 
     size_t pos = 12;
     while (pos + 8 <= wav.size()) {
         const uint8_t* chunk = wav.data() + pos;
-        uint32_t chunk_size = read_u32_le_bytes(chunk + 4);
-        size_t chunk_data = pos + 8;
+        uint32_t chunk_size  = read_u32_le_bytes(chunk + 4);
+        size_t chunk_data    = pos + 8;
         if (chunk_data + chunk_size > wav.size()) {
             break;
         }
 
         if (std::memcmp(chunk, "fmt ", 4) == 0 && chunk_size >= 16) {
-            format = read_u16_le_bytes(wav.data() + chunk_data);
-            channels = read_u16_le_bytes(wav.data() + chunk_data + 2);
-            sample_rate = read_u32_le_bytes(wav.data() + chunk_data + 4);
+            format          = read_u16_le_bytes(wav.data() + chunk_data);
+            channels        = read_u16_le_bytes(wav.data() + chunk_data + 2);
+            sample_rate     = read_u32_le_bytes(wav.data() + chunk_data + 4);
             bits_per_sample = read_u16_le_bytes(wav.data() + chunk_data + 14);
         } else if (std::memcmp(chunk, "data", 4) == 0) {
-            data = wav.data() + chunk_data;
+            data      = wav.data() + chunk_data;
             data_size = chunk_size;
         }
         pos = chunk_data + chunk_size + (chunk_size & 1);
@@ -1445,15 +1445,15 @@ sd_audio_t load_pcm_wav_from_file(const std::string& path) {
     }
 
     uint16_t bytes_per_sample = static_cast<uint16_t>((bits_per_sample + 7) / 8);
-    uint32_t frame_bytes = static_cast<uint32_t>(bytes_per_sample) * channels;
+    uint32_t frame_bytes      = static_cast<uint32_t>(bytes_per_sample) * channels;
     if (bytes_per_sample == 0 || frame_bytes == 0 || data_size < frame_bytes) {
         LOG_ERROR("invalid WAV sample format in '%s'", path.c_str());
         return audio;
     }
 
     uint64_t sample_count = data_size / frame_bytes;
-    size_t float_count = static_cast<size_t>(sample_count) * channels;
-    float* samples = (float*)malloc(float_count * sizeof(float));
+    size_t float_count    = static_cast<size_t>(sample_count) * channels;
+    float* samples        = (float*)malloc(float_count * sizeof(float));
     if (samples == nullptr) {
         return audio;
     }
@@ -1461,7 +1461,7 @@ sd_audio_t load_pcm_wav_from_file(const std::string& path) {
     for (uint64_t i = 0; i < sample_count; ++i) {
         for (uint16_t ch = 0; ch < channels; ++ch) {
             const uint8_t* src = data + i * frame_bytes + ch * bytes_per_sample;
-            float sample = 0.f;
+            float sample       = 0.f;
             if (format == 3 && bits_per_sample == 32) {
                 std::memcpy(&sample, src, sizeof(float));
             } else if (format == 1 && bits_per_sample == 8) {
@@ -1483,9 +1483,9 @@ sd_audio_t load_pcm_wav_from_file(const std::string& path) {
         }
     }
 
-    audio.sample_rate = sample_rate;
-    audio.channels = channels;
+    audio.sample_rate  = sample_rate;
+    audio.channels     = channels;
     audio.sample_count = sample_count;
-    audio.data = samples;
+    audio.data         = samples;
     return audio;
 }

--- a/examples/common/media_io.h
+++ b/examples/common/media_io.h
@@ -110,4 +110,6 @@ bool write_wav_to_file(const std::string& path,
                        uint32_t channels,
                        uint32_t sample_rate);
 
+sd_audio_t load_pcm_wav_from_file(const std::string& path);
+
 #endif  // __MEDIA_IO_H__

--- a/examples/common/resource_owners.hpp
+++ b/examples/common/resource_owners.hpp
@@ -40,12 +40,21 @@ struct UpscalerCtxDeleter {
     }
 };
 
+struct SDAudioDeleter {
+    void operator()(sd_audio_t* audio) const {
+        if (audio != nullptr) {
+            free_sd_audio(audio);
+        }
+    }
+};
+
 template <typename T>
 using FreeUniquePtr = std::unique_ptr<T, FreeDeleter>;
 
 using FilePtr        = std::unique_ptr<FILE, FileCloser>;
 using SDCtxPtr       = std::unique_ptr<sd_ctx_t, SDCtxDeleter>;
 using UpscalerCtxPtr = std::unique_ptr<upscaler_ctx_t, UpscalerCtxDeleter>;
+using SDAudioPtr     = std::unique_ptr<sd_audio_t, SDAudioDeleter>;
 
 class SDImageOwner {
 private:

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -395,6 +395,7 @@ typedef struct {
     int64_t seed;
     int video_frames;
     int fps;
+    const sd_audio_t* input_audio;
     float vace_strength;
     sd_tiling_params_t vae_tiling_params;
     sd_cache_params_t cache;

--- a/src/model/vae/ltx_audio_vae.hpp
+++ b/src/model/vae/ltx_audio_vae.hpp
@@ -250,9 +250,9 @@ namespace LTXV {
         sd::Tensor<float> basis({n_fft, 1, n_freqs * 2});
         for (int k = 0; k < n_freqs; ++k) {
             for (int n = 0; n < n_fft; ++n) {
-                double window          = 0.5 - 0.5 * std::cos(2.0 * kPi * n / static_cast<double>(n_fft));
-                double phase           = 2.0 * kPi * k * n / static_cast<double>(n_fft);
-                basis.index(n, 0, k)   = static_cast<float>(std::cos(phase) * window);
+                double window                  = 0.5 - 0.5 * std::cos(2.0 * kPi * n / static_cast<double>(n_fft));
+                double phase                   = 2.0 * kPi * k * n / static_cast<double>(n_fft);
+                basis.index(n, 0, k)           = static_cast<float>(std::cos(phase) * window);
                 basis.index(n, 0, k + n_freqs) = static_cast<float>(-std::sin(phase) * window);
             }
         }
@@ -276,12 +276,12 @@ namespace LTXV {
         }
 
         for (int m = 0; m < n_mels; ++m) {
-            double lower = mel_f[m];
+            double lower  = mel_f[m];
             double center = mel_f[m + 1];
-            double upper = mel_f[m + 2];
-            double enorm = 2.0 / std::max(upper - lower, 1e-12);
+            double upper  = mel_f[m + 2];
+            double enorm  = 2.0 / std::max(upper - lower, 1e-12);
             for (int f = 0; f < n_freqs; ++f) {
-                double freq = fft_freqs[f];
+                double freq  = fft_freqs[f];
                 double value = 0.0;
                 if (freq > lower && freq <= center) {
                     value = (freq - lower) / std::max(center - lower, 1e-12);

--- a/src/model/vae/ltx_audio_vae.hpp
+++ b/src/model/vae/ltx_audio_vae.hpp
@@ -1,6 +1,7 @@
 ﻿#ifndef __SD_MODEL_VAE_LTX_AUDIO_VAE_HPP__
 #define __SD_MODEL_VAE_LTX_AUDIO_VAE_HPP__
 
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include <numeric>
@@ -21,6 +22,10 @@ namespace LTXV {
         int latent_channels                                        = 8;
         int latent_frequency_bins                                  = 16;
         int audio_channels                                         = 2;
+        bool has_encoder                                           = false;
+        int encoder_channels                                       = 128;
+        std::vector<int> encoder_channel_multipliers               = {1, 2, 4};
+        int encoder_num_res_blocks                                 = 2;
         int decoder_channels                                       = 128;
         std::vector<int> decoder_channel_multipliers               = {1, 2, 4};
         int decoder_num_res_blocks                                 = 2;
@@ -74,6 +79,7 @@ namespace LTXV {
 
             const TensorStorage* decoder_conv_in   = require("audio_vae.decoder.conv_in.conv.weight");
             const TensorStorage* decoder_conv_out  = require("audio_vae.decoder.conv_out.conv.weight");
+            const TensorStorage* encoder_conv_in   = require("audio_vae.encoder.conv_in.conv.weight");
             const TensorStorage* latent_std        = require("audio_vae.per_channel_statistics.std-of-means");
             const TensorStorage* vocoder_conv_pre  = require("vocoder.vocoder.conv_pre.weight");
             const TensorStorage* vocoder_conv_post = require("vocoder.vocoder.conv_post.weight");
@@ -96,6 +102,40 @@ namespace LTXV {
 
             if (latent_std->ne[0] % std::max<int64_t>(1, decoder_conv_in->ne[2]) != 0) {
                 return config;
+            }
+
+            if (encoder_conv_in != nullptr) {
+                config.has_encoder      = true;
+                config.audio_channels   = static_cast<int>(encoder_conv_in->ne[2]);
+                config.encoder_channels = static_cast<int>(encoder_conv_in->ne[3]);
+
+                std::vector<std::pair<int, int>> encoder_level_channels;
+                for (const auto& pair : tensor_storage_map) {
+                    const std::string& name  = pair.first;
+                    const std::string prefix = "audio_vae.encoder.down.";
+                    const std::string suffix = ".block.0.conv1.conv.weight";
+                    if (!starts_with(name, prefix) || !ends_with(name, suffix)) {
+                        continue;
+                    }
+                    std::string level_str = name.substr(prefix.size(), name.size() - prefix.size() - suffix.size());
+                    int level             = std::stoi(level_str);
+                    encoder_level_channels.push_back({level, static_cast<int>(pair.second.ne[3])});
+                }
+                std::sort(encoder_level_channels.begin(), encoder_level_channels.end());
+                if (!encoder_level_channels.empty()) {
+                    config.encoder_channel_multipliers.clear();
+                    for (const auto& level_channel : encoder_level_channels) {
+                        config.encoder_channel_multipliers.push_back(level_channel.second / std::max(1, config.encoder_channels));
+                    }
+                }
+
+                int encoder_block_count = 0;
+                while (tensor_storage_map.find("audio_vae.encoder.down.0.block." + std::to_string(encoder_block_count) + ".conv1.conv.weight") != tensor_storage_map.end()) {
+                    ++encoder_block_count;
+                }
+                if (encoder_block_count > 0) {
+                    config.encoder_num_res_blocks = encoder_block_count;
+                }
             }
 
             std::vector<std::pair<int, int>> level_channels;
@@ -171,15 +211,88 @@ namespace LTXV {
             if (config.audio_channels != 2 || config.latent_channels != 8 || config.mel_bins != 64) {
                 return config;
             }
-            LOG_DEBUG("ltx_audio_vae: sample_rate = %d, mel_bins = %d, latent_channels = %d, latent_frequency_bins = %d, has_bwe = %s",
+            LOG_DEBUG("ltx_audio_vae: sample_rate = %d, mel_bins = %d, latent_channels = %d, latent_frequency_bins = %d, has_encoder = %s, has_bwe = %s",
                       config.sample_rate,
                       config.mel_bins,
                       config.latent_channels,
                       config.latent_frequency_bins,
+                      config.has_encoder ? "true" : "false",
                       config.has_bwe ? "true" : "false");
             return config;
         }
     };
+
+    static double ltx_audio_hz_to_mel(double freq) {
+        constexpr double min_log_hz  = 1000.0;
+        constexpr double min_log_mel = 15.0;
+        constexpr double logstep     = 0.06875177742094912;  // log(6.4) / 27
+        constexpr double f_sp        = 200.0 / 3.0;
+        if (freq < min_log_hz) {
+            return freq / f_sp;
+        }
+        return min_log_mel + std::log(freq / min_log_hz) / logstep;
+    }
+
+    static double ltx_audio_mel_to_hz(double mel) {
+        constexpr double min_log_hz  = 1000.0;
+        constexpr double min_log_mel = 15.0;
+        constexpr double logstep     = 0.06875177742094912;  // log(6.4) / 27
+        constexpr double f_sp        = 200.0 / 3.0;
+        if (mel < min_log_mel) {
+            return mel * f_sp;
+        }
+        return min_log_hz * std::exp(logstep * (mel - min_log_mel));
+    }
+
+    static sd::Tensor<float> build_encoder_stft_basis(int n_fft) {
+        constexpr double kPi = 3.14159265358979323846;
+        const int n_freqs    = n_fft / 2 + 1;
+        sd::Tensor<float> basis({n_fft, 1, n_freqs * 2});
+        for (int k = 0; k < n_freqs; ++k) {
+            for (int n = 0; n < n_fft; ++n) {
+                double window          = 0.5 - 0.5 * std::cos(2.0 * kPi * n / static_cast<double>(n_fft));
+                double phase           = 2.0 * kPi * k * n / static_cast<double>(n_fft);
+                basis.index(n, 0, k)   = static_cast<float>(std::cos(phase) * window);
+                basis.index(n, 0, k + n_freqs) = static_cast<float>(-std::sin(phase) * window);
+            }
+        }
+        return basis;
+    }
+
+    static sd::Tensor<float> build_encoder_mel_basis(int sample_rate, int n_fft, int n_mels) {
+        const int n_freqs = n_fft / 2 + 1;
+        sd::Tensor<float> basis({n_freqs, n_mels});
+        std::vector<double> fft_freqs(n_freqs);
+        for (int i = 0; i < n_freqs; ++i) {
+            fft_freqs[i] = (static_cast<double>(sample_rate) * 0.5) * static_cast<double>(i) / static_cast<double>(n_freqs - 1);
+        }
+
+        std::vector<double> mel_f(n_mels + 2);
+        const double min_mel = ltx_audio_hz_to_mel(0.0);
+        const double max_mel = ltx_audio_hz_to_mel(static_cast<double>(sample_rate) * 0.5);
+        for (int i = 0; i < n_mels + 2; ++i) {
+            double mel = min_mel + (max_mel - min_mel) * static_cast<double>(i) / static_cast<double>(n_mels + 1);
+            mel_f[i]   = ltx_audio_mel_to_hz(mel);
+        }
+
+        for (int m = 0; m < n_mels; ++m) {
+            double lower = mel_f[m];
+            double center = mel_f[m + 1];
+            double upper = mel_f[m + 2];
+            double enorm = 2.0 / std::max(upper - lower, 1e-12);
+            for (int f = 0; f < n_freqs; ++f) {
+                double freq = fft_freqs[f];
+                double value = 0.0;
+                if (freq > lower && freq <= center) {
+                    value = (freq - lower) / std::max(center - lower, 1e-12);
+                } else if (freq > center && freq < upper) {
+                    value = (upper - freq) / std::max(upper - center, 1e-12);
+                }
+                basis.index(f, m) = static_cast<float>(value * enorm);
+            }
+        }
+        return basis;
+    }
 
     static ggml_tensor* compute_log_mel_spectrogram(GGMLRunnerContext* runner_ctx,
                                                     ggml_tensor* waveform,
@@ -478,6 +591,31 @@ namespace LTXV {
         }
     };
 
+    struct AudioDownsample2D : public GGMLBlock {
+        AudioDownsample2D(int64_t channels) {
+            blocks["conv"] = std::make_shared<Conv2d>(channels,
+                                                      channels,
+                                                      std::pair<int, int>{3, 3},
+                                                      std::pair<int, int>{2, 2},
+                                                      std::pair<int, int>{0, 0});
+        }
+
+        ggml_tensor* forward(GGMLRunnerContext* ctx, ggml_tensor* x) {
+            auto conv = std::dynamic_pointer_cast<Conv2d>(blocks["conv"]);
+            x         = ggml_ext_pad_ext(ctx->ggml_ctx,
+                                         x,
+                                         0,
+                                         1,
+                                         2,
+                                         0,
+                                         0,
+                                         0,
+                                         0,
+                                         0);
+            return conv->forward(ctx, x);
+        }
+    };
+
     struct AudioResnetBlock2D : public GGMLBlock {
         int64_t in_channels;
         int64_t out_channels;
@@ -511,6 +649,86 @@ namespace LTXV {
                 x             = shortcut->forward(ctx, x);
             }
             return ggml_add(ctx->ggml_ctx, x, h);
+        }
+    };
+
+    struct AudioEncoder : public GGMLBlock {
+        LTXAudioVAEConfig config;
+
+        explicit AudioEncoder(const LTXAudioVAEConfig& config)
+            : config(config) {
+            int block_in      = config.encoder_channels;
+            blocks["conv_in"] = std::make_shared<HeightCausalConv2D>(config.audio_channels, block_in, std::pair<int, int>{3, 3});
+
+            for (int level = 0; level < static_cast<int>(config.encoder_channel_multipliers.size()); ++level) {
+                int block_out = config.encoder_channels * config.encoder_channel_multipliers[level];
+                for (int block_idx = 0; block_idx < config.encoder_num_res_blocks; ++block_idx) {
+                    blocks["down." + std::to_string(level) + ".block." + std::to_string(block_idx)] =
+                        std::make_shared<AudioResnetBlock2D>(block_in, block_out);
+                    block_in = block_out;
+                }
+                if (level != static_cast<int>(config.encoder_channel_multipliers.size()) - 1) {
+                    blocks["down." + std::to_string(level) + ".downsample"] = std::make_shared<AudioDownsample2D>(block_in);
+                }
+            }
+
+            blocks["mid.block_1"] = std::make_shared<AudioResnetBlock2D>(block_in, block_in);
+            blocks["mid.block_2"] = std::make_shared<AudioResnetBlock2D>(block_in, block_in);
+            blocks["norm_out"]    = std::make_shared<PixelNorm2D>();
+            blocks["conv_out"]    = std::make_shared<HeightCausalConv2D>(block_in, config.latent_channels * 2, std::pair<int, int>{3, 3});
+        }
+
+        ggml_tensor* normalize_latent(GGMLRunnerContext* ctx,
+                                      ggml_tensor* latent,
+                                      ggml_tensor* mean,
+                                      ggml_tensor* stddev) {
+            latent = ggml_ext_slice(ctx->ggml_ctx, latent, 2, 0, config.latent_channels);
+            latent = ggml_permute(ctx->ggml_ctx, latent, 0, 2, 1, 3);
+            latent = ggml_cont(ctx->ggml_ctx, latent);
+            latent = ggml_reshape_4d(ctx->ggml_ctx, latent, config.latent_frequency_bins * config.latent_channels, latent->ne[2], 1, latent->ne[3]);
+
+            mean   = ggml_reshape_4d(ctx->ggml_ctx, mean, mean->ne[0], 1, 1, 1);
+            stddev = ggml_reshape_4d(ctx->ggml_ctx, stddev, stddev->ne[0], 1, 1, 1);
+            latent = ggml_div(ctx->ggml_ctx, ggml_sub(ctx->ggml_ctx, latent, mean), stddev);
+
+            latent = ggml_reshape_4d(ctx->ggml_ctx,
+                                     latent,
+                                     config.latent_frequency_bins,
+                                     config.latent_channels,
+                                     latent->ne[1],
+                                     latent->ne[3]);
+            latent = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, latent, 0, 2, 1, 3));
+            return latent;
+        }
+
+        ggml_tensor* forward(GGMLRunnerContext* ctx,
+                             ggml_tensor* spectrogram,
+                             ggml_tensor* mean,
+                             ggml_tensor* stddev) {
+            auto conv_in     = std::dynamic_pointer_cast<HeightCausalConv2D>(blocks["conv_in"]);
+            auto mid_block_1 = std::dynamic_pointer_cast<AudioResnetBlock2D>(blocks["mid.block_1"]);
+            auto mid_block_2 = std::dynamic_pointer_cast<AudioResnetBlock2D>(blocks["mid.block_2"]);
+            auto norm_out    = std::dynamic_pointer_cast<PixelNorm2D>(blocks["norm_out"]);
+            auto conv_out    = std::dynamic_pointer_cast<HeightCausalConv2D>(blocks["conv_out"]);
+
+            auto x = conv_in->forward(ctx, spectrogram);
+            for (int level = 0; level < static_cast<int>(config.encoder_channel_multipliers.size()); ++level) {
+                for (int block_idx = 0; block_idx < config.encoder_num_res_blocks; ++block_idx) {
+                    auto block = std::dynamic_pointer_cast<AudioResnetBlock2D>(blocks["down." + std::to_string(level) + ".block." + std::to_string(block_idx)]);
+                    x          = block->forward(ctx, x);
+                }
+                if (level != static_cast<int>(config.encoder_channel_multipliers.size()) - 1) {
+                    auto downsample = std::dynamic_pointer_cast<AudioDownsample2D>(blocks["down." + std::to_string(level) + ".downsample"]);
+                    x               = downsample->forward(ctx, x);
+                }
+            }
+
+            x = mid_block_1->forward(ctx, x);
+            x = mid_block_2->forward(ctx, x);
+            x = norm_out->forward(ctx, x);
+            x = ggml_silu_inplace(ctx->ggml_ctx, x);
+            x = conv_out->forward(ctx, x);
+            return normalize_latent(ctx, x, mean, stddev);
         }
     };
 
@@ -914,6 +1132,9 @@ namespace LTXV {
 
         explicit LTXAudioVAE(const LTXAudioVAEConfig& config)
             : config(config) {
+            if (config.has_encoder) {
+                blocks["audio_vae.encoder"] = std::make_shared<AudioEncoder>(config);
+            }
             blocks["audio_vae.decoder"] = std::make_shared<AudioDecoder>(config);
             blocks["vocoder.vocoder"]   = std::make_shared<Vocoder>(config);
             if (config.has_bwe) {
@@ -993,6 +1214,18 @@ namespace LTXV {
 
             return waveform;
         }
+
+        ggml_tensor* encode(GGMLRunnerContext* ctx,
+                            ggml_tensor* waveform,
+                            ggml_tensor* stft_basis,
+                            ggml_tensor* mel_basis) {
+            GGML_ASSERT(config.has_encoder);
+            auto encoder = std::dynamic_pointer_cast<AudioEncoder>(blocks["audio_vae.encoder"]);
+            auto mean    = params["audio_vae.per_channel_statistics.mean-of-means"];
+            auto stddev  = params["audio_vae.per_channel_statistics.std-of-means"];
+            auto mel     = compute_log_mel_spectrogram(ctx, waveform, stft_basis, mel_basis, config.mel_hop_length);
+            return encoder->forward(ctx, mel, mean, stddev);
+        }
     };
 
     struct LTXAudioVAERunner : public GGMLRunner {
@@ -1000,6 +1233,8 @@ namespace LTXV {
         LTXAudioVAE model;
         std::string weight_prefix;
         sd::Tensor<float> bwe_skip_filter_tensor;
+        sd::Tensor<float> encoder_stft_basis_tensor;
+        sd::Tensor<float> encoder_mel_basis_tensor;
 
         LTXAudioVAERunner(ggml_backend_t backend,
                           const String2TensorStorage& tensor_storage_map,
@@ -1013,6 +1248,10 @@ namespace LTXV {
             if (config.has_bwe) {
                 const int bwe_ratio    = config.bwe_output_sample_rate / config.bwe_input_sample_rate;
                 bwe_skip_filter_tensor = sd::Tensor<float>::from_vector(build_hann_resample_filter(bwe_ratio));
+            }
+            if (config.has_encoder) {
+                encoder_stft_basis_tensor = build_encoder_stft_basis(config.n_fft);
+                encoder_mel_basis_tensor  = build_encoder_mel_basis(config.sample_rate, config.n_fft, config.mel_bins);
             }
         }
 
@@ -1043,6 +1282,29 @@ namespace LTXV {
             auto result = restore_trailing_singleton_dims(GGMLRunner::compute<float>(get_graph, n_threads, false, false, false), 4);
             int64_t t1  = ggml_time_ms();
             LOG_INFO("ltx audio vae decode completed, taking %.2fs", (t1 - t0) * 1.0f / 1000);
+            return result;
+        }
+
+        sd::Tensor<float> encode(int n_threads,
+                                 const sd::Tensor<float>& waveform_tensor) {
+            if (!config.has_encoder || waveform_tensor.empty() ||
+                encoder_stft_basis_tensor.empty() || encoder_mel_basis_tensor.empty()) {
+                return {};
+            }
+            int64_t t0     = ggml_time_ms();
+            auto get_graph = [&]() -> ggml_cgraph* {
+                auto waveform   = make_input(waveform_tensor);
+                auto stft_basis = make_input(encoder_stft_basis_tensor);
+                auto mel_basis  = make_input(encoder_mel_basis_tensor);
+                ggml_cgraph* gf = new_graph_custom(655360);
+                auto runner_ctx = GGMLRunner::get_context();
+                auto latent     = model.encode(&runner_ctx, waveform, stft_basis, mel_basis);
+                ggml_build_forward_expand(gf, latent);
+                return gf;
+            };
+            auto result = restore_trailing_singleton_dims(GGMLRunner::compute<float>(get_graph, n_threads, false, false, false), 4);
+            int64_t t1  = ggml_time_ms();
+            LOG_INFO("ltx audio vae encode completed, taking %.2fs", (t1 - t0) * 1.0f / 1000);
             return result;
         }
 

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -3068,8 +3068,8 @@ static sd::Tensor<float> sd_audio_to_ltx_waveform_tensor(const sd_audio_t* audio
 
     int64_t out_samples = static_cast<int64_t>(out_samples_u64);
     sd::Tensor<float> waveform({out_samples, target_channels, 1, 1});
-    const double src_rate = static_cast<double>(audio->sample_rate);
-    const double dst_rate = static_cast<double>(target_sample_rate);
+    const double src_rate  = static_cast<double>(audio->sample_rate);
+    const double dst_rate  = static_cast<double>(target_sample_rate);
     const int src_channels = static_cast<int>(audio->channels);
 
     auto src_value = [&](uint64_t sample, int channel) -> float {
@@ -3088,8 +3088,8 @@ static sd::Tensor<float> sd_audio_to_ltx_waveform_tensor(const sd_audio_t* audio
         uint64_t i1    = std::min<uint64_t>(i0 + 1, audio->sample_count - 1);
         float frac     = static_cast<float>(src_pos - static_cast<double>(i0));
         for (int ch = 0; ch < target_channels; ++ch) {
-            float v0 = src_value(i0, ch);
-            float v1 = src_value(i1, ch);
+            float v0                    = src_value(i0, ch);
+            float v1                    = src_value(i1, ch);
             waveform.index(t, ch, 0, 0) = v0 + (v1 - v0) * frac;
         }
     }
@@ -4760,9 +4760,9 @@ static std::optional<ImageGenerationLatents> prepare_video_generation_latents(sd
             }
 
             int64_t audio_encode_start = ggml_time_ms();
-            auto waveform = sd_audio_to_ltx_waveform_tensor(sd_vid_gen_params->input_audio,
-                                                            sd_ctx->sd->audio_vae_model->config.sample_rate,
-                                                            sd_ctx->sd->audio_vae_model->config.audio_channels);
+            auto waveform              = sd_audio_to_ltx_waveform_tensor(sd_vid_gen_params->input_audio,
+                                                                         sd_ctx->sd->audio_vae_model->config.sample_rate,
+                                                                         sd_ctx->sd->audio_vae_model->config.audio_channels);
             if (waveform.empty()) {
                 LOG_ERROR("failed to convert source audio for LTX A2V encoding");
                 return std::nullopt;

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <limits>
 #include <set>
 #include <unordered_set>
 #include <vector>
@@ -1101,9 +1102,6 @@ public:
         ignore_tensors.insert("model.diffusion_model.__32x32__");
         ignore_tensors.insert("model.diffusion_model.__index_timestep_zero__");
 
-        if (audio_vae_model) {
-            ignore_tensors.insert("audio_vae.encoder");
-        }
         if (version == VERSION_OVIS_IMAGE) {
             ignore_tensors.insert("text_encoders.llm.vision_model.");
             ignore_tensors.insert("text_encoders.llm.visual_tokenizer.");
@@ -2928,6 +2926,7 @@ void sd_vid_gen_params_init(sd_vid_gen_params_t* sd_vid_gen_params) {
     sd_vid_gen_params->seed                                  = -1;
     sd_vid_gen_params->video_frames                          = 6;
     sd_vid_gen_params->fps                                   = 16;
+    sd_vid_gen_params->input_audio                           = nullptr;
     sd_vid_gen_params->moe_boundary                          = 0.875f;
     sd_vid_gen_params->vace_strength                         = 1.f;
     sd_vid_gen_params->vae_tiling_params                     = {false, false, 0, 0, 0.5f, 0.0f, 0.0f, nullptr};
@@ -3025,6 +3024,77 @@ static sd_audio_t* waveform_to_sd_audio(const StableDiffusionGGML* sd,
     std::memcpy(audio->data, wavaform_t.data(), sample_bytes);
 
     return audio;
+}
+
+static sd_audio_t* clone_sd_audio(const sd_audio_t* src) {
+    if (src == nullptr || src->data == nullptr || src->sample_rate == 0 || src->channels == 0 || src->sample_count == 0) {
+        return nullptr;
+    }
+
+    sd_audio_t* audio = (sd_audio_t*)malloc(sizeof(sd_audio_t));
+    if (audio == nullptr) {
+        return nullptr;
+    }
+
+    audio->sample_rate  = src->sample_rate;
+    audio->channels     = src->channels;
+    audio->sample_count = src->sample_count;
+    size_t sample_bytes = static_cast<size_t>(src->sample_count) * static_cast<size_t>(src->channels) * sizeof(float);
+    audio->data         = (float*)malloc(sample_bytes);
+    if (audio->data == nullptr) {
+        free(audio);
+        return nullptr;
+    }
+
+    std::memcpy(audio->data, src->data, sample_bytes);
+    return audio;
+}
+
+static sd::Tensor<float> sd_audio_to_ltx_waveform_tensor(const sd_audio_t* audio,
+                                                         int target_sample_rate,
+                                                         int target_channels) {
+    if (audio == nullptr || audio->data == nullptr || audio->sample_rate == 0 ||
+        audio->channels == 0 || audio->sample_count == 0 || target_sample_rate <= 0 ||
+        target_channels <= 0) {
+        return {};
+    }
+
+    uint64_t out_samples_u64 = (audio->sample_count * static_cast<uint64_t>(target_sample_rate) +
+                                static_cast<uint64_t>(audio->sample_rate) - 1) /
+                               static_cast<uint64_t>(audio->sample_rate);
+    if (out_samples_u64 == 0 || out_samples_u64 > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+        return {};
+    }
+
+    int64_t out_samples = static_cast<int64_t>(out_samples_u64);
+    sd::Tensor<float> waveform({out_samples, target_channels, 1, 1});
+    const double src_rate = static_cast<double>(audio->sample_rate);
+    const double dst_rate = static_cast<double>(target_sample_rate);
+    const int src_channels = static_cast<int>(audio->channels);
+
+    auto src_value = [&](uint64_t sample, int channel) -> float {
+        int src_channel = channel;
+        if (src_channels == 1) {
+            src_channel = 0;
+        } else if (channel >= src_channels) {
+            src_channel = src_channels - 1;
+        }
+        return audio->data[static_cast<size_t>(sample) * static_cast<size_t>(src_channels) + static_cast<size_t>(src_channel)];
+    };
+
+    for (int64_t t = 0; t < out_samples; ++t) {
+        double src_pos = static_cast<double>(t) * src_rate / dst_rate;
+        uint64_t i0    = static_cast<uint64_t>(std::floor(src_pos));
+        uint64_t i1    = std::min<uint64_t>(i0 + 1, audio->sample_count - 1);
+        float frac     = static_cast<float>(src_pos - static_cast<double>(i0));
+        for (int ch = 0; ch < target_channels; ++ch) {
+            float v0 = src_value(i0, ch);
+            float v1 = src_value(i1, ch);
+            waveform.index(t, ch, 0, 0) = v0 + (v1 - v0) * frac;
+        }
+    }
+
+    return waveform;
 }
 
 void free_sd_audio(sd_audio_t* audio) {
@@ -3595,7 +3665,8 @@ static sd::Tensor<float> pack_ltxav_audio_and_video_latents(const sd::Tensor<flo
 
 static sd::Tensor<float> pack_ltxav_audio_and_video_denoise_mask(const sd::Tensor<float>& video_mask,
                                                                  const sd::Tensor<float>& video_latent,
-                                                                 const sd::Tensor<float>& audio_latent) {
+                                                                 const sd::Tensor<float>& audio_latent,
+                                                                 float audio_mask_value = 1.f) {
     if (video_mask.empty() || audio_latent.empty()) {
         return video_mask;
     }
@@ -3638,7 +3709,7 @@ static sd::Tensor<float> pack_ltxav_audio_and_video_denoise_mask(const sd::Tenso
 
     std::vector<int64_t> audio_mask_shape = video_latent.shape();
     audio_mask_shape[3]                   = extra_ch;
-    auto audio_mask                       = sd::Tensor<float>::ones(audio_mask_shape);
+    auto audio_mask                       = sd::full<float>(audio_mask_shape, audio_mask_value);
     return sd::ops::concat(video_mask_full, audio_mask, 3);
 }
 
@@ -4680,6 +4751,44 @@ static std::optional<ImageGenerationLatents> prepare_video_generation_latents(sd
     if (sd_version_is_ltxav(sd_ctx->sd->version)) {
         latents.audio_length = get_ltxav_num_audio_latents(request->frames, request->fps);
         latents.audio_latent = make_ltxav_empty_audio_latent(latents.audio_length);
+        if (sd_vid_gen_params->input_audio != nullptr &&
+            sd_vid_gen_params->input_audio->data != nullptr &&
+            sd_vid_gen_params->input_audio->sample_count > 0) {
+            if (sd_ctx->sd->audio_vae_model == nullptr || !sd_ctx->sd->audio_vae_model->config.has_encoder) {
+                LOG_ERROR("LTX A2V requires an audio VAE with encoder weights");
+                return std::nullopt;
+            }
+
+            int64_t audio_encode_start = ggml_time_ms();
+            auto waveform = sd_audio_to_ltx_waveform_tensor(sd_vid_gen_params->input_audio,
+                                                            sd_ctx->sd->audio_vae_model->config.sample_rate,
+                                                            sd_ctx->sd->audio_vae_model->config.audio_channels);
+            if (waveform.empty()) {
+                LOG_ERROR("failed to convert source audio for LTX A2V encoding");
+                return std::nullopt;
+            }
+
+            auto encoded_audio_latent = sd_ctx->sd->audio_vae_model->encode(sd_ctx->sd->n_threads, waveform);
+            if (encoded_audio_latent.empty()) {
+                LOG_ERROR("LTX A2V audio latent encoding failed");
+                return std::nullopt;
+            }
+
+            latents.audio_latent = resize_ltxav_audio_latent(encoded_audio_latent, latents.audio_length);
+            if (latents.audio_latent.empty()) {
+                LOG_ERROR("failed to resize encoded LTX A2V audio latent");
+                return std::nullopt;
+            }
+
+            int64_t audio_encode_end = ggml_time_ms();
+            LOG_INFO("encoded LTX A2V source audio latent %dx%dx%dx%d -> length %d, taking %.2fs",
+                     (int)encoded_audio_latent.shape()[0],
+                     (int)encoded_audio_latent.shape()[1],
+                     (int)encoded_audio_latent.shape()[2],
+                     (int)encoded_audio_latent.shape()[3],
+                     latents.audio_length,
+                     (audio_encode_end - audio_encode_start) * 1.0f / 1000);
+        }
     }
 
     if (sd_version_is_ltxav(sd_ctx->sd->version)) {
@@ -4957,10 +5066,17 @@ static std::optional<ImageGenerationLatents> prepare_video_generation_latents(sd
     }
 
     if (sd_version_is_ltxav(sd_ctx->sd->version) && !latents.audio_latent.empty()) {
+        bool has_input_audio = sd_vid_gen_params->input_audio != nullptr &&
+                               sd_vid_gen_params->input_audio->data != nullptr &&
+                               sd_vid_gen_params->input_audio->sample_count > 0;
+        if (has_input_audio && latents.denoise_mask.empty()) {
+            latents.denoise_mask = make_ltxav_video_denoise_mask(latents.init_latent, 1.f);
+        }
         if (!latents.denoise_mask.empty()) {
             latents.denoise_mask = pack_ltxav_audio_and_video_denoise_mask(latents.denoise_mask,
                                                                            latents.init_latent,
-                                                                           latents.audio_latent);
+                                                                           latents.audio_latent,
+                                                                           has_input_audio ? 0.f : 1.f);
         }
         latents.init_latent = pack_ltxav_audio_and_video_latents(latents.init_latent, latents.audio_latent);
     }
@@ -5232,8 +5348,14 @@ static bool apply_ltxv_refine_image_conditioning(sd_ctx_t* sd_ctx,
     }
 
     if (!audio_latent.empty()) {
+        bool has_input_audio = sd_vid_gen_params->input_audio != nullptr &&
+                               sd_vid_gen_params->input_audio->data != nullptr &&
+                               sd_vid_gen_params->input_audio->sample_count > 0;
         *latent       = pack_ltxav_audio_and_video_latents(video_latent, audio_latent);
-        *denoise_mask = pack_ltxav_audio_and_video_denoise_mask(video_mask, video_latent, audio_latent);
+        *denoise_mask = pack_ltxav_audio_and_video_denoise_mask(video_mask,
+                                                                video_latent,
+                                                                audio_latent,
+                                                                has_input_audio ? 0.f : 1.f);
     } else {
         *latent       = std::move(video_latent);
         *denoise_mask = std::move(video_mask);
@@ -5265,6 +5387,9 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
     int64_t t0                    = ggml_time_ms();
     sd_ctx->sd->vae_tiling_params = sd_vid_gen_params->vae_tiling_params;
     GenerationRequest request(sd_ctx, sd_vid_gen_params);
+    bool has_input_audio = sd_vid_gen_params->input_audio != nullptr &&
+                           sd_vid_gen_params->input_audio->data != nullptr &&
+                           sd_vid_gen_params->input_audio->sample_count > 0;
     bool latent_upscale_enabled     = request.hires.enabled;
     GenerationRequest hires_request = request;
     if (latent_upscale_enabled) {
@@ -5482,6 +5607,17 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
                                                   &hires_video_positions)) {
             return false;
         }
+        if (has_input_audio && hires_denoise_mask.empty() && x_t.shape()[3] > sd_ctx->sd->get_latent_channel()) {
+            int latent_channels = sd_ctx->sd->get_latent_channel();
+            auto video_latent   = sd::ops::slice(x_t, 3, 0, latent_channels);
+            auto audio_latent   = unpack_ltxav_audio_latent(x_t, latents.audio_length, latent_channels);
+            if (!audio_latent.empty()) {
+                hires_denoise_mask = pack_ltxav_audio_and_video_denoise_mask(make_ltxav_video_denoise_mask(video_latent, 1.f),
+                                                                              video_latent,
+                                                                              audio_latent,
+                                                                              0.f);
+            }
+        }
         noise = sd::Tensor<float>::randn_like(x_t, sd_ctx->sd->rng);
 
         W                                   = hires_request.width / hires_request.vae_scale_factor;
@@ -5550,6 +5686,9 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
 
     sd_audio_t* generated_audio = nullptr;
     if (sd_version_is_ltxav(sd_ctx->sd->version) &&
+        has_input_audio) {
+        generated_audio = clone_sd_audio(sd_vid_gen_params->input_audio);
+    } else if (sd_version_is_ltxav(sd_ctx->sd->version) &&
         latents.audio_length > 0 &&
         sd_ctx->sd->audio_vae_model != nullptr) {
         if (sd_ctx->sd->get_cancel_flag() == SD_CANCEL_ALL) {


### PR DESCRIPTION
## Summary

This PR allows for init audio allowing Audio to Video (A2V) for LTX2.3. 

## Related Issue / Discussion

Implements and closes https://github.com/leejet/stable-diffusion.cpp/issues/1674

## Additional Information

### **!! AI Disclosure: This PR was created with the assistance of OpenAI Codex !!** 

Besides I2V creating a video from a start frame, LTX2.3 also supports generating a video from an audio clip, audio to video (A2V) as seen in https://github.com/Lightricks/LTX-2/blob/main/packages/ltx-pipelines/src/ltx_pipelines/a2vid_two_stage.py

Previously in stable-diffusion.cpp, the audio vae encoder is ignored. This PR allows the audio latent to be created from a provided wav audio file with `--init-audio`, and used instead of denoising from the default audio latent.

I tested with the distilled LTX2.3 model. 

Run with CLI like this:
```
sd-cli.exe -M vid_gen --diffusion-model ltx-2.3-22b-distilled-1.1-Q4_K_S.gguf --vae ltx-2.3-22b-distilled_video_vae.safetensors --audio-vae ltx-2.3-22b-distilled_audio_vae.safetensors --llm gemma3-12b-it-Q4_K_M.gguf --embeddings-connectors ltx-2.3-22b-distilled_embeddings_connectors.safetensors -p "man speaking" --cfg-scale 1.0 --sampling-method euler -v -W 256 -H 256 --video-frames 65 --init-audio tonystark.wav -o output.avi
```

Example outputs and audio inputs for reference:

https://github.com/user-attachments/assets/d48b39ff-6b19-4dca-81dc-31ba741ba424

https://github.com/user-attachments/assets/0de65cee-7e91-4e15-a1a5-e516c60b2f82

[epic_rap.wav](https://github.com/user-attachments/files/29055785/rap.wav)
[tony_stark_cave.wav](https://github.com/user-attachments/files/29055788/tony.wav)


Known limitations:
- As this project does not currently ingest audio, a simple PCM .wav to `sd_audio_t` file loader was added. This can probably be improved or replaced (e.g. Miniaudio, Dr Wav).
- CLI only, not currently added to the sd.cpp server
- The .wav audio and the generated video length should match up. So for example if you use a 4s audio with 16fps, then you would use 16x4+1 = 65 frames generated.
- You may or may not have better results by including the text of spoken words in your prompt. I have seen mixed results, but often something as simple as "man speaking" already causes the lips and mouth to line up with the audio, though there is some element of randomness involved. YMMV.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).

pinging those who might be interested: @stduhpf @wbruna 
@leejet Marking PR as draft, but feel free to modify (you have branch access) or merge anytime at your discretion. If you prefer to replace this implementation, that's fine too.