### PR TITLE
fix(cli): resolve undefined mz_uncompress symbol on Windows

### DIFF
--- a/examples/cli/CMakeLists.txt
+++ b/examples/cli/CMakeLists.txt
@@ -15,7 +15,7 @@ target_include_directories(${TARGET} PRIVATE
     "${PROJECT_SOURCE_DIR}/src"
 )
 install(TARGETS ${TARGET} RUNTIME)
-target_link_libraries(${TARGET} PRIVATE stable-diffusion ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${TARGET} PRIVATE stable-diffusion zip ${CMAKE_THREAD_LIBS_INIT})
 if(SD_WEBP)
     target_compile_definitions(${TARGET} PRIVATE SD_USE_WEBP)
     target_link_libraries(${TARGET} PRIVATE webp libwebpmux)


### PR DESCRIPTION
## Summary

Fixes a build failure on Windows (lld-link: error: undefined symbol: mz_uncompress) caused by #1632.

## Related Issue / Discussion

https://github.com/leejet/stable-diffusion.cpp/pull/1632#issuecomment-4827550001

## Additional Information

The previous PR changed the zip library to be linked privately via object files into stable-diffusion. Because of this, the zip symbols are no longer exported transitively to the CLI example. Since image_metadata.cpp directly calls mz_uncompress, zip must be explicitly linked to the sd-cli target.


## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
