### PR TITLE
fix: detect vision patch size for unsplit (HF-format) Qwen3-VL

### DIFF
--- a/src/model/te/llm.hpp
+++ b/src/model/te/llm.hpp
@@ -200,7 +200,11 @@ namespace LLM {
                         config.vision.in_channels = tensor_storage.ne[2];
                         config.vision.hidden_size = tensor_storage.ne[3];
                     }
-                    if (contains(name, "visual.patch_embed.bias")) {
+                    // HF-format checkpoints keep the patch embed unsplit under a single name.
+                    if (contains(name, "visual.patch_embed.proj.weight")) {
+                        config.vision.patch_size = static_cast<int>(tensor_storage.ne[0]);
+                    }
+                    if (contains(name, "visual.patch_embed.bias") || contains(name, "visual.patch_embed.proj.bias")) {
                         config.vision.hidden_size = tensor_storage.ne[0];
                     }
                     if (contains(name, "visual.pos_embed.weight")) {


### PR DESCRIPTION
## Summary

HF/ComfyUI-format Qwen3-VL text encoders keep the vision patch embed **unsplit** as `visual.patch_embed.proj.weight`. The existing detection only matches the split `visual.patch_embed.proj.0.weight`, so `vision.patch_size` silently stays at the Qwen2.5-VL default of 14 instead of 16. Any model that builds the Qwen3-VL vision tower (e.g. Mage-Flow) then fails to load such an encoder with `patch_embed.proj.weight got [16, 16, ...], expected [14, 14, ...]`.

This reads the patch size from the unsplit weight's kernel extent (`ne[0]`), and additionally derives `hidden_size` from `visual.patch_embed.proj.bias` (the split name `visual.patch_embed.bias` does not match the unsplit `.proj.bias`). GGUF-sourced and split-format encoders are unaffected.

The `model.language_model.*` naming difference is already handled by `scripts/convert_qwen3_vl.py`; this only fixes the remaining patch-size detection, which that script does not touch.

## Related Issue / Discussion

Related to #1708 - users hit this loading the Comfy-Org bf16 Qwen3-VL; the convert script fixes naming but the unsplit patch size still mis-detects.

## Additional Information

Verified with the bf16 Qwen3-VL-4B from `Comfy-Org/Krea-2`, run through `scripts/convert_qwen3_vl.py`, then loaded as `--llm` for Mage-Flow: before this change it fails with `patch_embed.proj.weight ... expected [14, 14, ...]`; after, it loads and generates correctly. GGUF encoders continue to work unchanged.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
