### PR TITLE
feat: optional cooperative cancellation for in-flight image generation

### DIFF
--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -343,6 +343,15 @@ typedef void (*sd_preview_cb_t)(int step, int frame_count, sd_image_t* frames, b
 
 SD_API void sd_set_log_callback(sd_log_cb_t sd_log_cb, void* data);
 SD_API void sd_set_progress_callback(sd_progress_cb_t cb, void* data);
+
+// Optional cooperative cancellation of an in-flight generation. Backend-agnostic:
+// the sampler loop polls sd_is_cancelled() once per step and abandons cleanly, so a
+// cancelled generation returns an empty result rather than an error. Call
+// sd_reset_cancel() before starting a generation; sd_request_cancel() is safe to call
+// from another thread while one is running.
+SD_API void sd_request_cancel(void);
+SD_API void sd_reset_cancel(void);
+SD_API bool sd_is_cancelled(void);
 SD_API void sd_set_preview_callback(sd_preview_cb_t cb, enum preview_t mode, int interval, bool denoised, bool noisy, void* data);
 SD_API int32_t sd_get_num_physical_cores();
 SD_API const char* sd_get_system_info();

--- a/src/denoiser.hpp
+++ b/src/denoiser.hpp
@@ -6,6 +6,8 @@
 #include "ggml_extend.hpp"
 #include "gits_noise.inl"
 
+#include "stable-diffusion.h"
+
 /*================================================= CompVisDenoiser ==================================================*/
 
 // Ref: https://github.com/crowsonkb/k-diffusion/blob/master/k_diffusion/external.py
@@ -777,6 +779,7 @@ static bool sample_k_diffusion(sample_method_t method,
             ggml_tensor* d     = ggml_dup_tensor(work_ctx, x);
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 float sigma = sigmas[i];
 
                 // denoise
@@ -833,6 +836,7 @@ static bool sample_k_diffusion(sample_method_t method,
             ggml_tensor* d = ggml_dup_tensor(work_ctx, x);
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 float sigma = sigmas[i];
 
                 // denoise
@@ -869,6 +873,7 @@ static bool sample_k_diffusion(sample_method_t method,
             ggml_tensor* x2 = ggml_dup_tensor(work_ctx, x);
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 // denoise
                 ggml_tensor* denoised = model(x, sigmas[i], -(i + 1));
                 if (denoised == nullptr) {
@@ -925,6 +930,7 @@ static bool sample_k_diffusion(sample_method_t method,
             ggml_tensor* x2 = ggml_dup_tensor(work_ctx, x);
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 // denoise
                 ggml_tensor* denoised = model(x, sigmas[i], -(i + 1));
                 if (denoised == nullptr) {
@@ -983,6 +989,7 @@ static bool sample_k_diffusion(sample_method_t method,
             ggml_tensor* x2    = ggml_dup_tensor(work_ctx, x);
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 // denoise
                 ggml_tensor* denoised = model(x, sigmas[i], -(i + 1));
                 if (denoised == nullptr) {
@@ -1055,6 +1062,7 @@ static bool sample_k_diffusion(sample_method_t method,
             auto t_fn = [](float sigma) -> float { return -log(sigma); };
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 // denoise
                 ggml_tensor* denoised = model(x, sigmas[i], i + 1);
                 if (denoised == nullptr) {
@@ -1097,6 +1105,7 @@ static bool sample_k_diffusion(sample_method_t method,
             auto t_fn = [](float sigma) -> float { return -log(sigma); };
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 // denoise
                 ggml_tensor* denoised = model(x, sigmas[i], i + 1);
                 if (denoised == nullptr) {
@@ -1143,6 +1152,7 @@ static bool sample_k_diffusion(sample_method_t method,
             std::vector<ggml_tensor*> buffer_model;
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 float sigma      = sigmas[i];
                 float sigma_next = sigmas[i + 1];
 
@@ -1221,6 +1231,7 @@ static bool sample_k_diffusion(sample_method_t method,
             ggml_tensor* x_next = x;
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 float sigma  = sigmas[i];
                 float t_next = sigmas[i + 1];
 
@@ -1294,6 +1305,7 @@ static bool sample_k_diffusion(sample_method_t method,
             ggml_tensor* d     = ggml_dup_tensor(work_ctx, x);
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 float sigma = sigmas[i];
 
                 // denoise
@@ -1364,6 +1376,7 @@ static bool sample_k_diffusion(sample_method_t method,
                 ggml_dup_tensor(work_ctx, x);
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 // The "trailing" DDIM timestep, see S. Lin et al.,
                 // "Common Diffusion Noise Schedulers and Sample Steps
                 // are Flawed", arXiv:2305.08891 [cs], p. 4, Table
@@ -1551,6 +1564,7 @@ static bool sample_k_diffusion(sample_method_t method,
                 ggml_dup_tensor(work_ctx, x);
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 // Analytic form for TCD timesteps
                 int timestep = TIMESTEPS - 1 -
                                (TIMESTEPS / original_steps) *
@@ -1712,6 +1726,7 @@ static bool sample_k_diffusion(sample_method_t method,
             };
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 ggml_tensor* denoised = model(x, sigmas[i], i + 1);
                 if (denoised == nullptr) {
                     return false;
@@ -1818,6 +1833,7 @@ static bool sample_k_diffusion(sample_method_t method,
             };
 
             for (int i = 0; i < steps; i++) {
+                if (sd_is_cancelled()) { return false; }  // cooperative cancel: abandon at the next step
                 float sigma_from = sigmas[i];
                 float sigma_to   = sigmas[i + 1];
 

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -25,6 +25,28 @@
 #include "latent-preview.h"
 #include "name_conversion.h"
 
+#include <atomic>
+
+// Cooperative cancellation flag. The sampler step loop (denoiser.hpp) polls
+// sd_is_cancelled() and abandons the diffusion cleanly; generate_image_internal also
+// short-circuits between pipeline stages. A single process-wide flag is sufficient for
+// a caller that runs one generation at a time. Clear it with sd_reset_cancel() before
+// starting a generation -- never from inside a running one -- so that a cancel raised
+// during model load, encode, sampling, or decode persists for the whole call.
+static std::atomic<bool> g_sd_cancel{false};
+
+void sd_request_cancel(void) {
+    g_sd_cancel.store(true, std::memory_order_relaxed);
+}
+
+void sd_reset_cancel(void) {
+    g_sd_cancel.store(false, std::memory_order_relaxed);
+}
+
+bool sd_is_cancelled(void) {
+    return g_sd_cancel.load(std::memory_order_relaxed);
+}
+
 const char* model_version_to_str[] = {
     "SD 1.x",
     "SD 1.x Inpaint",
@@ -2348,7 +2370,9 @@ public:
         };
 
         if (!sample_k_diffusion(method, denoise, work_ctx, x, sigmas, sampler_rng, eta)) {
-            LOG_ERROR("Diffusion model sampling failed");
+            if (!sd_is_cancelled()) {  // cancellation is expected control flow, not an error
+                LOG_ERROR("Diffusion model sampling failed");
+            }
             if (control_net) {
                 control_net->free_control_ctx();
                 control_net->free_compute_buffer();
@@ -3145,6 +3169,13 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
         (sd_version_is_inpaint_or_unet_edit(sd_ctx->sd->version) && guidance.txt_cfg != guidance.img_cfg)) {
         img_cond = SDCondition(uncond.c_crossattn, uncond.c_vector, cond.c_concat);
     }
+    // A cancel that arrived during text encoding (before the sampler's per-step checks
+    // engage) short-circuits here, before any sampling work. ggml_free(work_ctx) matches
+    // the existing NULL-return cleanup path.
+    if (sd_is_cancelled()) {
+        ggml_free(work_ctx);
+        return NULL;
+    }
     for (int b = 0; b < batch_count; b++) {
         int64_t sampling_start = ggml_time_ms();
         int64_t cur_seed       = seed + b;
@@ -3192,7 +3223,7 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
             // print_ggml_tensor(x_0);
             LOG_INFO("sampling completed, taking %.2fs", (sampling_end - sampling_start) * 1.0f / 1000);
             final_latents.push_back(x_0);
-        } else {
+        } else if (!sd_is_cancelled()) {  // cancellation is expected control flow, not an error
             LOG_ERROR("sampling for image %d/%d failed after %.2fs", b + 1, batch_count, (sampling_end - sampling_start) * 1.0f / 1000);
         }
     }
@@ -3202,6 +3233,13 @@ sd_image_t* generate_image_internal(sd_ctx_t* sd_ctx,
     }
     int64_t t3 = ggml_time_ms();
     LOG_INFO("generating %" PRId64 " latent images completed, taking %.2fs", final_latents.size(), (t3 - t1) * 1.0f / 1000);
+
+    // A cancel raised during or just after sampling skips the VAE decode entirely.
+    // ggml_free(work_ctx) matches the existing NULL-return cleanup path.
+    if (sd_is_cancelled()) {
+        ggml_free(work_ctx);
+        return NULL;
+    }
 
     // Decode to image
     LOG_INFO("decoding %zu latents", final_latents.size());


### PR DESCRIPTION
## Summary

Adds an optional cooperative cancellation primitive so a host application can abandon an **in-flight `generate_image`** call and get an empty result back promptly, instead of waiting for the full denoise plus VAE decode to finish.

Motivation: in an interactive host, a long generation sometimes needs to be dropped the moment the user does something else. Today there is no way to interrupt a generation once it is running — only to let it finish and discard the result.

## API

Three new functions in `stable-diffusion.h`:

```c
SD_API void sd_request_cancel(void);  // ask the running generation to abandon at its next step
SD_API void sd_reset_cancel(void);    // clear the flag; call before starting a generation
SD_API bool sd_is_cancelled(void);    // read the flag
```

Existing behaviour is unchanged for anyone who never calls `sd_request_cancel()`.

## How it works

- A file-scope `std::atomic<bool>` flag.
- `sample_k_diffusion` polls it once at the top of each step loop. On cancel the loop returns `false` — the same clean-abort path each sampler already takes when `denoised == nullptr` — which unwinds to a `NULL` result naturally.
- Two additional short-circuits in `generate_image_internal` (after text encoding, and before the VAE decode) catch a cancel that lands between the per-step checks, freeing `work_ctx` on the way out to match the function's existing `NULL`-return cleanup.
- A cancelled generation therefore yields an empty result rather than an error, so the two sampling-failure `LOG_ERROR` calls are suppressed while a cancel is in effect.

This is deliberately host-side C++ rather than a ggml abort callback, so it behaves identically across CPU, CUDA, Vulkan and Metal builds.

## Notes and open questions

- The flag is **process-wide**, which is simple and correct for a caller that runs one generation at a time. It does not target a specific `sd_ctx_t`.
- If you would prefer a **per-`sd_ctx` cancel** so concurrent contexts can be cancelled independently, I am happy to rework it that way, with tests in whatever style you prefer. I did not want to build the larger variant speculatively — let me know your preference and I will adjust before you spend review time on this shape.
- `generate_video` is untouched here; the same primitive extends to it easily if that is wanted.
- The branch is based on `545fac4` rather than current `master`, since that is the commit this was built and exercised against. Happy to rebase.

## Testing

Exercised against real FLUX.2-Klein generations from a host application on macOS/Metal:

- a normal generation still returns a full image;
- a cancel requested mid-generation (at step 6 of 28) returns an empty result promptly with no crash;
- a cancel flag set before a generation short-circuits it in ~380 ms against a ~10.4 s uncancelled baseline.

I have not added tests to this repo — glad to add some in your preferred style if you would like them before merging.
