### PR TITLE
Fix: Avoid crash and warn when using Qwen 2D VAE for Wan video

### DIFF
--- a/src/model/vae/wan_vae.hpp
+++ b/src/model/vae/wan_vae.hpp
@@ -747,7 +747,6 @@ namespace WAN {
                 x = conv1->forward(ctx, x);
             }
             // sd::ggml_graph_cut::mark_graph_cut(x, "wan_vae.encoder.prelude", "x");
-
             // downsamples
             std::vector<int64_t> dims = {dim};
             for (int u : dim_mult) {
@@ -804,7 +803,6 @@ namespace WAN {
             } else {
                 x = head_2->forward(ctx, x);
             }
-
             return x;
         }
     };
@@ -1119,6 +1117,10 @@ namespace WAN {
             GGML_ASSERT(b == 1);
             GGML_ASSERT(decode_only == false);
 
+            if(x->ne[2]>1 && is_2D) {
+                LOG_WARN("Using 2D VAE to encode video, expect poor results");
+            }
+
             clear_cache();
 
             if (wan2_2) {
@@ -1138,7 +1140,8 @@ namespace WAN {
                     auto in = ggml_ext_slice(ctx->ggml_ctx, x, 2, 0, 1);  // [b*c, 1, h, w]
                     out     = encoder->forward(ctx, in, b, _enc_feat_map, _enc_conv_idx, i);
                 } else {
-                    auto in   = ggml_ext_slice(ctx->ggml_ctx, x, 2, 1 + 4 * (i - 1), 1 + 4 * i);  // [b*c, 4, h, w]
+                    // if is_2D, drop 3 out of 4 frames
+                    auto in   = ggml_ext_slice(ctx->ggml_ctx, x, 2, 1 + 4 * (i - 1), (is_2D ? 1 - 3 : 1) + 4 * i);  // [b*c, 4, h, w]
                     auto out_ = encoder->forward(ctx, in, b, _enc_feat_map, _enc_conv_idx, i);
                     out       = ggml_concat(ctx->ggml_ctx, out, out_, 2);
                 }
@@ -1160,6 +1163,10 @@ namespace WAN {
                             int64_t b = 1) {
             // z: [b*c, t, h, w]
             GGML_ASSERT(b == 1);
+
+            if(z->ne[2]>1 && is_2D) {
+                LOG_WARN("Using 2D VAE to decode video, expect poor results");
+            }
 
             clear_cache();
 
@@ -1185,6 +1192,12 @@ namespace WAN {
                     auto in   = ggml_ext_slice(ctx->ggml_ctx, x, 2, i, i + 1);  // [b*c, 1, h, w]
                     auto out_ = decoder->forward(ctx, in, b, _feat_map, _conv_idx, i);
                     out       = ggml_concat(ctx->ggml_ctx, out, out_, 2);
+                    if (is_2D) {
+                        // repeat frames to avoid mismatch
+                        for (int j = 0; j < 4 - 1; j++) {
+                            out = ggml_concat(ctx->ggml_ctx, out, out_, 2);
+                        }
+                    }
                 }
             }
             if (wan2_2) {

--- a/src/model/vae/wan_vae.hpp
+++ b/src/model/vae/wan_vae.hpp
@@ -747,6 +747,7 @@ namespace WAN {
                 x = conv1->forward(ctx, x);
             }
             // sd::ggml_graph_cut::mark_graph_cut(x, "wan_vae.encoder.prelude", "x");
+
             // downsamples
             std::vector<int64_t> dims = {dim};
             for (int u : dim_mult) {
@@ -803,6 +804,7 @@ namespace WAN {
             } else {
                 x = head_2->forward(ctx, x);
             }
+
             return x;
         }
     };
@@ -1117,7 +1119,7 @@ namespace WAN {
             GGML_ASSERT(b == 1);
             GGML_ASSERT(decode_only == false);
 
-            if(x->ne[2]>1 && is_2D) {
+            if (x->ne[2] > 1 && is_2D) {
                 LOG_WARN("Using 2D VAE to encode video, expect poor results");
             }
 
@@ -1164,7 +1166,7 @@ namespace WAN {
             // z: [b*c, t, h, w]
             GGML_ASSERT(b == 1);
 
-            if(z->ne[2]>1 && is_2D) {
+            if (z->ne[2] > 1 && is_2D) {
                 LOG_WARN("Using 2D VAE to decode video, expect poor results");
             }
 


### PR DESCRIPTION
## Summary

Using Qwen2D vae to encode/decode videos was causing crashes (assert failed) without any explicit warning or error message.

This PR "fixes" it by dropping input frames for encoding and duplicating frames for decoding. Of course this causes choppy results, so I've added a warning to notify the user.

## Related Issue / Discussion

Cont: https://github.com/leejet/stable-diffusion.cpp/pull/1714

## Additional Information

<!-- Add verification notes, screenshots, sample output, or other context when applicable. -->

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
