### PR TITLE
feat: denoise strength as starting noise level

### DIFF
--- a/src/runtime/denoiser.hpp
+++ b/src/runtime/denoiser.hpp
@@ -1013,6 +1013,7 @@ struct Denoiser {
                                             const sd::Tensor<float>& latent)         = 0;
     virtual sd::Tensor<float> inverse_noise_scaling(float sigma,
                                                     const sd::Tensor<float>& latent) = 0;
+    virtual float noise_level_to_sigma(float noise_level)                            = 0;
 
     virtual std::vector<float> get_sigmas(uint32_t n, int image_seq_len, scheduler_t scheduler_type, SDVersion version, const char* extra_sample_args = nullptr) {
         auto bound_t_to_sigma = std::bind(&Denoiser::t_to_sigma, this, std::placeholders::_1);
@@ -1160,6 +1161,10 @@ struct CompVisDenoiser : public Denoiser {
         SD_UNUSED(sigma);
         return latent;
     }
+
+    float noise_level_to_sigma(float noise_level){
+        return noise_level / (1.0f - noise_level);
+    }
 };
 
 struct CompVisVDenoiser : public CompVisDenoiser {
@@ -1246,6 +1251,10 @@ struct DiscreteFlowDenoiser : public Denoiser {
     }
     sd::Tensor<float> inverse_noise_scaling(float sigma, const sd::Tensor<float>& latent) override {
         return latent * (1.0f / (1.0f - sigma));
+    }
+    
+    float noise_level_to_sigma(float noise_level){
+        return noise_level;
     }
 };
 
@@ -1382,6 +1391,11 @@ struct MiniT2IFlowDenoiser : public Denoiser {
     sd::Tensor<float> inverse_noise_scaling(float sigma, const sd::Tensor<float>& latent) override {
         SD_UNUSED(sigma);
         return latent;
+    }
+
+    float noise_level_to_sigma(float noise_level){
+        SD_UNUSED(noise_level);
+        return 1.0f;
     }
 
     std::vector<float> get_sigmas(uint32_t n, int image_seq_len, scheduler_t scheduler_type, SDVersion version, const char* extra_sample_args = nullptr) override {

--- a/src/runtime/denoiser.hpp
+++ b/src/runtime/denoiser.hpp
@@ -1162,7 +1162,7 @@ struct CompVisDenoiser : public Denoiser {
         return latent;
     }
 
-    float noise_level_to_sigma(float noise_level){
+    float noise_level_to_sigma(float noise_level) {
         return noise_level / (1.0f - noise_level);
     }
 };
@@ -1252,8 +1252,8 @@ struct DiscreteFlowDenoiser : public Denoiser {
     sd::Tensor<float> inverse_noise_scaling(float sigma, const sd::Tensor<float>& latent) override {
         return latent * (1.0f / (1.0f - sigma));
     }
-    
-    float noise_level_to_sigma(float noise_level){
+
+    float noise_level_to_sigma(float noise_level) {
         return noise_level;
     }
 };
@@ -1393,7 +1393,7 @@ struct MiniT2IFlowDenoiser : public Denoiser {
         return latent;
     }
 
-    float noise_level_to_sigma(float noise_level){
+    float noise_level_to_sigma(float noise_level) {
         SD_UNUSED(noise_level);
         return 1.0f;
     }

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -4050,13 +4050,56 @@ static std::optional<ImageGenerationLatents> prepare_image_generation_latents(sd
         LOG_INFO("IMG2IMG");
 
         if (request->strength < 1.f) {
-            size_t t_enc = static_cast<size_t>(plan->sample_steps * request->strength);
-            if (t_enc == static_cast<size_t>(plan->sample_steps)) {
-                t_enc--;
+            bool strength_as_noise_level = false;
+            bool force_first_sigma       = false;
+            for (const auto& [key, value] : parse_key_value_args(sd_img_gen_params->sample_params.extra_sample_args, "img2img arg")) {
+                if (key == "strength_as_noise_level") {
+                    if (!parse_strict_bool(value, strength_as_noise_level)) {
+                        LOG_WARN("ignoring invalid img2img sample arg '%s=%s'", key.c_str(), value.c_str());
+                    }
+                } else if (key == "force_first_sigma") {
+                    if (!parse_strict_bool(value, force_first_sigma)) {
+                        LOG_WARN("ignoring invalid img2img sample arg '%s=%s'", key.c_str(), value.c_str());
+                    }
+                }
+            }
+
+            size_t t_enc;
+            float target_sigma = -1;
+            if (!strength_as_noise_level) {
+                t_enc = static_cast<size_t>(plan->sample_steps * request->strength);
+                if (t_enc == static_cast<size_t>(plan->sample_steps)) {
+                    t_enc--;
+                }
+            } else {
+                LOG_DEBUG("Interpreting denoise strength as relative noise level");
+                // assume x_noised = K * (x * (1-noise_level) + noise * noise_level) = K * lerp(x, noise, noise_level)
+                // K = 1, noise_level = sigma for flow models
+                // K = 1+sigma, noise_level=sigma/(1+sigma) for diffusion models
+                float target_noise_level = request->strength;
+                target_sigma             = sd_ctx->sd->denoiser->noise_level_to_sigma(target_noise_level);
+                size_t start_index       = 0;
+                for (size_t i = 0; i < plan->sigmas.size(); ++i) {
+                    if (plan->sigmas[i] <= target_sigma) {
+                        start_index = i;
+                        break;
+                    }
+                }
+
+                if (start_index >= plan->sigmas.size() - 1) {
+                    start_index = plan->sigmas.size() - 2;  // Leave at least 1 step
+                }
+                t_enc = plan->sample_steps - start_index - 1;
             }
             LOG_INFO("target t_enc is %zu steps", t_enc);
             std::vector<float> sigma_sched;
             sigma_sched.assign(plan->sigmas.begin() + plan->sample_steps - t_enc - 1, plan->sigmas.end());
+
+            if (target_sigma > 0 && force_first_sigma && strength_as_noise_level) {
+                LOG_DEBUG("force_first_sigma to %.4f (from %.4f)", target_sigma, sigma_sched[0]);
+                sigma_sched[0] = target_sigma;
+            }
+
             plan->sigmas       = std::move(sigma_sched);
             plan->sample_steps = static_cast<int>(plan->sigmas.size() - 1);
         }


### PR DESCRIPTION
## Summary

Currently, in `img2img` mode, the `strength` parameter simply determines how many denoising steps to skip (e.g., a strength of 0.7 skips the first 30% of steps). This is a simple and familliar behavior, probably inherited from legacy engines like Automatic1111. 

The issue with this approach is that it doesn't align with the intuitive meaning of "denoising strength," and the actual amount of noise added is heavily dependent on the specific scheduler being used.

This PR introduces an alternative interpretation of the `strength` parameter, treating it as a **noise level** rather than a step count. When enabled, a strength of 0.7 ensures that denoising begins at the step where the model's input is approximately a mix of 70% noise and 30% initial image.

**Key Changes:**
* **Noise-based Strength:** Allows `strength` to control the actual noise ratio. Depending on the scheduler and model, this may produce significantly different results than the default step-skipping method.
* **Sigma Adjustment:** Added an optional mechanism to edit the first step's sigmas to exactly match the requested noise level. Since this modifies the schedule, it is disabled by default.
* **Backward Compatibility:** To avoid breaking existing workflows, these features are disabled by default.

**Configuration:**
These can be enabled via the `--extra-sample-args` argument using the following boolean fields:
* `strength_as_noise_level`
* `force_first_sigma`



## Related Issue / Discussion

N/A

## Additional Information

### With dreamshaper v8 (unet/diffusion):

Default behavior:
| strength | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| default scheduler | <img width="512" height="512" alt="output_0 1_standard" src="https://github.com/user-attachments/assets/bdf611c3-d60e-420e-9e26-fbf197b3a412" /> | <img width="512" height="512" alt="output_0 2_standard" src="https://github.com/user-attachments/assets/f04ee8de-ce07-402b-9cad-98029ad7ab77" /> | <img width="512" height="512" alt="output_0 3_standard" src="https://github.com/user-attachments/assets/ba383271-7b11-40ba-bc69-1d98a849bfbf" /> | <img width="512" height="512" alt="output_0 4_standard" src="https://github.com/user-attachments/assets/97f38ee1-6c3c-4a09-9fe2-7eb35e2fe9fc" /> | <img width="512" height="512" alt="output_0 5_standard" src="https://github.com/user-attachments/assets/06c27594-3ccd-4a2e-b47c-16b219d6ab05" /> | <img width="512" height="512" alt="output_0 6_standard" src="https://github.com/user-attachments/assets/3447eebf-aec6-4f0f-bdda-33015088d99c" /> | <img width="512" height="512" alt="output_0 7_standard" src="https://github.com/user-attachments/assets/9b452b26-405a-4ed5-8bdd-2aa85a62ebb8" /> | <img width="512" height="512" alt="output_0 8_standard" src="https://github.com/user-attachments/assets/f9f6aaf5-78c4-4b62-a604-06a1f4c17ef2" /> | <img width="512" height="512" alt="output_0 9_standard" src="https://github.com/user-attachments/assets/20ee9e50-fc9a-4f37-8ed0-2474321e604d" /> |
| karras scheduler | <img width="512" height="512" alt="output_0 1_standard" src="https://github.com/user-attachments/assets/a4634893-d7dc-48ae-81de-31fad6143c0a" /> | <img width="512" height="512" alt="output_0 2_standard" src="https://github.com/user-attachments/assets/ed393af5-1293-4a3e-9d62-fd38b1c08343" /> | <img width="512" height="512" alt="output_0 3_standard" src="https://github.com/user-attachments/assets/79154dce-74c7-496c-8de9-efd1ac33bf23" /> | <img width="512" height="512" alt="output_0 4_standard" src="https://github.com/user-attachments/assets/889b4e1c-d88a-4b44-ac92-02c6702ca3c5" /> | <img width="512" height="512" alt="output_0 5_standard" src="https://github.com/user-attachments/assets/5469e1a0-ca37-43c0-a00e-600ee7fb04ba" /> | <img width="512" height="512" alt="output_0 6_standard" src="https://github.com/user-attachments/assets/8b507f48-5bd3-471b-918a-534f752e456e" /> | <img width="512" height="512" alt="output_0 7_standard" src="https://github.com/user-attachments/assets/3d91c766-feca-4fc2-9333-445373610afe" /> | <img width="512" height="512" alt="output_0 8_standard" src="https://github.com/user-attachments/assets/08088b5e-475a-465c-a370-2397fcf5a89e" /> | <img width="512" height="512" alt="output_0 9_standard" src="https://github.com/user-attachments/assets/cfb6e31b-8195-4ced-b85d-332e01c67ec7" /> |

Enabling `strength_as_noise_level=on`:
| strength | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| default scheduler | <img width="512" height="512" alt="output_0 1_noise_level" src="https://github.com/user-attachments/assets/b68b639c-c916-4094-bfc5-572e6657959b" /> | <img width="512" height="512" alt="output_0 2_noise_level" src="https://github.com/user-attachments/assets/e251841c-a1ff-428a-a3a6-557ec4592c50" /> | <img width="512" height="512" alt="output_0 3_noise_level" src="https://github.com/user-attachments/assets/4f99a43a-f6d4-4856-816b-6bc0703e5250" /> | <img width="512" height="512" alt="output_0 4_noise_level" src="https://github.com/user-attachments/assets/cb1d8a2a-81fb-4674-9c36-7e29a9fa388c" /> | <img width="512" height="512" alt="output_0 5_noise_level" src="https://github.com/user-attachments/assets/5b24c9ca-c299-4dfa-8fa5-c31b17e7b4bd" /> | <img width="512" height="512" alt="output_0 6_noise_level" src="https://github.com/user-attachments/assets/f08764e5-5f52-4500-b0cd-b602e074371e" /> | <img width="512" height="512" alt="output_0 7_noise_level" src="https://github.com/user-attachments/assets/90b6783b-d9de-41ee-9513-c8096a4f6da4" /> | <img width="512" height="512" alt="output_0 8_noise_level" src="https://github.com/user-attachments/assets/6a7ebbc9-a62a-46b6-aeb4-20da8888610e" /> | <img width="512" height="512" alt="output_0 9_noise_level" src="https://github.com/user-attachments/assets/a79052fa-7e90-42a4-9277-b1f6ff58a8a6" /> |
| karras scheduler | <img width="512" height="512" alt="output_0 1_noise_level" src="https://github.com/user-attachments/assets/6957a6a7-da09-4f43-bcc8-9c1f4ac00182" /> | <img width="512" height="512" alt="output_0 2_noise_level" src="https://github.com/user-attachments/assets/bf146fb0-c5c9-4fdc-8cee-1157f8e51870" /> | <img width="512" height="512" alt="output_0 3_noise_level" src="https://github.com/user-attachments/assets/895af1d0-e632-480e-8c24-b5ab5c774e7c" /> | <img width="512" height="512" alt="output_0 4_noise_level" src="https://github.com/user-attachments/assets/b1071ae7-3b56-4184-8b51-6ea03c9584ac" /> | <img width="512" height="512" alt="output_0 5_noise_level" src="https://github.com/user-attachments/assets/0a8eccef-4218-4966-95c0-9378f0c49df3" /> | <img width="512" height="512" alt="output_0 6_noise_level" src="https://github.com/user-attachments/assets/87be2567-f913-40e2-ab1b-2be5b20de8e3" /> | <img width="512" height="512" alt="output_0 7_noise_level" src="https://github.com/user-attachments/assets/5b4018d6-9096-480f-9276-14abaa2e7cd3" /> | <img width="512" height="512" alt="output_0 8_noise_level" src="https://github.com/user-attachments/assets/b00b7ee5-5107-4e42-b3e3-ce811a3599c5" /> | <img width="512" height="512" alt="output_0 9_noise_level" src="https://github.com/user-attachments/assets/b2729adf-2e73-4dd4-9607-5762f2c01c4a" /> |

Enabling `strength_as_noise_level=on,force_first_sigma=on`:
| strength | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| default scheduler | <img width="512" height="512" alt="output_0 1_sigma_on" src="https://github.com/user-attachments/assets/b710aeac-5ef9-428b-ab55-c157782116a5" /> | <img width="512" height="512" alt="output_0 2_sigma_on" src="https://github.com/user-attachments/assets/c0b793e3-c946-4fe9-998c-247a248fcc23" /> | <img width="512" height="512" alt="output_0 3_sigma_on" src="https://github.com/user-attachments/assets/0596d33e-15f4-4f19-9390-cf2fefce1496" /> | <img width="512" height="512" alt="output_0 4_sigma_on" src="https://github.com/user-attachments/assets/39ddaebc-4596-4b81-aeb8-5eccec242a3f" /> | <img width="512" height="512" alt="output_0 5_sigma_on" src="https://github.com/user-attachments/assets/d42820a6-2f4a-4be2-b925-2d408ff4048a" /> | <img width="512" height="512" alt="output_0 6_sigma_on" src="https://github.com/user-attachments/assets/8ebb21ba-1351-44f7-99cd-238ae0a7a97b" /> | <img width="512" height="512" alt="output_0 7_sigma_on" src="https://github.com/user-attachments/assets/c6c7a820-4e31-4de7-adce-1f37ccc5c376" /> | <img width="512" height="512" alt="output_0 8_sigma_on" src="https://github.com/user-attachments/assets/a4f89f33-9ab5-4f23-b158-6900ca0e05cd" /> | <img width="512" height="512" alt="output_0 9_sigma_on" src="https://github.com/user-attachments/assets/1089aa78-3e4c-4884-98e9-49a6787c5a06" /> |
| karras scheduler | <img width="512" height="512" alt="output_0 1_sigma_on" src="https://github.com/user-attachments/assets/c706da26-a10f-4efc-bed4-c2741e979117" /> | <img width="512" height="512" alt="output_0 2_sigma_on" src="https://github.com/user-attachments/assets/f46a4d23-865c-4d56-b2de-4cca98348501" /> | <img width="512" height="512" alt="output_0 3_sigma_on" src="https://github.com/user-attachments/assets/aa758a9a-041b-47b0-bcb6-ad1090257bd6" /> | <img width="512" height="512" alt="output_0 4_sigma_on" src="https://github.com/user-attachments/assets/4e155607-00c5-43fd-bae8-3da2a9a7b866" /> | <img width="512" height="512" alt="output_0 5_sigma_on" src="https://github.com/user-attachments/assets/47636f1d-00ab-4564-a7f9-7a143d5e956e" /> | <img width="512" height="512" alt="output_0 6_sigma_on" src="https://github.com/user-attachments/assets/1bde1dd5-2f49-4466-bd51-3969d1a1d9e0" /> | <img width="512" height="512" alt="output_0 7_sigma_on" src="https://github.com/user-attachments/assets/3a1a6197-b0c6-4966-a15a-4b0c9cc144a3" /> | <img width="512" height="512" alt="output_0 8_sigma_on" src="https://github.com/user-attachments/assets/e9f62cfe-14a6-4bc5-af8a-ed87a0654664" /> | <img width="512" height="512" alt="output_0 9_sigma_on" src="https://github.com/user-attachments/assets/1a76914f-6442-4e87-9b5c-1805dcbe7338" /> |

### With Flux2 Klein 4b (DiT/Flow):
| strength | 0.1 | 0.2 | 0.3 | 0.4 | 0.5 | 0.6 | 0.7 | 0.8 | 0.9 | 
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| default | <img width="512" height="512" alt="output_0 1_standard" src="https://github.com/user-attachments/assets/b990efdb-d489-4d10-8a90-2a64cb172326" /> | <img width="512" height="512" alt="output_0 2_standard" src="https://github.com/user-attachments/assets/f044cbd2-6205-471b-9816-f377a1c685a0" /> | <img width="512" height="512" alt="output_0 3_standard" src="https://github.com/user-attachments/assets/75860bf7-8c63-448f-bfee-93d42352321f" /> | <img width="512" height="512" alt="output_0 4_standard" src="https://github.com/user-attachments/assets/c7b345e4-8f01-4cc0-acef-94c0d1896bcc" /> | <img width="512" height="512" alt="output_0 5_standard" src="https://github.com/user-attachments/assets/244afec9-01ba-434d-bc23-c0e88e679aef" /> | <img width="512" height="512" alt="output_0 6_standard" src="https://github.com/user-attachments/assets/2eb238b4-132a-4763-9c3b-4edfe7b689a6" /> | <img width="512" height="512" alt="output_0 7_standard" src="https://github.com/user-attachments/assets/4a795afa-87b5-4210-a115-0acd81aa8ce0" /> | <img width="512" height="512" alt="output_0 8_standard" src="https://github.com/user-attachments/assets/21c25349-933a-4529-80a7-dee58bb0ea9f" /> | <img width="512" height="512" alt="output_0 9_standard" src="https://github.com/user-attachments/assets/2d5e4807-acf5-4333-8b98-2a4f5fd1b47d" /> |
| noise level | <img width="512" height="512" alt="output_0 1_noise_level" src="https://github.com/user-attachments/assets/159b1fe5-7255-4658-b871-3fce84ae439c" /> | <img width="512" height="512" alt="output_0 2_noise_level" src="https://github.com/user-attachments/assets/814777fc-8583-49f2-984b-d5c9d4e157da" /> | <img width="512" height="512" alt="output_0 3_noise_level" src="https://github.com/user-attachments/assets/47e6a773-e245-4ee6-b438-a5194d65d46e" /> | <img width="512" height="512" alt="output_0 4_noise_level" src="https://github.com/user-attachments/assets/37317155-a1ed-410f-a697-a9edfc46c5c8" /> | <img width="512" height="512" alt="output_0 5_noise_level" src="https://github.com/user-attachments/assets/4ca374a8-ccb3-46de-bf22-b795e0ffa5a6" /> | <img width="512" height="512" alt="output_0 6_noise_level" src="https://github.com/user-attachments/assets/57dc3d67-3202-4e97-bbdf-f7a1677634bb" /> | <img width="512" height="512" alt="output_0 7_noise_level" src="https://github.com/user-attachments/assets/9d71d2c3-19cf-43f3-b5c6-088b917e23b9" /> | <img width="512" height="512" alt="output_0 8_noise_level" src="https://github.com/user-attachments/assets/e2fd62e2-0b06-4aea-b446-0e37c4fbf6ff" /> | <img width="512" height="512" alt="output_0 9_noise_level" src="https://github.com/user-attachments/assets/272ebb1a-51d5-423a-89aa-dbf521525126" /> |
| + first sigma | <img width="512" height="512" alt="output_0 1_sigma_on" src="https://github.com/user-attachments/assets/c0f936a8-3ceb-4d37-8846-fd922f91cb52" /> | <img width="512" height="512" alt="output_0 2_sigma_on" src="https://github.com/user-attachments/assets/7a6202c8-4b8f-4ceb-a5ba-b98ecb447e98" /> | <img width="512" height="512" alt="output_0 3_sigma_on" src="https://github.com/user-attachments/assets/45055088-0d85-40eb-a4b7-76e24df57dc2" /> | <img width="512" height="512" alt="output_0 4_sigma_on" src="https://github.com/user-attachments/assets/a3d8cf88-913e-43ce-bbf9-d9ac96dcfbfe" /> | <img width="512" height="512" alt="output_0 5_sigma_on" src="https://github.com/user-attachments/assets/7c824375-4cfc-48f2-b674-86c8d85b9751" /> | <img width="512" height="512" alt="output_0 6_sigma_on" src="https://github.com/user-attachments/assets/4e8361c0-b353-4df5-81d3-29301b7438ad" /> | <img width="512" height="512" alt="output_0 7_sigma_on" src="https://github.com/user-attachments/assets/ff7b0fad-eae6-4eac-864a-566cf9461dc1" /> | <img width="512" height="512" alt="output_0 8_sigma_on" src="https://github.com/user-attachments/assets/3c86bdec-65c9-48ef-bd31-cc1c1cb29690" /> | <img width="512" height="512" alt="output_0 9_sigma_on" src="https://github.com/user-attachments/assets/a0aa92a7-4cd9-49d1-857e-572f1b81fe97" /> |


## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
