### PR TITLE
ci: adopt dynamic cpu backends on released binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,7 +341,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - build: "cpuonly"
+          - build: "cpu"
             defines: "-DGGML_NATIVE=OFF -DSD_BUILD_SHARED_LIBS=ON -DSD_BUILD_SHARED_GGML_LIB=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON"
           - build: "cuda12"
             defines: "-DSD_CUDA=ON -DSD_BUILD_SHARED_LIBS=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90;100;120' -DCMAKE_CUDA_FLAGS='-Xcudafe \"--diag_suppress=177\" -Xcudafe \"--diag_suppress=550\"' -DGGML_NATIVE=OFF -DSD_BUILD_SHARED_GGML_LIB=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -510,7 +510,6 @@ jobs:
             -DSD_HIPBLAS=ON `
             -DSD_BUILD_SHARED_LIBS=ON `
             -DGGML_NATIVE=OFF `
-            -DSD_BUILD_SHARED_GGML_LIB=ON `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang.exe" `
             -DCMAKE_CXX_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang++.exe" `
             -DCMAKE_HIP_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang.exe" `
@@ -639,9 +638,6 @@ jobs:
             -DSD_HIPBLAS=ON `
             -DSD_BUILD_SHARED_LIBS=ON `
             -DGGML_NATIVE=OFF `
-            -DSD_BUILD_SHARED_GGML_LIB=ON `
-            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON `
-            -DCMAKE_INSTALL_RPATH='$ORIGIN' `
             -DCMAKE_C_COMPILER=clang `
             -DCMAKE_CXX_COMPILER=clang++ `
             -DCMAKE_BUILD_TYPE=Release `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,20 @@ jobs:
         with:
           version: 10.15.1
 
+      - name: Free disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo apt-get clean
+
+          echo "After cleanup:"
+          df -h
+
       - name: Dependencies
         id: depends
         run: |
@@ -134,6 +148,20 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 10.15.1
+
+      - name: Free disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo apt-get clean
+
+          echo "After cleanup:"
+          df -h
 
       - name: Dependencies
         id: depends
@@ -256,6 +284,9 @@ jobs:
           # if set to "true" but frees about 6 GB
           tool-cache: false
 
+      - name: Check disk space
+        run: df -h
+
       - name: Build and push Docker image
         id: build-push
         uses: docker/build-push-action@v6
@@ -364,6 +395,11 @@ jobs:
         with:
           version: 10.15.1
 
+      - name: Check disk space before dependencies
+        run: |
+          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
+          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
+
       - name: Install cuda-toolkit
         id: cuda-toolkit
         if: ${{ matrix.build == 'cuda12' }}
@@ -381,6 +417,11 @@ jobs:
           & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
           Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
+
+      - name: Check disk space before build
+        run: |
+          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
+          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
 
       - name: Activate MSVC environment
         id: msvc_dev_cmd
@@ -466,6 +507,11 @@ jobs:
         with:
           version: 10.15.1
 
+      - name: Check disk space before ROCm setup
+        run: |
+          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
+          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
+
       - name: Cache ROCm Installation
         id: cache-rocm
         uses: actions/cache@v4
@@ -489,6 +535,11 @@ jobs:
           mkdir C:\TheRock\build -Force
           tar -xzf "${env:RUNNER_TEMP}\rocm.tar.gz" -C C:\TheRock\build --strip-components=1
           write-host "Completed ROCm extraction"
+
+      - name: Check disk space after ROCm setup
+        run: |
+          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
+          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
 
       - name: Setup ROCm Environment
         run: |
@@ -586,6 +637,11 @@ jobs:
         with:
           version: 10.15.1
 
+      - name: Check disk space before ROCm setup
+        run: |
+          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
+          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
+
       - name: Cache ROCm Installation
         id: cache-rocm
         uses: actions/cache@v4
@@ -618,6 +674,11 @@ jobs:
               exit 1
           }
           write-host "Completed AMD HIP SDK installation"
+
+      - name: Check disk space after ROCm setup
+        run: |
+          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
+          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
 
       - name: Verify ROCm
         run: |
@@ -711,6 +772,25 @@ jobs:
         run: |
           sudo apt install -y build-essential cmake wget zip ninja-build
 
+      - name: Free disk space
+        run: |
+          echo "Before cleanup:"
+          df -h
+
+          # Remove preinstalled SDKs and caches not needed for this job.
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache || true
+
+          # Remove old package lists and caches before the large ROCm install.
+          sudo rm -rf /var/lib/apt/lists/* || true
+          sudo apt-get clean
+
+          echo "After cleanup:"
+          df -h
+
       - name: Setup Legacy ROCm
         if: matrix.ROCM_VERSION == '7.2.1'
         id: legacy_env
@@ -731,19 +811,6 @@ jobs:
 
           sudo apt update
           sudo apt-get install -y libssl-dev rocm-hip-sdk
-
-      - name: Free disk space
-        run: |
-          # Remove preinstalled SDKs and caches not needed for this job
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo rm -rf /opt/hostedtoolcache || true
-
-          # Remove old package lists and caches
-          sudo rm -rf /var/lib/apt/lists/* || true
-          sudo apt clean
 
       - name: Setup TheRock
         if: matrix.ROCM_VERSION != '7.2.1'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -519,24 +519,7 @@ jobs:
             -DHIP_PATH="${env:HIP_PATH}" `
             -DCMAKE_BUILD_TYPE=Release `
             -DGPU_TARGETS="${{ env.GPU_TARGETS }}"
-          cmake --build . --config Release --parallel 1 --verbose 2>&1 | Tee-Object -FilePath build.log
-          $buildExitCode = $LASTEXITCODE
-          if ($buildExitCode -ne 0) {
-            Write-Host "Build failed. First matching error context from build.log:"
-            Select-String -Path build.log -Pattern 'error:|fatal error|FAILED:|No space left|Access is denied|undefined reference|unresolved external|LNK[0-9]+|C[0-9]{4}' -Context 5,8 | Select-Object -First 80
-            exit $buildExitCode
-          }
-
-      - name: Upload build logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-therock-rocm-build-logs
-          path: |
-            build/build.log
-            build/CMakeFiles/CMakeOutput.log
-            build/CMakeFiles/CMakeError.log
-          if-no-files-found: ignore
+          cmake --build . --config Release --parallel ${env:NUMBER_OF_PROCESSORS}
 
       - name: Get commit hash
         id: commit
@@ -667,24 +650,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++ `
             -DCMAKE_BUILD_TYPE=Release `
             -DGPU_TARGETS="${{ env.GPU_TARGETS }}"
-          cmake --build . --config Release --parallel 1 --verbose 2>&1 | Tee-Object -FilePath build.log
-          $buildExitCode = $LASTEXITCODE
-          if ($buildExitCode -ne 0) {
-            Write-Host "Build failed. First matching error context from build.log:"
-            Select-String -Path build.log -Pattern 'error:|fatal error|FAILED:|No space left|Access is denied|undefined reference|unresolved external|LNK[0-9]+|C[0-9]{4}' -Context 5,8 | Select-Object -First 80
-            exit $buildExitCode
-          }
-
-      - name: Upload build logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows-hip-sdk-build-logs
-          path: |
-            build/build.log
-            build/CMakeFiles/CMakeOutput.log
-            build/CMakeFiles/CMakeError.log
-          if-no-files-found: ignore
+          cmake --build . --config Release --parallel ${env:NUMBER_OF_PROCESSORS}
 
       - name: Get commit hash
         id: commit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -511,8 +511,6 @@ jobs:
             -DSD_BUILD_SHARED_LIBS=ON `
             -DGGML_NATIVE=OFF `
             -DSD_BUILD_SHARED_GGML_LIB=ON `
-            -DGGML_BACKEND_DL=ON `
-            -DGGML_CPU_ALL_VARIANTS=ON `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang.exe" `
             -DCMAKE_CXX_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang++.exe" `
             -DCMAKE_HIP_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang.exe" `
@@ -642,8 +640,6 @@ jobs:
             -DSD_BUILD_SHARED_LIBS=ON `
             -DGGML_NATIVE=OFF `
             -DSD_BUILD_SHARED_GGML_LIB=ON `
-            -DGGML_BACKEND_DL=ON `
-            -DGGML_CPU_ALL_VARIANTS=ON `
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON `
             -DCMAKE_INSTALL_RPATH='$ORIGIN' `
             -DCMAKE_C_COMPILER=clang `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,20 +72,6 @@ jobs:
         with:
           version: 10.15.1
 
-      - name: Free disk space
-        run: |
-          echo "Before cleanup:"
-          df -h
-
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo apt-get clean
-
-          echo "After cleanup:"
-          df -h
-
       - name: Dependencies
         id: depends
         run: |
@@ -148,20 +134,6 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 10.15.1
-
-      - name: Free disk space
-        run: |
-          echo "Before cleanup:"
-          df -h
-
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo apt-get clean
-
-          echo "After cleanup:"
-          df -h
 
       - name: Dependencies
         id: depends
@@ -284,9 +256,6 @@ jobs:
           # if set to "true" but frees about 6 GB
           tool-cache: false
 
-      - name: Check disk space
-        run: df -h
-
       - name: Build and push Docker image
         id: build-push
         uses: docker/build-push-action@v6
@@ -395,11 +364,6 @@ jobs:
         with:
           version: 10.15.1
 
-      - name: Check disk space before dependencies
-        run: |
-          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
-          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
-
       - name: Install cuda-toolkit
         id: cuda-toolkit
         if: ${{ matrix.build == 'cuda12' }}
@@ -417,11 +381,6 @@ jobs:
           & "$env:RUNNER_TEMP\VulkanSDK-Installer.exe" --accept-licenses --default-answer --confirm-command install
           Add-Content $env:GITHUB_ENV "VULKAN_SDK=C:\VulkanSDK\${env:VULKAN_VERSION}"
           Add-Content $env:GITHUB_PATH "C:\VulkanSDK\${env:VULKAN_VERSION}\bin"
-
-      - name: Check disk space before build
-        run: |
-          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
-          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
 
       - name: Activate MSVC environment
         id: msvc_dev_cmd
@@ -507,11 +466,6 @@ jobs:
         with:
           version: 10.15.1
 
-      - name: Check disk space before ROCm setup
-        run: |
-          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
-          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
-
       - name: Cache ROCm Installation
         id: cache-rocm
         uses: actions/cache@v4
@@ -535,11 +489,6 @@ jobs:
           mkdir C:\TheRock\build -Force
           tar -xzf "${env:RUNNER_TEMP}\rocm.tar.gz" -C C:\TheRock\build --strip-components=1
           write-host "Completed ROCm extraction"
-
-      - name: Check disk space after ROCm setup
-        run: |
-          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
-          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
 
       - name: Setup ROCm Environment
         run: |
@@ -637,11 +586,6 @@ jobs:
         with:
           version: 10.15.1
 
-      - name: Check disk space before ROCm setup
-        run: |
-          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
-          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
-
       - name: Cache ROCm Installation
         id: cache-rocm
         uses: actions/cache@v4
@@ -674,11 +618,6 @@ jobs:
               exit 1
           }
           write-host "Completed AMD HIP SDK installation"
-
-      - name: Check disk space after ROCm setup
-        run: |
-          [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.DriveType -eq 'Fixed' -and $_.IsReady } | Select-Object Name, @{Name="TotalGB"; Expression={[math]::Round($_.TotalSize / 1GB, 2)}}, @{Name="FreeGB"; Expression={[math]::Round($_.AvailableFreeSpace / 1GB, 2)}} | Format-Table -AutoSize
-          Write-Host "RUNNER_TEMP=$env:RUNNER_TEMP"
 
       - name: Verify ROCm
         run: |
@@ -772,25 +711,6 @@ jobs:
         run: |
           sudo apt install -y build-essential cmake wget zip ninja-build
 
-      - name: Free disk space
-        run: |
-          echo "Before cleanup:"
-          df -h
-
-          # Remove preinstalled SDKs and caches not needed for this job.
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo rm -rf /opt/hostedtoolcache || true
-
-          # Remove old package lists and caches before the large ROCm install.
-          sudo rm -rf /var/lib/apt/lists/* || true
-          sudo apt-get clean
-
-          echo "After cleanup:"
-          df -h
-
       - name: Setup Legacy ROCm
         if: matrix.ROCM_VERSION == '7.2.1'
         id: legacy_env
@@ -811,6 +731,19 @@ jobs:
 
           sudo apt update
           sudo apt-get install -y libssl-dev rocm-hip-sdk
+
+      - name: Free disk space
+        run: |
+          # Remove preinstalled SDKs and caches not needed for this job
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache || true
+
+          # Remove old package lists and caches
+          sudo rm -rf /var/lib/apt/lists/* || true
+          sudo apt clean
 
       - name: Setup TheRock
         if: matrix.ROCM_VERSION != '7.2.1'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -519,7 +519,24 @@ jobs:
             -DHIP_PATH="${env:HIP_PATH}" `
             -DCMAKE_BUILD_TYPE=Release `
             -DGPU_TARGETS="${{ env.GPU_TARGETS }}"
-          cmake --build . --config Release --parallel ${env:NUMBER_OF_PROCESSORS}
+          cmake --build . --config Release --parallel 1 --verbose 2>&1 | Tee-Object -FilePath build.log
+          $buildExitCode = $LASTEXITCODE
+          if ($buildExitCode -ne 0) {
+            Write-Host "Build failed. First matching error context from build.log:"
+            Select-String -Path build.log -Pattern 'error:|fatal error|FAILED:|No space left|Access is denied|undefined reference|unresolved external|LNK[0-9]+|C[0-9]{4}' -Context 5,8 | Select-Object -First 80
+            exit $buildExitCode
+          }
+
+      - name: Upload build logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-therock-rocm-build-logs
+          path: |
+            build/build.log
+            build/CMakeFiles/CMakeOutput.log
+            build/CMakeFiles/CMakeError.log
+          if-no-files-found: ignore
 
       - name: Get commit hash
         id: commit
@@ -650,7 +667,24 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++ `
             -DCMAKE_BUILD_TYPE=Release `
             -DGPU_TARGETS="${{ env.GPU_TARGETS }}"
-          cmake --build . --config Release --parallel ${env:NUMBER_OF_PROCESSORS}
+          cmake --build . --config Release --parallel 1 --verbose 2>&1 | Tee-Object -FilePath build.log
+          $buildExitCode = $LASTEXITCODE
+          if ($buildExitCode -ne 0) {
+            Write-Host "Build failed. First matching error context from build.log:"
+            Select-String -Path build.log -Pattern 'error:|fatal error|FAILED:|No space left|Access is denied|undefined reference|unresolved external|LNK[0-9]+|C[0-9]{4}' -Context 5,8 | Select-Object -First 80
+            exit $buildExitCode
+          }
+
+      - name: Upload build logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-hip-sdk-build-logs
+          path: |
+            build/build.log
+            build/CMakeFiles/CMakeOutput.log
+            build/CMakeFiles/CMakeError.log
+          if-no-files-found: ignore
 
       - name: Get commit hash
         id: commit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -707,6 +707,25 @@ jobs:
         run: |
           sudo apt install -y build-essential cmake wget zip ninja-build
 
+      - name: Free disk space
+        run: |
+          df -h
+
+          # Remove preinstalled SDKs and caches not needed for this job before
+          # installing ROCm. The legacy ROCm apt packages are large enough to
+          # exhaust ubuntu-latest if cleanup runs after installation.
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache || true
+          sudo rm -rf /usr/share/swift || true
+          sudo rm -rf /usr/local/share/boost || true
+          docker system prune -af || true
+
+          sudo apt clean
+          df -h
+
       - name: Setup Legacy ROCm
         if: matrix.ROCM_VERSION == '7.2.1'
         id: legacy_env
@@ -727,19 +746,6 @@ jobs:
 
           sudo apt update
           sudo apt-get install -y libssl-dev rocm-hip-sdk
-
-      - name: Free disk space
-        run: |
-          # Remove preinstalled SDKs and caches not needed for this job
-          sudo rm -rf /usr/share/dotnet || true
-          sudo rm -rf /usr/local/lib/android || true
-          sudo rm -rf /opt/ghc || true
-          sudo rm -rf /usr/local/.ghcup || true
-          sudo rm -rf /opt/hostedtoolcache || true
-
-          # Remove old package lists and caches
-          sudo rm -rf /var/lib/apt/lists/* || true
-          sudo apt clean
 
       - name: Setup TheRock
         if: matrix.ROCM_VERSION != '7.2.1'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DGGML_AVX2=ON -DSD_BUILD_SHARED_LIBS=ON
+          cmake .. -DSD_BUILD_SHARED_LIBS=ON -DGGML_NATIVE=OFF -DSD_BUILD_SHARED_GGML_LIB=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
           cmake --build . --config Release
 
       - name: Get commit hash
@@ -146,7 +146,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DSD_BUILD_SHARED_LIBS=ON -DSD_VULKAN=ON
+          cmake .. -DSD_BUILD_SHARED_LIBS=ON -DSD_VULKAN=ON -DGGML_NATIVE=OFF -DSD_BUILD_SHARED_GGML_LIB=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DCMAKE_INSTALL_RPATH='$ORIGIN'
           cmake --build . --config Release
 
       - name: Get commit hash
@@ -341,18 +341,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - build: "noavx"
-            defines: "-DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DSD_BUILD_SHARED_LIBS=ON"
-          - build: "avx2"
-            defines: "-DGGML_NATIVE=OFF -DGGML_AVX2=ON -DSD_BUILD_SHARED_LIBS=ON"
-          - build: "avx"
-            defines: "-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=OFF -DSD_BUILD_SHARED_LIBS=ON"
-          - build: "avx512"
-            defines: "-DGGML_NATIVE=OFF -DGGML_AVX512=ON -DGGML_AVX=ON -DGGML_AVX2=ON -DSD_BUILD_SHARED_LIBS=ON"
+          - build: "cpuonly"
+            defines: "-DGGML_NATIVE=OFF -DSD_BUILD_SHARED_LIBS=ON -DSD_BUILD_SHARED_GGML_LIB=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON"
           - build: "cuda12"
-            defines: "-DSD_CUDA=ON -DSD_BUILD_SHARED_LIBS=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90;100;120' -DCMAKE_CUDA_FLAGS='-Xcudafe \"--diag_suppress=177\" -Xcudafe \"--diag_suppress=550\"'"
+            defines: "-DSD_CUDA=ON -DSD_BUILD_SHARED_LIBS=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90;100;120' -DCMAKE_CUDA_FLAGS='-Xcudafe \"--diag_suppress=177\" -Xcudafe \"--diag_suppress=550\"' -DGGML_NATIVE=OFF -DSD_BUILD_SHARED_GGML_LIB=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON"
           - build: "vulkan"
-            defines: "-DSD_VULKAN=ON -DSD_BUILD_SHARED_LIBS=ON"
+            defines: "-DSD_VULKAN=ON -DSD_BUILD_SHARED_LIBS=ON -DGGML_NATIVE=OFF -DSD_BUILD_SHARED_GGML_LIB=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON"
     steps:
       - name: Clone
         id: checkout
@@ -399,19 +393,6 @@ jobs:
           cd build
           cmake .. -DCMAKE_CXX_FLAGS='/bigobj' -G Ninja -DCMAKE_C_COMPILER=cl.exe -DCMAKE_CXX_COMPILER=cl.exe -DCMAKE_BUILD_TYPE=Release ${{ matrix.defines }}
           cmake --build .
-
-      - name: Check AVX512F support
-        id: check_avx512f
-        if: ${{ matrix.build == 'avx512' }}
-        continue-on-error: true
-        run: |
-          cd build
-          $vcdir = $(vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath)
-          $msvc = $(join-path $vcdir $('VC\Tools\MSVC\'+$(gc -raw $(join-path $vcdir 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt')).Trim()))
-          $cl =  $(join-path $msvc 'bin\Hostx64\x64\cl.exe')
-          echo 'int main(void){unsigned int a[4];__cpuid(a,7);return !(a[1]&65536);}' >> avx512f.c
-          & $cl /O2 /GS- /kernel avx512f.c /link /nodefaultlib /entry:main
-          .\avx512f.exe && echo "AVX512F: YES" && ( echo HAS_AVX512F=1 >> $env:GITHUB_ENV ) || echo "AVX512F: NO"
 
       - name: Get commit hash
         id: commit
@@ -529,6 +510,9 @@ jobs:
             -DSD_HIPBLAS=ON `
             -DSD_BUILD_SHARED_LIBS=ON `
             -DGGML_NATIVE=OFF `
+            -DSD_BUILD_SHARED_GGML_LIB=ON `
+            -DGGML_BACKEND_DL=ON `
+            -DGGML_CPU_ALL_VARIANTS=ON `
             -DCMAKE_C_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang.exe" `
             -DCMAKE_CXX_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang++.exe" `
             -DCMAKE_HIP_COMPILER="${env:HIP_PATH}\lib\llvm\bin\clang.exe" `
@@ -657,6 +641,11 @@ jobs:
             -DSD_HIPBLAS=ON `
             -DSD_BUILD_SHARED_LIBS=ON `
             -DGGML_NATIVE=OFF `
+            -DSD_BUILD_SHARED_GGML_LIB=ON `
+            -DGGML_BACKEND_DL=ON `
+            -DGGML_CPU_ALL_VARIANTS=ON `
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON `
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' `
             -DCMAKE_C_COMPILER=clang `
             -DCMAKE_CXX_COMPILER=clang++ `
             -DCMAKE_BUILD_TYPE=Release `
@@ -794,6 +783,11 @@ jobs:
             -DGPU_TARGETS="${{ matrix.gpu_targets }}" \
             -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DGGML_NATIVE=OFF \
+            -DSD_BUILD_SHARED_GGML_LIB=ON \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_CPU_ALL_VARIANTS=ON \
             -DSD_BUILD_SHARED_LIBS=ON
           cmake --build . --config Release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,14 @@ WORKDIR /sd.cpp
 
 COPY . .
 
-RUN cmake . -B ./build
+RUN cmake . -B ./build \
+    -DSD_BUILD_SHARED_LIBS=ON \
+    -DGGML_NATIVE=OFF \
+    -DSD_BUILD_SHARED_GGML_LIB=ON \
+    -DGGML_BACKEND_DL=ON \
+    -DGGML_CPU_ALL_VARIANTS=ON \
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+    -DCMAKE_INSTALL_RPATH='$ORIGIN'
 RUN cmake --build ./build --config Release --parallel
 
 FROM ubuntu:$UBUNTU_VERSION AS runtime
@@ -28,7 +35,9 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends libgomp1 && \
     apt-get clean
 
-COPY --from=build /sd.cpp/build/bin/sd-cli /sd-cli
-COPY --from=build /sd.cpp/build/bin/sd-server /sd-server
+COPY --from=build /sd.cpp/build/bin /sd.cpp/bin
+RUN printf '#!/bin/sh\nexec /sd.cpp/bin/sd-cli "$@"\n' > /sd-cli && \
+    printf '#!/bin/sh\nexec /sd.cpp/bin/sd-server "$@"\n' > /sd-server && \
+    chmod +x /sd-cli /sd-server
 
 ENTRYPOINT [ "/sd-cli" ]

--- a/Dockerfile.cuda
+++ b/Dockerfile.cuda
@@ -26,6 +26,13 @@ ARG GGML_CUDA_FA_ALL_QUANTS=""
 
 RUN cmake . -B ./build \
     -DSD_CUDA=ON \
+    -DSD_BUILD_SHARED_LIBS=ON \
+    -DGGML_NATIVE=OFF \
+    -DSD_BUILD_SHARED_GGML_LIB=ON \
+    -DGGML_BACKEND_DL=ON \
+    -DGGML_CPU_ALL_VARIANTS=ON \
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+    -DCMAKE_INSTALL_RPATH='$ORIGIN' \
     ${CUDA_ARCHITECTURES:+-DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCHITECTURES}"} \
     ${GGML_CUDA_FA_ALL_QUANTS:+-DGGML_CUDA_FA_ALL_QUANTS=${GGML_CUDA_FA_ALL_QUANTS}}
 RUN cmake --build ./build --config Release -j$(nproc)
@@ -36,7 +43,9 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends libgomp1 && \
     apt-get clean
 
-COPY --from=build /sd.cpp/build/bin/sd-cli /sd-cli
-COPY --from=build /sd.cpp/build/bin/sd-server /sd-server
+COPY --from=build /sd.cpp/build/bin /sd.cpp/bin
+RUN printf '#!/bin/sh\nexec /sd.cpp/bin/sd-cli "$@"\n' > /sd-cli && \
+    printf '#!/bin/sh\nexec /sd.cpp/bin/sd-server "$@"\n' > /sd-server && \
+    chmod +x /sd-cli /sd-server
 
 ENTRYPOINT [ "/sd-cli" ]

--- a/Dockerfile.musa
+++ b/Dockerfile.musa
@@ -24,12 +24,22 @@ RUN mkdir build && cd build && \
     cmake .. -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
         -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -fopenmp -I/usr/lib/llvm-14/lib/clang/14.0.0/include -L/usr/lib/llvm-14/lib" \
         -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -fopenmp -I/usr/lib/llvm-14/lib/clang/14.0.0/include -L/usr/lib/llvm-14/lib" \
-        -DSD_MUSA=ON -DCMAKE_BUILD_TYPE=Release && \
+        -DSD_MUSA=ON \
+        -DSD_BUILD_SHARED_LIBS=ON \
+        -DGGML_NATIVE=OFF \
+        -DSD_BUILD_SHARED_GGML_LIB=ON \
+        -DGGML_BACKEND_DL=ON \
+        -DGGML_CPU_ALL_VARIANTS=ON \
+        -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+        -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+        -DCMAKE_BUILD_TYPE=Release && \
     cmake --build . --config Release
 
 FROM mthreads/musa:${MUSA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}-amd64 as runtime
 
-COPY --from=build /sd.cpp/build/bin/sd-cli /sd-cli
-COPY --from=build /sd.cpp/build/bin/sd-server /sd-server
+COPY --from=build /sd.cpp/build/bin /sd.cpp/bin
+RUN printf '#!/bin/sh\nexec /sd.cpp/bin/sd-cli "$@"\n' > /sd-cli && \
+    printf '#!/bin/sh\nexec /sd.cpp/bin/sd-server "$@"\n' > /sd-server && \
+    chmod +x /sd-cli /sd-server
 
 ENTRYPOINT [ "/sd-cli" ]

--- a/Dockerfile.sycl
+++ b/Dockerfile.sycl
@@ -21,12 +21,23 @@ WORKDIR /sd.cpp
 COPY . .
 
 RUN mkdir build && cd build && \
-    cmake .. -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx -DSD_SYCL=ON -DCMAKE_BUILD_TYPE=Release && \
+    cmake .. -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx \
+        -DSD_SYCL=ON \
+        -DSD_BUILD_SHARED_LIBS=ON \
+        -DGGML_NATIVE=OFF \
+        -DSD_BUILD_SHARED_GGML_LIB=ON \
+        -DGGML_BACKEND_DL=ON \
+        -DGGML_CPU_ALL_VARIANTS=ON \
+        -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+        -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+        -DCMAKE_BUILD_TYPE=Release && \
     cmake --build . --config Release -j$(nproc)
 
 FROM intel/oneapi-basekit:${SYCL_VERSION}-devel-ubuntu24.04 AS runtime
 
-COPY --from=build /sd.cpp/build/bin/sd-cli /sd-cli
-COPY --from=build /sd.cpp/build/bin/sd-server /sd-server
+COPY --from=build /sd.cpp/build/bin /sd.cpp/bin
+RUN printf '#!/bin/sh\nexec /sd.cpp/bin/sd-cli "$@"\n' > /sd-cli && \
+    printf '#!/bin/sh\nexec /sd.cpp/bin/sd-server "$@"\n' > /sd-server && \
+    chmod +x /sd-cli /sd-server
 
 ENTRYPOINT [ "/sd-cli" ]

--- a/Dockerfile.vulkan
+++ b/Dockerfile.vulkan
@@ -19,7 +19,15 @@ WORKDIR /sd.cpp
 
 COPY . .
 
-RUN cmake . -B ./build -DSD_VULKAN=ON
+RUN cmake . -B ./build \
+    -DSD_VULKAN=ON \
+    -DSD_BUILD_SHARED_LIBS=ON \
+    -DGGML_NATIVE=OFF \
+    -DSD_BUILD_SHARED_GGML_LIB=ON \
+    -DGGML_BACKEND_DL=ON \
+    -DGGML_CPU_ALL_VARIANTS=ON \
+    -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+    -DCMAKE_INSTALL_RPATH='$ORIGIN'
 RUN cmake --build ./build --config Release --parallel
 
 FROM ubuntu:$UBUNTU_VERSION AS runtime
@@ -28,7 +36,9 @@ RUN apt-get update && \
     apt-get install --yes --no-install-recommends libgomp1 libvulkan1 mesa-vulkan-drivers && \
     apt-get clean
 
-COPY --from=build /sd.cpp/build/bin/sd-cli /sd-cli
-COPY --from=build /sd.cpp/build/bin/sd-server /sd-server
+COPY --from=build /sd.cpp/build/bin /sd.cpp/bin
+RUN printf '#!/bin/sh\nexec /sd.cpp/bin/sd-cli "$@"\n' > /sd-cli && \
+    printf '#!/bin/sh\nexec /sd.cpp/bin/sd-server "$@"\n' > /sd-server && \
+    chmod +x /sd-cli /sd-server
 
 ENTRYPOINT [ "/sd-cli" ]


### PR DESCRIPTION
## Summary

Switches build options on all released binaries to use dynamic ggml backends, enables multiple CPU variants, and replaces noavx/avx/avx2/avx512 variants with a single one.

This should fix recurrent issues where specific Github CI builders release binaries that assume AVX2 or AVX512, and enable compatibility with several CPU generations in all our builds.

## Related Issue / Discussion

To be honest, I'm not used to the Github release process, so there could be bugs with the non-Linux releases, or the Docker image generation. I was only able to test the released Linux binaries; I've made a test build on my own fork some time ago (details on #1589 ).

Related to #1591 . 

Should fix: #1343 , #1351 , #1483 , #1588 , #1589 , #1695 .

## Additional Information

## Checklist

- [X] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
