### PR TITLE
fix: add missing sampler names to stable-diffusion.cpp

### DIFF
--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -141,6 +141,8 @@ const char* sampling_methods_str[] = {
     "Euler CFG++",
     "Euler A CFG++",
     "Euler GE",
+    "DPM++ (2M) SDE",
+    "DPM++ (2M) SDE BT",
 };
 
 /*================================================== Helper Functions ================================================*/


### PR DESCRIPTION
Addendum to https://github.com/leejet/stable-diffusion.cpp/pull/1742, https://github.com/leejet/stable-diffusion.cpp/pull/1743.

And thank you!