### PR TITLE
fix: protect cross_attn and output_proj tokens for Anima LoRAs

### DIFF
--- a/src/name_conversion.cpp
+++ b/src/name_conversion.cpp
@@ -1102,6 +1102,8 @@ std::string convert_sep_to_dot(std::string name) {
         "norm1_context",
         "ff_context",
         "x_embedder",
+        "cross_attn",
+        "output_proj",
     };
 
     // record the positions of underscores that should NOT be replaced


### PR DESCRIPTION
## Summary

Fixes the names for some attn-related tensors when loading LoRAs for anima models.


## Related Issue / Discussion

N/A

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
