### PR TITLE
fix: null pointer dereference when loading malformed LoHa file

### DIFF
--- a/src/model/adapter/lora.hpp
+++ b/src/model/adapter/lora.hpp
@@ -342,7 +342,9 @@ struct LoraModel : public GGMLRunner {
             iter = lora_tensors.find(hada_1_mid_name);
             if (iter != lora_tensors.end()) {
                 hada_1_mid = ggml_ext_cast_f32(ctx, backend, iter->second);
-                hada_1_up  = ggml_cont(ctx, ggml_transpose(ctx, hada_1_up));
+                if (hada_1_up != nullptr) {
+                    hada_1_up = ggml_cont(ctx, ggml_transpose(ctx, hada_1_up));
+                }
             }
 
             iter = lora_tensors.find(hada_2_down_name);
@@ -358,7 +360,9 @@ struct LoraModel : public GGMLRunner {
             iter = lora_tensors.find(hada_2_mid_name);
             if (iter != lora_tensors.end()) {
                 hada_2_mid = ggml_ext_cast_f32(ctx, backend, iter->second);
-                hada_2_up  = ggml_cont(ctx, ggml_transpose(ctx, hada_2_up));
+                if (hada_2_up != nullptr) {
+                    hada_2_up = ggml_cont(ctx, ggml_transpose(ctx, hada_2_up));
+                }
             }
 
             if (hada_1_up == nullptr || hada_1_down == nullptr || hada_2_up == nullptr || hada_2_down == nullptr) {


### PR DESCRIPTION
## Summary

<!-- Describe what changed and why. Keep the PR focused on one clear change. -->

In `get_loha_weight_diff()`, a null pointer dereference occurs when `hada_t1` is present but `hada_w1_a` is missing, or when `hada_t2` is present but `hada_w2_a` is missing.

## Related Issue / Discussion

<!-- Link related issues, discussions, or previous PRs if applicable. -->

The nullptr check at line 368 (`if (hada_1_up == nullptr || ...`) is never reached because the crash happens first.

## Additional Information

<!-- Add verification notes, screenshots, sample output, or other context when applicable. -->

To reproduce the crash:
```
printf '\x8a\x00\x00\x00\x00\x00\x00\x00{"model.diffusion_model.input_blocks.1.1.transformer_blocks.0.attn1.to_q.hada_t1": {"dtype": "F32", "shape": [1], "data_offsets": [0, 4]}}AAAA' > /tmp/bad.safetensors
./bin/sd-cli -m ../models/v1-5-pruned-emaonly.safetensors --lora-model-dir /tmp -p "<lora:bad.safetensors:1.0>" -o /tmp/output.png
```

## Checklist

- [X] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
