### PR TITLE
fix: avoid structured binding capture in Hunyuan config

### DIFF
--- a/src/model/diffusion/hunyuan.hpp
+++ b/src/model/diffusion/hunyuan.hpp
@@ -197,7 +197,9 @@ namespace Hunyuan {
                 }
             }
 
-            for (const auto& [name, storage] : tensor_storage_map) {
+            for (const auto& entry : tensor_storage_map) {
+                const auto& name    = entry.first;
+                const auto& storage = entry.second;
                 if (!starts_with(name, prefix)) {
                     continue;
                 }


### PR DESCRIPTION
## Summary

- Avoid capturing structured bindings in Hunyuan Video weight detection
- Restore compatibility with clang 14 in C++17 mode, fixing the MUSA container build

## Related Issue / Discussion

N/A

## Additional Information

N/A

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
