### PR TITLE
fix: avoid f16 overflow in Z-Image quantized matmuls on ROCm

### DIFF
--- a/src/model/diffusion/z_image.hpp
+++ b/src/model/diffusion/z_image.hpp
@@ -150,6 +150,8 @@ namespace ZImage {
 
             if (sd_backend_is(ctx->backend, "ROCm")) {
                 out_proj->set_scale(1.f / 16.f);
+                out_proj->set_force_prec_f32(true);
+                qkv_proj->set_force_prec_f32(true);
             }
 
             auto qkv = qkv_proj->forward(ctx, x);                                                                            // [N, n_token, (num_heads + num_kv_heads*2)*head_dim]
@@ -227,7 +229,7 @@ namespace ZImage {
             auto w2 = std::dynamic_pointer_cast<Linear>(blocks["w2"]);
             auto w3 = std::dynamic_pointer_cast<Linear>(blocks["w3"]);
 
-            if (sd_backend_is(ctx->backend, "Vulkan")) {
+            if (sd_backend_is(ctx->backend, "Vulkan") || sd_backend_is(ctx->backend, "ROCm")) {
                 w2->set_force_prec_f32(true);
             }
 


### PR DESCRIPTION
Fixes white image generation on ROCm backend by forcing 32-bit precision.

I don't know how many other image engines are affected, but might be worth a look.

- [X] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
