### PR TITLE
feat: add --prompt-file and --negative-prompt-file flags

### DIFF
--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <regex>
@@ -1415,6 +1416,42 @@ ArgOptions SDGenerationParams::get_options() {
         return 1;
     };
 
+    auto on_prompt_file_arg = [&](int argc, const char** argv, int index) {
+        if (++index >= argc) {
+            return -1;
+        }
+        const char* arg = argv[index];
+        std::ifstream f(arg, std::ios::binary);
+        try {
+            prompt = std::string(std::istreambuf_iterator<char>{f}, {});
+        } catch (const std::ios_base::failure&) {
+            f.setstate(std::ios_base::failbit);
+        }
+        if (f.fail()) {
+            LOG_ERROR("error: failed to read prompt file '%s'\n", arg);
+            return -1;
+        }
+        return 1;
+    };
+
+    auto on_negative_prompt_file_arg = [&](int argc, const char** argv, int index) {
+        if (++index >= argc) {
+            return -1;
+        }
+        const char* arg = argv[index];
+        std::ifstream f(arg, std::ios::binary);
+        try {
+            negative_prompt = std::string(std::istreambuf_iterator<char>{f}, {});
+        } catch (const std::ios_base::failure&) {
+            f.setstate(std::ios_base::failbit);
+        }
+        if (f.fail()) {
+            LOG_ERROR("error: failed to read negative prompt file '%s'\n", arg);
+            return -1;
+        }
+        return 1;
+    };
+
     options.manual_options = {
         {"-s",
          "--seed",
@@ -1478,6 +1515,14 @@ ArgOptions SDGenerationParams::get_options() {
          "--vae-relative-tile-size",
          "relative tile size for vae tiling, format [X]x[Y], in fraction of image size if < 1, in number of tiles per dim if >=1 (overrides --vae-tile-size)",
          on_relative_tile_size_arg},
+        {"",
+         "--prompt-file",
+         "path to the file containing the prompt to render",
+         on_prompt_file_arg},
+        {"",
+         "--negative-prompt-file",
+         "path to the file containing the negative prompt",
+         on_negative_prompt_file_arg},
 
     };
 


### PR DESCRIPTION
as an alternative to passing long strings to the --prompt and --negative-prompt flags.

## Summary
What: Provide alternative flags that populate the `prompt` and `negative_prompt` variables from file content.
Why: Putting the prompts in files makes them easier to edit and leak less info on a multi-user system.

Granted, there are other ways to accomplish those goals, but I found this to be the best for my use case. I've been maintaining a patch locally for ~2 months now.

## Related Issue / Discussion
https://github.com/leejet/stable-diffusion.cpp/issues/1199 was filed by someone else near the start of the year, so I'm probably not the only one who wants this feature.

## Additional Information
I tested manually with good cases:
- file exists
- /dev/stdin

I also tested some error cases to make sure it doesn't crash or silently succeed:
- file not found
- no read permission
- broken symlink
- directory instead of file

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
