### PR TITLE
imatrix: reject a repeated entry with an inconsistent value count (#1749)

### DIFF
--- a/src/runtime/imatrix.cpp
+++ b/src/runtime/imatrix.cpp
@@ -287,6 +287,10 @@ bool IMatrixCollector::load_imatrix(const char* fname) {
         if (e.values.empty()) {
             e.values.resize(nval, 0);
             e.counts.resize(nval, 0);
+        } else if (e.values.size() != (size_t)nval) {
+            LOG_ERROR("inconsistent size for a repeated entry (%d vs %d)\n", (int)e.values.size(), nval);
+            stats_ = {};
+            return false;
         }
 
         std::vector<float> tmp(nval);


### PR DESCRIPTION
Fixes #1749.

`load_imatrix` resizes an entry's `values`/`counts` vectors only when they are empty, so a repeated tensor name with a larger `nval` writes past the end of both buffers in the accumulation loop. This mirrors the check `collect_imatrix` already does in the same file: reject a repeated entry whose value count does not match, instead of writing out of bounds. Valid imatrix files are unaffected; a crafted file with a mismatched repeated entry is cleanly rejected with an error.
