### PR TITLE
fix: use larger image VAE encode tiles

### DIFF
--- a/src/model/vae/vae.hpp
+++ b/src/model/vae/vae.hpp
@@ -133,7 +133,11 @@ public:
             int64_t H              = input.shape()[1] / scale_factor;
             float tile_overlap;
             int tile_size_x, tile_size_y;
-            get_tile_sizes(tile_size_x, tile_size_y, tile_overlap, tiling_params, W, H, 1.30539f);
+            // Image VAE encode is more sensitive to tile boundary context than decode.
+            // Keep the smaller legacy factor for video VAEs, but default image encode
+            // tiles to 64 latent pixels so a 512px SD image is encoded as one tile.
+            const float encode_tile_factor = (sd_version_is_wan(version) || sd_version_is_ltxav(version)) ? 1.30539f : 2.0f;
+            get_tile_sizes(tile_size_x, tile_size_y, tile_overlap, tiling_params, W, H, encode_tile_factor);
             LOG_DEBUG("VAE Tile size: %dx%d", tile_size_x, tile_size_y);
             output = tiled_compute(input,
                                    n_threads,


### PR DESCRIPTION
## Summary

- Increase the default image VAE encode tiling factor so 512px SD img2img inputs encode as a single 64x64 latent tile under `--vae-tiling`.
- Preserve the legacy smaller encode tile factor for Wan/LTX video VAEs and leave decode tiling behavior unchanged.

## Related Issue / Discussion

N/A

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
