### PR TITLE
feat: support guidance_schedule

### DIFF
--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -960,7 +960,7 @@ ArgOptions SDGenerationParams::get_options() {
          &hires_upscaler},
         {"",
          "--extra-sample-args",
-         "extra sampler/scheduler/guidance args, key=value list. APG supports apg_eta, apg_momentum, apg_norm_threshold, apg_norm_threshold_smoothing; SLG supports slg_uncond; lcm supports noise_clip_std, noise_scale_start, noise_scale_end; ltx2 supports max_shift, base_shift, stretch, terminal; euler_ge supports gamma",
+         "extra sampler/scheduler/guidance args, key=value list. CFG supports guidance_schedule; APG supports apg_eta, apg_momentum, apg_norm_threshold, apg_norm_threshold_smoothing; SLG supports slg_uncond; lcm supports noise_clip_std, noise_scale_start, noise_scale_end; ltx2 supports max_shift, base_shift, stretch, terminal; euler_ge supports gamma;",
          (int)',',
          &extra_sample_args},
         {"",

--- a/src/runtime/guidance.cpp
+++ b/src/runtime/guidance.cpp
@@ -68,43 +68,42 @@ namespace sd::guidance {
         std::vector<float> schedule;
 
         while (!spec.empty()) {
-            auto sep   = spec.find('+');
+            auto sep     = spec.find('+');
             auto segment = spec.substr(0, sep);
 
             auto x = segment.find('x');
             if (x == std::string::npos) {
-                LOG_ERROR("Invalid guidance schedule segment: '%s' (expected <count>x<guidance>)", segment.c_str());
+                LOG_ERROR("Invalid guidance schedule segment: '%s' (expected <guidance>x<count>)", segment.c_str());
                 return {};
             }
 
-            int count;
             float guidance;
+            int count;
 
-            auto count_str    = segment.substr(0, x);
-            auto guidance_str = segment.substr(x + 1);
-
-            // Replaced std::from_chars with std::stoi for Xcode compatibility
-            try {
-                size_t idx = 0;
-                count = std::stoi(count_str, &idx);
-                if (idx != count_str.size()) {
-                    LOG_ERROR("Invalid count in guidance schedule: '%s'", count_str.c_str());
-                    return {};
-                }
-            } catch (const std::exception&) {
-                LOG_ERROR("Invalid count in guidance schedule: '%s'", count_str.c_str());
-                return {};
-            }
+            auto guidance_str = segment.substr(0, x);
+            auto count_str    = segment.substr(x + 1);
 
             try {
                 size_t idx = 0;
-                guidance = std::stof(guidance_str, &idx);
+                guidance   = std::stof(guidance_str, &idx);
                 if (idx != guidance_str.size()) {
                     LOG_ERROR("Invalid guidance value in guidance schedule: '%s'", guidance_str.c_str());
                     return {};
                 }
             } catch (const std::exception&) {
                 LOG_ERROR("Invalid guidance value in guidance schedule: '%s'", guidance_str.c_str());
+                return {};
+            }
+
+            try {
+                size_t idx = 0;
+                count      = std::stoi(count_str, &idx);
+                if (idx != count_str.size()) {
+                    LOG_ERROR("Invalid count in guidance schedule: '%s'", count_str.c_str());
+                    return {};
+                }
+            } catch (const std::exception&) {
+                LOG_ERROR("Invalid count in guidance schedule: '%s'", count_str.c_str());
                 return {};
             }
 
@@ -119,7 +118,6 @@ namespace sd::guidance {
                 break;
             }
 
-            // Use substr to remove the processed part
             spec = spec.substr(sep + 1);
         }
 

--- a/src/runtime/guidance.cpp
+++ b/src/runtime/guidance.cpp
@@ -6,7 +6,6 @@
 #include <string>
 #include <utility>
 #include <optional>
-#include <charconv>
 
 #include "core/util.h"
 
@@ -84,25 +83,27 @@ namespace sd::guidance {
             auto count_str    = segment.substr(0, x);
             auto guidance_str = segment.substr(x + 1);
 
-            // Use std::from_chars for parsing
-            auto [count_ptr, count_ec] =
-                std::from_chars(count_str.data(),
-                                count_str.data() + count_str.size(),
-                                count);
-
-            if (count_ec != std::errc{} ||
-                count_ptr != count_str.data() + count_str.size()) {
+            // Replaced std::from_chars with std::stoi for Xcode compatibility
+            try {
+                size_t idx = 0;
+                count = std::stoi(count_str, &idx);
+                if (idx != count_str.size()) {
+                    LOG_ERROR("Invalid count in guidance schedule: '%s'", count_str.c_str());
+                    return {};
+                }
+            } catch (const std::exception&) {
                 LOG_ERROR("Invalid count in guidance schedule: '%s'", count_str.c_str());
                 return {};
             }
 
-            auto [guidance_ptr, guidance_ec] =
-                std::from_chars(guidance_str.data(),
-                                guidance_str.data() + guidance_str.size(),
-                                guidance);
-
-            if (guidance_ec != std::errc{} ||
-                guidance_ptr != guidance_str.data() + guidance_str.size()) {
+            try {
+                size_t idx = 0;
+                guidance = std::stof(guidance_str, &idx);
+                if (idx != guidance_str.size()) {
+                    LOG_ERROR("Invalid guidance value in guidance schedule: '%s'", guidance_str.c_str());
+                    return {};
+                }
+            } catch (const std::exception&) {
                 LOG_ERROR("Invalid guidance value in guidance schedule: '%s'", guidance_str.c_str());
                 return {};
             }

--- a/src/runtime/guidance.cpp
+++ b/src/runtime/guidance.cpp
@@ -5,6 +5,8 @@
 #include <cstdlib>
 #include <string>
 #include <utility>
+#include <optional>
+#include <charconv>
 
 #include "core/util.h"
 
@@ -63,6 +65,82 @@ namespace sd::guidance {
         return uncond;
     }
 
+    std::vector<float> parse_guidance_schedule_from_spec(std::string spec) {
+        std::vector<float> schedule;
+
+        while (!spec.empty()) {
+            auto sep   = spec.find('+');
+            auto segment = spec.substr(0, sep);
+
+            auto x = segment.find('x');
+            if (x == std::string::npos) {
+                LOG_ERROR("Invalid guidance schedule segment: '%s' (expected <count>x<guidance>)", segment.c_str());
+                return {};
+            }
+
+            int count;
+            float guidance;
+
+            auto count_str    = segment.substr(0, x);
+            auto guidance_str = segment.substr(x + 1);
+
+            // Use std::from_chars for parsing
+            auto [count_ptr, count_ec] =
+                std::from_chars(count_str.data(),
+                                count_str.data() + count_str.size(),
+                                count);
+
+            if (count_ec != std::errc{} ||
+                count_ptr != count_str.data() + count_str.size()) {
+                LOG_ERROR("Invalid count in guidance schedule: '%s'", count_str.c_str());
+                return {};
+            }
+
+            auto [guidance_ptr, guidance_ec] =
+                std::from_chars(guidance_str.data(),
+                                guidance_str.data() + guidance_str.size(),
+                                guidance);
+
+            if (guidance_ec != std::errc{} ||
+                guidance_ptr != guidance_str.data() + guidance_str.size()) {
+                LOG_ERROR("Invalid guidance value in guidance schedule: '%s'", guidance_str.c_str());
+                return {};
+            }
+
+            if (count <= 0) {
+                LOG_ERROR("Guidance schedule count must be positive");
+                return {};
+            }
+
+            schedule.insert(schedule.end(), count, guidance);
+
+            if (sep == std::string::npos) {
+                break;
+            }
+
+            // Use substr to remove the processed part
+            spec = spec.substr(sep + 1);
+        }
+
+        return schedule;
+    }
+
+    std::vector<float> parse_guidance_schedule(const char* extra_sample_args) {
+        std::vector<float> guidance_schedule;
+        std::string guidance_schedule_str = "";
+         for (const auto& [key, value] : parse_key_value_args(extra_sample_args, "extra sample arg")) {
+            float parsed = 0.0f;
+            if (key == "guidance_schedule") {
+                guidance_schedule_str = value;
+            }
+        }
+
+        if (!guidance_schedule_str.empty()) {
+            guidance_schedule = parse_guidance_schedule_from_spec(guidance_schedule_str);
+        }
+        return guidance_schedule;
+    }
+
     ClassifierFreeGuidance::ClassifierFreeGuidance(float guidance_scale,
                                                    float image_guidance_scale)
         : guidance_scale_(guidance_scale),
@@ -70,8 +148,10 @@ namespace sd::guidance {
     }
 
     GuiderOutput ClassifierFreeGuidance::forward(const GuidanceInput& input,
-                                                 GuiderOutput previous) const {
+                                                 GuiderOutput previous,
+                                                std::optional<float> scale_override) const {
         (void)previous;
+        float guidance_scale       = scale_override.value_or(guidance_scale_);
 
         GuiderOutput output;
         if (!has_tensor(input.pred_cond)) {
@@ -86,14 +166,14 @@ namespace sd::guidance {
                 const sd::Tensor<float>& pred_img_uncond = *input.pred_img_uncond;
                 output.pred                              = pred_img_uncond +
                               image_guidance_scale_ * (pred_uncond - pred_img_uncond) +
-                              guidance_scale_ * (pred_cond - pred_uncond);
+                              guidance_scale * (pred_cond - pred_uncond);
 
             } else {
-                output.pred = pred_uncond + guidance_scale_ * (pred_cond - pred_uncond);
+                output.pred = pred_uncond + guidance_scale * (pred_cond - pred_uncond);
             }
         } else if (has_tensor(input.pred_img_uncond)) {
             const sd::Tensor<float>& pred_img_uncond = *input.pred_img_uncond;
-            output.pred                              = pred_img_uncond + guidance_scale_ * (pred_cond - pred_img_uncond);
+            output.pred                              = pred_img_uncond + guidance_scale * (pred_cond - pred_img_uncond);
         }
 
         return output;
@@ -128,8 +208,10 @@ namespace sd::guidance {
     }
 
     GuiderOutput AdaptiveProjectedGuidance::forward(const GuidanceInput& input,
-                                                    GuiderOutput previous) const {
+                                                    GuiderOutput previous,
+                                                    std::optional<float> scale_override) const {
         (void)previous;
+        float guidance_scale       = scale_override.value_or(guidance_scale_);
 
         GuiderOutput output;
         if (!has_tensor(input.pred_cond)) {
@@ -144,13 +226,13 @@ namespace sd::guidance {
                 const sd::Tensor<float>& pred_img_uncond = *input.pred_img_uncond;
                 output.pred                              = pred_img_uncond +
                               image_guidance_scale_ * (pred_uncond - pred_img_uncond) +
-                              guidance_scale_ * (pred_cond - pred_uncond);
+                              guidance_scale * (pred_cond - pred_uncond);
             } else {
-                output.pred = pred_uncond + guidance_scale_ * (pred_cond - pred_uncond);
+                output.pred = pred_uncond + guidance_scale * (pred_cond - pred_uncond);
             }
         } else if (has_tensor(input.pred_img_uncond)) {
             const sd::Tensor<float>& pred_img_uncond = *input.pred_img_uncond;
-            output.pred                              = pred_img_uncond + guidance_scale_ * (pred_cond - pred_img_uncond);
+            output.pred                              = pred_img_uncond + guidance_scale * (pred_cond - pred_img_uncond);
         }
         if (!has_tensor(input.pred_uncond) && !has_tensor(input.pred_img_uncond)) {
             return output;
@@ -162,7 +244,7 @@ namespace sd::guidance {
         sd::Tensor<float> deltas = calculate_guidance_delta(pred_cond,
                                                             pred_uncond,
                                                             pred_img_uncond,
-                                                            guidance_scale_,
+                                                            guidance_scale,
                                                             image_guidance_scale_);
         if (params_.momentum != 0.0f) {
             if (momentum_buffer_.shape() != deltas.shape()) {
@@ -239,7 +321,8 @@ namespace sd::guidance {
     }
 
     GuiderOutput SkipLayerGuidance::forward(const GuidanceInput& input,
-                                            GuiderOutput output) const {
+                                            GuiderOutput output,
+                                            std::optional<float> /*scale_override*/) const {
         if (scale_ == 0.0f || !is_enabled_for_step(input) || !input.predict_skip_layer) {
             return output;
         }

--- a/src/runtime/guidance.h
+++ b/src/runtime/guidance.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <functional>
 #include <vector>
+#include <optional>
 
 #include "core/tensor.hpp"
 
@@ -27,6 +28,7 @@ namespace sd::guidance {
     AdaptiveProjectedGuidanceParams parse_adaptive_projected_guidance_args(const char* extra_sample_args);
     bool is_adaptive_projected_guidance_enabled(const AdaptiveProjectedGuidanceParams& params);
     bool parse_skip_layer_guidance_uncond_arg(const char* extra_sample_args);
+    std::vector<float> parse_guidance_schedule(const char* extra_sample_args);
 
     struct GuidanceInput {
         int step                                 = 0;
@@ -42,7 +44,8 @@ namespace sd::guidance {
     public:
         virtual ~BaseGuidance()                                   = default;
         virtual GuiderOutput forward(const GuidanceInput& input,
-                                     GuiderOutput previous) const = 0;
+                                     GuiderOutput previous,
+                                     std::optional<float> scale_override = std::nullopt) const = 0;
     };
 
     class ClassifierFreeGuidance : public BaseGuidance {
@@ -54,7 +57,8 @@ namespace sd::guidance {
                                float image_guidance_scale);
 
         GuiderOutput forward(const GuidanceInput& input,
-                             GuiderOutput previous) const override;
+                             GuiderOutput previous,
+                             std::optional<float> scale_override = std::nullopt) const override;
     };
 
     class AdaptiveProjectedGuidance : public BaseGuidance {
@@ -69,7 +73,8 @@ namespace sd::guidance {
                                   AdaptiveProjectedGuidanceParams params);
 
         GuiderOutput forward(const GuidanceInput& input,
-                             GuiderOutput previous) const override;
+                             GuiderOutput previous,
+                             std::optional<float> scale_override = std::nullopt) const override;
     };
 
     class SkipLayerGuidance : public BaseGuidance {
@@ -88,7 +93,8 @@ namespace sd::guidance {
         const std::vector<int>& layers() const;
 
         GuiderOutput forward(const GuidanceInput& input,
-                             GuiderOutput previous) const override;
+                             GuiderOutput previous,
+                             std::optional<float> scale_override = std::nullopt) const override;
     };
 
 }  // namespace sd::guidance

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1943,14 +1943,14 @@ public:
         bool slg_uncond     = sd::guidance::parse_skip_layer_guidance_uncond_arg(extra_sample_args);
         
         std::vector<float> guidance_schedule = sd::guidance::parse_guidance_schedule(extra_sample_args);
-        if(!guidance_schedule.empty() && guidance_schedule.size() != sigmas.size()) {
+        if(!guidance_schedule.empty() && guidance_schedule.size() != sigmas.size() - 1) {
             if(guidance_schedule.size() > sigmas.size()) {
-                LOG_WARN("guidance_schedule length (%zu) is greater than sigmas length (%zu)", guidance_schedule.size(), sigmas.size());
-                LOG_WARN("truncating guidance_schedule to match sigmas length");
-                guidance_schedule.resize(sigmas.size());
+                LOG_WARN("guidance_schedule length (%zu) is greater than number of steps (%zu)", guidance_schedule.size(), sigmas.size() - 1);
+                LOG_WARN("truncating guidance_schedule to match step count");
+                guidance_schedule.resize(sigmas.size() - 1);
             } else {
                 LOG_INFO("padding guidance_schedule with cfg_scale");
-                while(guidance_schedule.size() < sigmas.size()) {
+                while(guidance_schedule.size() < sigmas.size() - 1) {
                     guidance_schedule.push_back(cfg_scale);
                 }
             }

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1956,6 +1956,18 @@ public:
             }
         }
 
+        if(!guidance_schedule.empty()) {
+            std::string schedule_str = "[";
+            for(size_t i = 0; i < guidance_schedule.size(); ++i) {
+                schedule_str += std::to_string(guidance_schedule[i]);
+                if(i < guidance_schedule.size() - 1) {
+                    schedule_str += ", ";
+                }
+            }
+            schedule_str += "]";
+            LOG_DEBUG("using guidance schedule: %s", schedule_str.c_str());
+        }
+
         sd_sample::SampleCacheRuntime cache_runtime = sd_sample::init_sample_cache_runtime(version,
                                                                                            cache_params,
                                                                                            denoiser.get(),

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1941,6 +1941,20 @@ public:
         float img_cfg_scale = guidance.img_cfg;
         float slg_scale     = guidance.slg.scale;
         bool slg_uncond     = sd::guidance::parse_skip_layer_guidance_uncond_arg(extra_sample_args);
+        
+        std::vector<float> guidance_schedule = sd::guidance::parse_guidance_schedule(extra_sample_args);
+        if(!guidance_schedule.empty() && guidance_schedule.size() != sigmas.size()) {
+            if(guidance_schedule.size() > sigmas.size()) {
+                LOG_WARN("guidance_schedule length (%zu) is greater than sigmas length (%zu)", guidance_schedule.size(), sigmas.size());
+                LOG_WARN("truncating guidance_schedule to match sigmas length");
+                guidance_schedule.resize(sigmas.size());
+            } else {
+                LOG_INFO("padding guidance_schedule with cfg_scale");
+                while(guidance_schedule.size() < sigmas.size()) {
+                    guidance_schedule.push_back(cfg_scale);
+                }
+            }
+        }
 
         sd_sample::SampleCacheRuntime cache_runtime = sd_sample::init_sample_cache_runtime(version,
                                                                                            cache_params,
@@ -2182,7 +2196,9 @@ public:
             guidance_input.pred_uncond     = uncond_out.empty() ? nullptr : &uncond_out;
             guidance_input.pred_img_uncond = img_uncond_out.empty() ? nullptr : &img_uncond_out;
 
-            sd::guidance::GuiderOutput guided = primary_guidance.forward(guidance_input, {});
+            sd::guidance::GuiderOutput guided =  guidance_schedule.empty()? 
+                                            primary_guidance.forward(guidance_input, {}):
+                                            primary_guidance.forward(guidance_input, {}, guidance_schedule[guidance_schedule.size() - 1 - step]);
             if (guided.pred.empty()) {
                 return {};
             }


### PR DESCRIPTION
## Summary

Supports a new `guidance_schedule` parameter (under `--extra-sample-args`) to improve Ideogram4 support. This could also benefit other models.

**What it does:** Allows the guidance (CFG scale) to change throughout the denoising process. For example, you can use lower guidance values during the final "polishing" steps to help reduce artifacts.

**Format:** `<guidance>x<steps>[+<guidance>x<steps>...]`

Examples:

* `30x7.5` → use CFG scale `7.5` for the final 30 denoising steps.
* `10x5.0+20x7.5` → use CFG scale `5.0` for the last 10 steps, and `7.5` for the 20 steps before that.
* `10x4+10x6+10x8` → use CFG scale `4` for the last 10 steps, `6` for the preceding 10 steps, and `8` for the 10 steps before that.

**Note:** The schedule is applied in reverse order: the first entry corresponds to the final denoising steps, not the initial ones.

If the schedule contains fewer entries than the total number of denoising steps, the regular CFG scale parameter is used for the remaining earlier steps. If it contains more entries than there are denoising steps, the extra entries are ignored.

## Related Issue / Discussion

<!-- Link related issues, discussions, or previous PRs if applicable. -->
N/A

## Additional Information

Recommended Values for Ideogram4 (source: https://github.com/ideogram-oss/ideogram4/blob/main/src/ideogram4/sampler_configs.py)

- 48 steps: `3.0x3+7.0x45`
- 20 steps: `3.0x2+7.0x18`
- 12 steps: `3.0x1+7.0x11`

(since 7.0 is the default CFG scale, you can get away with just `3.0xN` and the rest will be padded with `7.0` anyways)

Examples: (generated with https://github.com/leejet/stable-diffusion.cpp/pull/1669 also applied)

| No guidance schedule | Recommended schedule |
| -- | -- |
| <img width="1024" height="1536" alt="guidance_schedule_off" src="https://github.com/user-attachments/assets/c335e098-4116-4266-8149-4b50eb12f48c" /> | <img width="1024" height="1536" alt="guidance_schedule_on" src="https://github.com/user-attachments/assets/c031c905-54d7-45b1-a3d3-2d19d2ae3e56" /> |
| <img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/939c888e-c96e-44e5-85e0-9a35b37e63b5" /> | <img width="1024" height="1024" alt="output" src="https://github.com/user-attachments/assets/bf826e8e-1934-406e-9728-8ada4f5093be" /> |

<details>
<summary> Commands used </summary>

`.\buildhip\bin\sd-cli.exe -h --diffusion-model ..\ComfyUI\models\unet\Ideogram\ideogram4-Q8_0.gguf --uncond-diffusion-model ..\ComfyUI\models\unet\Ideogram\ideogram4_unconditional-iQ4_NL.gguf   --llm ..\ComfyUI\models\llm\Qwen\Qwen3-VL-8B-Instruct-Q4_K_M.gguf --vae ..\ComfyUI\models\vae\flux\full_encoder_small_decoder.safetensors --diffusion-fa -v --color --offload-to-cpu -W 1024 -H 1536 --preview proj --steps 20 --extra-sample-args "guidance_schedule=3x2"  -p --% "{\"aspect_ratio\":\"2:3\",\"high_level_description\":\"An abstract, dreamlike digital illustration of Hatsune Miku surrounded by swirling energy and power elements in a vibrant blue color palette.\",\"compositional_deconstruction\":{\"background\":\"An abstract, ethereal void filled with deep indigo and electric blue gradients, featuring floating geometric shards, swirling energy ribbons, and soft bokeh particles that create a sense of weightless, dreamlike depth.\",\"elements\":[{\"type\":\"obj\",\"bbox\":[120,250,880,750],\"desc\":\"Hatsune Miku, depicted with delicate linework. She has long, wind-swept teal twin-tails flowing dynamically around her. Her eyes feature striking white pupils against a vivid blue iris. She wears her signature futuristic grey and teal outfit with glowing accents, her expression one of focused intensity.\"},{\"type\":\"obj\",\"bbox\":[450,400,600,550],\"desc\":\"A sleek, futuristic silver and teal microphone held close to Miku's mouth, emitting small arcs of blue electricity.\"},{\"type\":\"obj\",\"bbox\":[100,100,900,900],\"desc\":\"Swirling power elements consisting of jagged electric bolts and flowing neon-blue energy ribbons that spiral around the central figure, emphasizing a sense of raw energy and movement.\"}]}}"`

`\buildhip\bin\sd-cli.exe --diffusion-model ..\ComfyUI\models\unet\Ideogram\ideogram4-Q8_0.gguf --uncond-diffusion-model ..\ComfyUI\models\unet\Ideogram\ideogram4_unconditional-iQ4_NL.gguf   --llm ..\ComfyUI\models\llm\Qwen\Qwen3-VL-8B-Instruct-Q4_K_M.gguf --vae ..\ComfyUI\models\vae\flux\full_encoder_small_decoder.safetensors --diffusion-fa -v --color --offload-to-cpu -W 1024 -H 1024 --preview proj --steps 12 --extra-sample-args "mu=0.5,std=1.75;guidance_schedule=3x1"  -p --% "{\"high_level_description\":\"A square 1024 x 1024 luxury fashion magazine cover featuring exactly one short chubby fluffy cat as the main model. The cat sits on a soft ivory studio floor, facing the viewer with a stylish calm expression, wearing tiny black sunglasses, a red silk scarf, and a small gold collar charm. In front of the cat on the floor is a wide horizontal luxury nameplate that clearly reads ideogram4.cpp. The whole design feels premium, fashionable, clean, and editorial.\",\"style_description\":{\"aesthetics\":\"luxury fashion magazine cover, high-end pet couture campaign, minimalist editorial design, elegant studio photography, soft paper texture, refined typography, fashionable and polished\",\"lighting\":\"Soft diffused studio lighting, gentle spotlight on the cat, subtle floor shadow, warm ivory highlights, clean separation between subject and background\",\"photo\":\"high-resolution fashion editorial photography look, front-facing cat portrait, crisp fur details, glossy sunglasses, clear readable nameplate text, shallow depth of field\",\"medium\":\"mixed media fashion photography and premium editorial graphic design\",\"color_palette\":[\"#F4EFE7\",\"#111111\",\"#D8B56D\",\"#B73A3A\",\"#FFFFFF\",\"#8A7A6A\"]},\"compositional_deconstruction\":{\"canvas\":\"Square 1024 x 1024 canvas with a normal upright orientation. Do not rotate the poster or any text. Use a clean fashion magazine cover layout.\",\"background\":\"Warm ivory studio backdrop with subtle paper grain, a soft spotlight gradient, faint floor shadow, and a few minimal gold editorial lines. The background is spacious, premium, and uncluttered.\",\"layout\":\"Top center has a small elegant headline. Center area features one cat as the main fashion model. Lower foreground has a wide horizontal luxury nameplate placed on the floor in front of the cat. Bottom center has a small footer. All text is horizontal, upright, and readable left to right.\",\"elements\":[{\"type\":\"text\",\"desc\":\"Top center headline reading LOOK WHAT I FOUND in a refined high-fashion serif font. The headline is horizontal, centered, elegant, and secondary to the nameplate text.\"},{\"type\":\"obj\",\"desc\":\"Exactly one short chubby fluffy cat sitting in the center like a luxury fashion model. The cat has a large round head, compact body, short legs, soft detailed fur, expressive eyes, and a calm confident pose. The cat is cute and rounded, not tall, not stretched, not duplicated.\"},{\"type\":\"obj\",\"desc\":\"Tiny glossy black sunglasses worn naturally by the cat, slightly oversized but still showing the cat face clearly. The sunglasses add a chic fashion-editorial attitude.\"},{\"type\":\"obj\",\"desc\":\"A red silk scarf tied neatly around the cat neck, with soft folds and a couture feeling. The scarf must not cover the cat face or the nameplate.\"},{\"type\":\"obj\",\"desc\":\"A small gold collar charm or fashion accessory under the scarf, subtle and premium, adding a luxury campaign detail.\"},{\"type\":\"obj\",\"desc\":\"In the lower foreground, place a wide horizontal luxury nameplate on the floor in front of the cat. The nameplate is low, flat, landscape-oriented, much wider than tall, like a fashion show seat card or premium display plaque. It is centered, front-facing, level, and fully visible. It must not become vertical, tall, standing, rotated, or side-facing.\"},{\"type\":\"text\",\"desc\":\"Print the exact text ideogram4.cpp only on the wide horizontal nameplate. Use clean bold black lettering, perfectly spelled, lowercase, with the number 4 and .cpp extension. The text must fit completely inside the nameplate, stay horizontal, and be readable from left to right.\"},{\"type\":\"obj\",\"desc\":\"Add sparse premium editorial accents around the edges: thin gold lines, small code brackets, tiny cursor marks, subtle dots, and minimal geometric details. No extra cats, no stickers, no animal faces, no busy decorations.\"},{\"type\":\"text\",\"desc\":\"Bottom center footer reading tiny paws, big compile energy in a small refined monospace or editorial font. The footer is horizontal, centered, understated, and much smaller than the nameplate text.\"}]}}"
`
</details>


<!-- Add verification notes, screenshots, sample output, or other context when applicable. -->

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
