### PR TITLE
feat: move circular padding to per-generation params

### DIFF
--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -555,18 +555,6 @@ ArgOptions SDContextParams::get_options() {
          "use ggml_conv2d_direct in the vae model",
          true, &vae_conv_direct},
         {"",
-         "--circular",
-         "enable circular padding for convolutions",
-         true, &circular},
-        {"",
-         "--circularx",
-         "enable circular RoPE wrapping on x-axis (width) only",
-         true, &circular_x},
-        {"",
-         "--circulary",
-         "enable circular RoPE wrapping on y-axis (height) only",
-         true, &circular_y},
-        {"",
          "--chroma-disable-dit-mask",
          "disable dit mask for chroma",
          false, &chroma_use_dit_mask},
@@ -853,9 +841,6 @@ std::string SDContextParams::to_string() const {
         << "  diffusion_flash_attn: " << (diffusion_flash_attn ? "true" : "false") << ",\n"
         << "  diffusion_conv_direct: " << (diffusion_conv_direct ? "true" : "false") << ",\n"
         << "  vae_conv_direct: " << (vae_conv_direct ? "true" : "false") << ",\n"
-        << "  circular: " << (circular ? "true" : "false") << ",\n"
-        << "  circular_x: " << (circular_x ? "true" : "false") << ",\n"
-        << "  circular_y: " << (circular_y ? "true" : "false") << ",\n"
         << "  chroma_use_dit_mask: " << (chroma_use_dit_mask ? "true" : "false") << ",\n"
         << "  qwen_image_zero_cond_t: " << (qwen_image_zero_cond_t ? "true" : "false") << ",\n"
         << "  chroma_use_t5_mask: " << (chroma_use_t5_mask ? "true" : "false") << ",\n"
@@ -912,8 +897,6 @@ sd_ctx_params_t SDContextParams::to_sd_ctx_params_t(bool taesd_preview) {
     sd_ctx_params.tae_preview_only                = taesd_preview;
     sd_ctx_params.diffusion_conv_direct           = diffusion_conv_direct;
     sd_ctx_params.vae_conv_direct                 = vae_conv_direct;
-    sd_ctx_params.circular_x                      = circular || circular_x;
-    sd_ctx_params.circular_y                      = circular || circular_y;
     sd_ctx_params.force_sdxl_vae_conv_scale       = force_sdxl_vae_conv_scale;
     sd_ctx_params.chroma_use_dit_mask             = chroma_use_dit_mask;
     sd_ctx_params.chroma_use_t5_mask              = chroma_use_t5_mask;
@@ -1189,6 +1172,18 @@ ArgOptions SDGenerationParams::get_options() {
          "disable auto resize of ref images",
          false,
          &auto_resize_ref_image},
+        {"",
+         "--circular",
+         "enable circular padding on both axes for tileable output",
+         true, &circular},
+        {"",
+         "--circularx",
+         "enable circular padding on x-axis (width) only",
+         true, &circular_x},
+        {"",
+         "--circulary",
+         "enable circular padding on y-axis (height) only",
+         true, &circular_y},
         {"",
          "--disable-image-metadata",
          "do not embed generation metadata on image files",
@@ -2475,6 +2470,8 @@ sd_img_gen_params_t SDGenerationParams::to_sd_img_gen_params_t() {
     params.hires.upscale_tile_size   = hires_upscale_tile_size;
     params.hires.custom_sigmas       = hires_custom_sigmas.empty() ? nullptr : hires_custom_sigmas.data();
     params.hires.custom_sigmas_count = static_cast<int>(hires_custom_sigmas.size());
+    params.circular_x                = circular || circular_x;
+    params.circular_y                = circular || circular_y;
     return params;
 }
 
@@ -2540,6 +2537,8 @@ sd_vid_gen_params_t SDGenerationParams::to_sd_vid_gen_params_t() {
     params.hires.upscale_tile_size   = hires_upscale_tile_size;
     params.hires.custom_sigmas       = hires_custom_sigmas.empty() ? nullptr : hires_custom_sigmas.data();
     params.hires.custom_sigmas_count = static_cast<int>(hires_custom_sigmas.size());
+    params.circular_x                = circular || circular_x;
+    params.circular_y                = circular || circular_y;
     return params;
 }
 

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -165,10 +165,6 @@ struct SDContextParams {
     bool diffusion_conv_direct = false;
     bool vae_conv_direct       = false;
 
-    bool circular   = false;
-    bool circular_x = false;
-    bool circular_y = false;
-
     bool chroma_use_dit_mask = true;
     bool chroma_use_t5_mask  = false;
     int chroma_t5_mask_pad   = 1;
@@ -245,6 +241,10 @@ struct SDGenerationParams {
 
     int upscale_repeats   = 1;
     int upscale_tile_size = 128;
+
+    bool circular   = false;
+    bool circular_x = false;
+    bool circular_y = false;
 
     bool hires_enabled         = false;
     std::string hires_upscaler = "Latent";

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -216,8 +216,6 @@ typedef struct {
     bool tae_preview_only;
     bool diffusion_conv_direct;
     bool vae_conv_direct;
-    bool circular_x;
-    bool circular_y;
     bool force_sdxl_vae_conv_scale;
     bool chroma_use_dit_mask;
     bool chroma_use_t5_mask;
@@ -385,6 +383,8 @@ typedef struct {
     sd_cache_params_t cache;
     sd_hires_params_t hires;
     int qwen_image_layers;
+    bool circular_x;
+    bool circular_y;
 } sd_img_gen_params_t;
 
 typedef struct {
@@ -410,6 +410,8 @@ typedef struct {
     sd_tiling_params_t vae_tiling_params;
     sd_cache_params_t cache;
     sd_hires_params_t hires;
+    bool circular_x;
+    bool circular_y;
 } sd_vid_gen_params_t;
 
 typedef struct sd_ctx_t sd_ctx_t;

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -863,10 +863,6 @@ public:
             use_tae          = true;
         }
 
-        if (sd_ctx_params->circular_x || sd_ctx_params->circular_y) {
-            LOG_INFO("Using circular padding for convolutions");
-        }
-
         {
             if (!ensure_backend_pair(SDBackendModule::TE) ||
                 !ensure_backend_pair(SDBackendModule::DIFFUSION)) {
@@ -1369,15 +1365,6 @@ public:
                 }
             }
 
-            diffusion_model->set_circular_axes(sd_ctx_params->circular_x, sd_ctx_params->circular_y);
-            if (high_noise_diffusion_model) {
-                high_noise_diffusion_model->set_circular_axes(sd_ctx_params->circular_x, sd_ctx_params->circular_y);
-            }
-            if (control_net) {
-                control_net->set_circular_axes(sd_ctx_params->circular_x, sd_ctx_params->circular_y);
-            }
-            circular_x = sd_ctx_params->circular_x;
-            circular_y = sd_ctx_params->circular_y;
         }
 
         LOG_DEBUG("validating model metadata");
@@ -3061,8 +3048,6 @@ void sd_ctx_params_init(sd_ctx_params_t* sd_ctx_params) {
     sd_ctx_params->eager_load           = false;
     sd_ctx_params->enable_mmap          = false;
     sd_ctx_params->diffusion_flash_attn = false;
-    sd_ctx_params->circular_x           = false;
-    sd_ctx_params->circular_y           = false;
     sd_ctx_params->chroma_use_dit_mask  = true;
     sd_ctx_params->chroma_use_t5_mask   = false;
     sd_ctx_params->chroma_t5_mask_pad   = 1;
@@ -3114,8 +3099,6 @@ char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {
              "auto_fit: %s\n"
              "flash_attn: %s\n"
              "diffusion_flash_attn: %s\n"
-             "circular_x: %s\n"
-             "circular_y: %s\n"
              "chroma_use_dit_mask: %s\n"
              "chroma_use_t5_mask: %s\n"
              "chroma_t5_mask_pad: %d\n"
@@ -3152,8 +3135,6 @@ char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {
              BOOL_STR(sd_ctx_params->auto_fit),
              BOOL_STR(sd_ctx_params->flash_attn),
              BOOL_STR(sd_ctx_params->diffusion_flash_attn),
-             BOOL_STR(sd_ctx_params->circular_x),
-             BOOL_STR(sd_ctx_params->circular_y),
              BOOL_STR(sd_ctx_params->chroma_use_dit_mask),
              BOOL_STR(sd_ctx_params->chroma_use_t5_mask),
              sd_ctx_params->chroma_t5_mask_pad,
@@ -3234,6 +3215,8 @@ void sd_img_gen_params_init(sd_img_gen_params_t* sd_img_gen_params) {
     sd_img_gen_params->batch_count       = 1;
     sd_img_gen_params->control_strength  = 0.9f;
     sd_img_gen_params->qwen_image_layers = 3;
+    sd_img_gen_params->circular_x        = false;
+    sd_img_gen_params->circular_y        = false;
     sd_img_gen_params->pm_params         = {nullptr, 0, nullptr, 20.f};
     sd_img_gen_params->pulid_params      = {nullptr, 1.0f};
     sd_img_gen_params->vae_tiling_params = {false, false, 0, 0, 0.5f, 0.0f, 0.0f, nullptr};
@@ -3267,6 +3250,8 @@ char* sd_img_gen_params_to_str(const sd_img_gen_params_t* sd_img_gen_params) {
              "control_strength: %.2f\n"
              "photo maker: {style_strength = %.2f, id_images_count = %d, id_embed_path = %s}\n"
              "VAE tiling: %s (temporal=%s, extra_tiling_args=%s)\n"
+             "circular_x: %s\n"
+             "circular_y: %s\n"
              "hires: {enabled=%s, upscaler=%s, model_path=%s, scale=%.2f, target=%dx%d, steps=%d, denoising_strength=%.2f}\n",
              SAFE_STR(sd_img_gen_params->prompt),
              SAFE_STR(sd_img_gen_params->negative_prompt),
@@ -3288,6 +3273,8 @@ char* sd_img_gen_params_to_str(const sd_img_gen_params_t* sd_img_gen_params) {
              BOOL_STR(sd_img_gen_params->vae_tiling_params.enabled),
              BOOL_STR(sd_img_gen_params->vae_tiling_params.temporal_tiling),
              SAFE_STR(sd_img_gen_params->vae_tiling_params.extra_tiling_args),
+             BOOL_STR(sd_img_gen_params->circular_x),
+             BOOL_STR(sd_img_gen_params->circular_y),
              BOOL_STR(sd_img_gen_params->hires.enabled),
              sd_hires_upscaler_name(sd_img_gen_params->hires.upscaler),
              SAFE_STR(sd_img_gen_params->hires.model_path),
@@ -3336,6 +3323,8 @@ void sd_vid_gen_params_init(sd_vid_gen_params_t* sd_vid_gen_params) {
     sd_vid_gen_params->hires.upscale_tile_size               = 128;
     sd_vid_gen_params->hires.custom_sigmas                   = nullptr;
     sd_vid_gen_params->hires.custom_sigmas_count             = 0;
+    sd_vid_gen_params->circular_x                            = false;
+    sd_vid_gen_params->circular_y                            = false;
     sd_cache_params_init(&sd_vid_gen_params->cache);
 }
 
@@ -4211,6 +4200,25 @@ struct CircularAxesState {
     bool circular_y = false;
 };
 
+static void apply_circular_axes_to_diffusion(sd_ctx_t* sd_ctx, bool circular_x, bool circular_y) {
+    sd_ctx->sd->circular_x = circular_x;
+    sd_ctx->sd->circular_y = circular_y;
+    if (sd_ctx->sd->diffusion_model) {
+        sd_ctx->sd->diffusion_model->set_circular_axes(circular_x, circular_y);
+    }
+    if (sd_ctx->sd->high_noise_diffusion_model) {
+        sd_ctx->sd->high_noise_diffusion_model->set_circular_axes(circular_x, circular_y);
+    }
+    if (sd_ctx->sd->control_net) {
+        sd_ctx->sd->control_net->set_circular_axes(circular_x, circular_y);
+    }
+    if (circular_x || circular_y) {
+        LOG_INFO("Using circular padding for convolutions (x=%s, y=%s)",
+                 circular_x ? "true" : "false",
+                 circular_y ? "true" : "false");
+    }
+}
+
 static CircularAxesState configure_image_vae_axes(sd_ctx_t* sd_ctx,
                                                   const sd_img_gen_params_t* sd_img_gen_params,
                                                   const GenerationRequest& request) {
@@ -4967,6 +4975,7 @@ SD_API bool generate_image(sd_ctx_t* sd_ctx,
     sd_ctx->sd->sampler_rng->manual_seed(request.seed);
     sd_ctx->sd->set_flow_shift(sd_img_gen_params->sample_params.flow_shift);
     sd_ctx->sd->apply_loras(sd_img_gen_params->loras, sd_img_gen_params->lora_count);
+    apply_circular_axes_to_diffusion(sd_ctx, sd_img_gen_params->circular_x, sd_img_gen_params->circular_y);
 
     ImageVaeAxesGuard axes_guard(sd_ctx, sd_img_gen_params, request);
 
@@ -5805,6 +5814,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
     }
     int64_t t0                    = ggml_time_ms();
     sd_ctx->sd->vae_tiling_params = sd_vid_gen_params->vae_tiling_params;
+    apply_circular_axes_to_diffusion(sd_ctx, sd_vid_gen_params->circular_x, sd_vid_gen_params->circular_y);
     GenerationRequest request(sd_ctx, sd_vid_gen_params);
     bool latent_upscale_enabled     = request.hires.enabled;
     GenerationRequest hires_request = request;


### PR DESCRIPTION
## Summary

Moves the `circular_x` / `circular_y` flags from `sd_ctx_params_t` to `sd_img_gen_params_t` and `sd_vid_gen_params_t`. Previously users had to unload and reload the model to switch between tileable and non-tileable output; now they can vary it per generate call on a persistent context.

The setter `set_circular_axes` is just two bool assignments on the runner context, and the VAE encode/decode entry points already take `circular_x` / `circular_y` as function arguments, so nothing about the plumbing required a load-time decision.

## Related Issue / Discussion

None.

## Additional Information

### Behavior verified

Loaded AcornXL_V2 (SDXL) once, ran two consecutive generations of \"seamless tiling brick wall texture, flat lighting\" at 512x512, 20 steps, karras, seed 42:

- With `--circular`: log shows `Using circular padding for convolutions (x=true, y=true)`, output has wrapped edges.
- Without: log stays silent, output is a normal brick wall.

Same executable, same code path, no reload.

### Changes

- `sd_ctx_params_t`: dropped `circular_x`, `circular_y` (default init, param string, and print). Load-time `set_circular_axes` calls in `StableDiffusionGGML::load_from_file` removed.
- `sd_img_gen_params_t`, `sd_vid_gen_params_t`: appended `circular_x`, `circular_y`; wired defaults in `_init` and printing in `sd_img_gen_params_to_str`.
- New helper `apply_circular_axes_to_diffusion(sd_ctx, cx, cy)` invoked at the top of `generate_image` / `generate_video`. Sets the sd struct fields (so the existing VAE guard picks them up) and calls `set_circular_axes` on `diffusion_model`, `high_noise_diffusion_model`, and `control_net`. Logs only when a flag is on.
- CLI: `--circular`, `--circularx`, `--circulary` moved from `SDParams` to `SDGenerationParams`; assignment routed to `sd_img_gen_params_t` / `sd_vid_gen_params_t` in `to_sd_img_gen_params_t` and `to_sd_vid_gen_params_t`.
- Enum values and existing gen struct field order preserved; new fields appended.

### Notes

- No CUDA / Vulkan gating - circular padding is model-side conv padding, backend-agnostic.
- The VAE tiling adjust logic (`configure_image_vae_axes`) continues to read `sd_ctx->sd->circular_x/y`. Those are now set from gen params at generate-time, one line before the guard runs.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).