### PR TITLE
fix: correct TAEHV encoding for image models

### DIFF
--- a/src/model/vae/tae.hpp
+++ b/src/model/vae/tae.hpp
@@ -548,7 +548,7 @@ public:
         }
         auto result = decoder->forward(ctx, z);
         if (sd_version_is_wan(version) || sd_version_is_ltxav(version)) {
-            // (W, H, C, T) -> (W, H, T, C)
+            // (W, H, T, C) -> (W, H, C, T)
             result = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, result, 0, 1, 3, 2));
         }
         return result;
@@ -556,8 +556,10 @@ public:
 
     ggml_tensor* encode(GGMLRunnerContext* ctx, ggml_tensor* x) {
         auto encoder = std::dynamic_pointer_cast<TinyVideoEncoder>(blocks["encoder"]);
-        // (W, H, T, C) -> (W, H, C, T)
-        x                  = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 0, 1, 3, 2));
+        if (sd_version_is_wan(version) || sd_version_is_ltxav(version)) {
+            // (W, H, T, C) -> (W, H, C, T)
+            x = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 0, 1, 3, 2));
+        }
         int64_t num_frames = x->ne[3];
         if (num_frames % encoder->t_downscale) {
             // pad to multiple of encoder->t_downscale at the end
@@ -567,7 +569,10 @@ public:
             }
         }
         x = encoder->forward(ctx, x);
-        x = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 0, 1, 3, 2));
+        if (sd_version_is_wan(version) || sd_version_is_ltxav(version)) {
+            // (W, H, C, T) -> (W, H, T, C)
+            x = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 0, 1, 3, 2));
+        }
         return x;
     }
 };


### PR DESCRIPTION
## Summary

Fixes an assertion failure with Anima and Krea 2 in image to image:

> ggml/src/ggml.c:4429: GGML_ASSERT(a->ne[2] == b->ne[2]) failed

<details>

```
[INFO ] common.cpp:2075 - set width x height to 512 x 512
ggml/src/ggml.c:4429: GGML_ASSERT(a->ne[2] == b->ne[2]) failed
[New LWP 4111733]
[New LWP 4111732]
[New LWP 4111731]
[New LWP 4111730]
[New LWP 4111719]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
__syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
warning: 56     ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S: Arquivo ou diretório inexistente
#0  __syscall_cancel_arch () at ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S:56
56      in ../sysdeps/unix/sysv/linux/x86_64/syscall_cancel.S
#1  0x00007f931349b668 in __internal_syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=<optimized out>, a5=a5@entry=0, a6=a6@entry=0, nr=61) at ./nptl/cancellation.c:49
warning: 49     ./nptl/cancellation.c: Arquivo ou diretório inexistente
#2  0x00007f931349b6ad in __syscall_cancel (a1=<optimized out>, a2=<optimized out>, a3=<optimized out>, a4=<optimized out>, a5=a5@entry=0, a6=a6@entry=0, nr=61) at ./nptl/cancellation.c:75
75      in ./nptl/cancellation.c
#3  0x00007f93135067c7 in __GI___wait4 (pid=<optimized out>, stat_loc=<optimized out>, options=<optimized out>, usage=<optimized out>) at ../sysdeps/unix/sysv/linux/wait4.c:30
warning: 30     ../sysdeps/unix/sysv/linux/wait4.c: Arquivo ou diretório inexistente
#4  0x000056370c98fbfb in ggml_print_backtrace ()
#5  0x000056370c98fd4e in ggml_abort ()
#6  0x000056370c998a54 in ggml_im2col ()
#7  0x000056370c9990b9 in ggml_conv_2d ()
#8  0x000056370bbb36e7 in ggml_ext_conv_2d(ggml_context*, ggml_tensor*, ggml_tensor*, ggml_tensor*, int, int, int, int, int, int, bool, bool, bool, float) ()
#9  0x000056370bc4451c in Conv2d::forward(GGMLRunnerContext*, ggml_tensor*) ()
#10 0x000056370bc528f4 in TinyVideoEncoder::forward(GGMLRunnerContext*, ggml_tensor*) ()
#11 0x000056370bc59ac7 in std::_Function_handler<ggml_cgraph* (), TinyVideoAutoEncoder::_compute(int, sd::Tensor<float> const&, bool)::{lambda()#1}>::_M_invoke(std::_Any_data const&) ()
#12 0x000056370bbc2f3e in std::optional<sd::Tensor<float> > GGMLRunner::compute<float>(std::function<ggml_cgraph* ()>, int, bool, bool, bool, bool) [clone .constprop.0] ()
#13 0x000056370bd523c7 in TinyVideoAutoEncoder::_compute(int, sd::Tensor<float> const&, bool) ()
#14 0x000056370bbef82b in StableDiffusionGGML::encode_first_stage(sd::Tensor<float> const&) ()
#15 0x000056370bbbd7f2 in prepare_image_generation_latents(sd_ctx_t*, sd_img_gen_params_t const*, GenerationRequest*, SamplePlan*) ()
#16 0x000056370bbc78c1 in generate_image ()
#17 0x000056370ba7db04 in main ()
[Inferior 1 (process 4111705) detached]
```

</details>

## Checklist

- [X] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
