### PR TITLE
fix: validate safetensors data offsets

### DIFF
--- a/src/model_io/safetensors_io.cpp
+++ b/src/model_io/safetensors_io.cpp
@@ -43,7 +43,7 @@ bool is_safetensors_file(const std::string& file_path) {
     }
 
     size_t header_size_ = model_io::read_u64(header_size_buf);
-    if (header_size_ >= file_size_ || header_size_ <= 2) {
+    if (header_size_ > file_size_ - ST_HEADER_SIZE_LEN || header_size_ <= 2) {
         return false;
     }
 
@@ -114,10 +114,11 @@ bool read_safetensors_file(const std::string& file_path,
     }
 
     size_t header_size_ = model_io::read_u64(header_size_buf);
-    if (header_size_ >= file_size_) {
+    if (header_size_ > file_size_ - ST_HEADER_SIZE_LEN) {
         set_error(error, "invalid safetensor file '" + file_path + "'");
         return false;
     }
+    const size_t data_start = ST_HEADER_SIZE_LEN + header_size_;
 
     // read header
     std::vector<char> header_buf;
@@ -156,6 +157,10 @@ bool read_safetensors_file(const std::string& file_path,
 
         size_t begin = tensor_info["data_offsets"][0].get<size_t>();
         size_t end   = tensor_info["data_offsets"][1].get<size_t>();
+        if (begin > end || end > file_size_ - data_start) {
+            set_error(error, "data offsets out of bounds for tensor '" + name + "'");
+            return false;
+        }
 
         ggml_type type = safetensors_dtype_to_ggml_type(dtype);
         if (type == GGML_TYPE_COUNT) {
@@ -187,7 +192,7 @@ bool read_safetensors_file(const std::string& file_path,
             n_dims = 1;
         }
 
-        TensorStorage tensor_storage(name, type, ne, n_dims, 0, ST_HEADER_SIZE_LEN + header_size_ + begin);
+        TensorStorage tensor_storage(name, type, ne, n_dims, 0, data_start + begin);
         tensor_storage.reverse_ne();
 
         size_t tensor_data_size = end - begin;

--- a/src/runtime/denoiser.hpp
+++ b/src/runtime/denoiser.hpp
@@ -1897,10 +1897,10 @@ public:
     }
 
     sd::Tensor<float> operator()(double sigma_a, double sigma_b) {
-        double a          = clamp(std::min(sigma_a, sigma_b));
-        double b          = clamp(std::max(sigma_a, sigma_b));
-        auto dW           = w(b) - w(a);
-        float span        = static_cast<float>(std::max(std::abs(sigma_b - sigma_a), 1e-12));
+        double a   = clamp(std::min(sigma_a, sigma_b));
+        double b   = clamp(std::max(sigma_a, sigma_b));
+        auto dW    = w(b) - w(a);
+        float span = static_cast<float>(std::max(std::abs(sigma_b - sigma_a), 1e-12));
         return dW * (1.0f / std::sqrt(span));
     }
 


### PR DESCRIPTION
## Summary

 - Validate safetensors header length relative to the 8-byte size prefix.
 - Reject tensor `data_offsets` where `begin > end` or where the declared tensor byte range extends past the file data section.

## Related Issue / Discussion

N/A

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
