### PR TITLE
fix: workaround for Anima with Vulkan and Flash Attention

### DIFF
--- a/src/model/diffusion/anima.hpp
+++ b/src/model/diffusion/anima.hpp
@@ -227,6 +227,7 @@ namespace Anima {
             k4 = k_norm->forward(ctx, k4);
 
             ggml_tensor* attn_out = nullptr;
+            float scale           = (sd_backend_is(ctx->backend, "Vulkan") && ctx->flash_attn_enabled) ? 1.0f / 32.0f : 1.0f;
             if (pe_q != nullptr || pe_k != nullptr) {
                 if (pe_q == nullptr) {
                     pe_q = pe_k;
@@ -244,7 +245,8 @@ namespace Anima {
                                                      num_heads,
                                                      nullptr,
                                                      true,
-                                                     ctx->flash_attn_enabled);
+                                                     ctx->flash_attn_enabled,
+                                                     scale);
             } else {
                 auto q_flat = ggml_reshape_3d(ctx->ggml_ctx, q4, head_dim * num_heads, L_q, N);
                 auto k_flat = ggml_reshape_3d(ctx->ggml_ctx, k4, head_dim * num_heads, L_k, N);
@@ -256,7 +258,8 @@ namespace Anima {
                                                      num_heads,
                                                      nullptr,
                                                      false,
-                                                     ctx->flash_attn_enabled);
+                                                     ctx->flash_attn_enabled,
+                                                     scale);
             }
 
             return out_proj->forward(ctx, attn_out);


### PR DESCRIPTION
## Summary

Avoids broken images on Anima with Vulkan + Flash Attention.

## Related Issue / Discussion

#1647 (unrelated) has the original discussion, and some tests; I don't think this was reported on a specific issue.

## Additional Information

> sd-cli --backend vulkan1 -p "1girl, pointing to a blackboard where it is written: FLASH ATTENTION <lora:anima-turbo-lora-v0.1:1>" --sampling-method euler --scheduler sgm_uniform --steps 8 -W 1024 -H 1024 --cfg-scale 1  --vae-tiling --vae-conv-direct  -s 1 --diffusion-model anima-base-v1.0.safetensors --lora-model-dir . --vae Qwen_Image-VAE.safetensors --llm Qwen3-0.6B-UD-Q4_K_XL.gguf --fa

| master (7f0e728b7d42f2490dfa5dd9539082d904f2f6b2) | PR |
|---|---|
| <img width="400" height="400" alt="master flash attention" src="https://github.com/user-attachments/assets/8f097e3d-3021-440f-9791-d82162313577" /> | <img width="400" height="400" alt="PR flash attention" src="https://github.com/user-attachments/assets/4c2945cb-532a-421e-887b-7f04c2ddd466" /> |

Not sure how to choose the best scale; values between 1/8 and 1/128 seemed to work fine on my card (RX 7600 XT, radv, amdgpu).

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
