### PR TITLE
feat: add -ngl to cap diffusion layers resident in VRAM

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -202,6 +202,37 @@ sd-cli -m model.safetensors -p "a cat" --backend diffusion=cuda0,te=cpu,vae=cpu 
 
 This keeps text encoding and VAE execution on CPU while the diffusion model runs on GPU.
 
+## Layer count (`-ngl`)
+
+`-ngl` / `--gpu-layers` caps how many diffusion layers stay resident in VRAM.
+The remainder live in RAM and are copied in for the layer that needs them, then
+released:
+
+```shell
+sd-cli -m model.safetensors -p "a cat" -ngl 20
+```
+
+The default of `-1` keeps everything on the GPU. `-ngl 0` keeps no layer
+resident, which is the slowest but smallest-footprint setting.
+
+The count is an upper bound, not a demand: residency is also capped by what the
+device can actually hold, so asking for more layers than fit fills VRAM and
+streams the remainder instead of failing. `-ngl 999` is therefore a reasonable
+way to say "use as much VRAM as there is". Unlike llama.cpp, the number will not
+push the allocator past what it has.
+
+Because streaming reads weights out of host memory, `-ngl` implies
+`--offload-to-cpu` and `--stream-layers`; setting it is enough on its own.
+
+This is the count-based counterpart of `--max-vram`, which expresses the same
+residency decision as a byte budget. When `-ngl` is given it takes precedence,
+and segment merging is disabled so that one segment corresponds to one layer.
+Like the other single-device mechanisms it does not combine with a multi-device
+layer split.
+
+Use `-v` to see the split; each layer logs as `residency=RESIDENT` or
+`residency=STREAMED`.
+
 ## Backend sharing and lifetime
 
 Backends are managed by `SDBackendManager`.

--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -513,6 +513,12 @@ ArgOptions SDContextParams::get_options() {
          "number of threads to use during computation (default: -1). "
          "If threads <= 0, then threads will be set to the number of CPU physical cores",
          &n_threads},
+        {"-ngl",
+         "--gpu-layers",
+         "maximum number of diffusion layers to keep resident in VRAM; the remainder stream from RAM "
+         "each step (default: -1, keep everything on the GPU). Also capped by available VRAM, so a "
+         "large value simply fills the device. Implies --offload-to-cpu and --stream-layers",
+         &n_gpu_layers},
     };
 
     options.bool_options = {
@@ -772,8 +778,13 @@ void SDContextParams::prepare_backend_assignments() {
     effective_backend        = backend;
     effective_params_backend = params_backend;
 
-    if (offload_params_to_cpu) {
+    // Streaming reads weights out of host memory, so a layer budget only means
+    // anything once the diffusion params live on the CPU.
+    if (offload_params_to_cpu || n_gpu_layers >= 0) {
         prepend_backend_assignment(effective_params_backend, "*=cpu");
+    }
+    if (n_gpu_layers >= 0) {
+        stream_layers = true;
     }
 
     if (clip_on_cpu) {
@@ -832,6 +843,7 @@ std::string SDContextParams::to_string() const {
         << "  offload_params_to_cpu: " << (offload_params_to_cpu ? "true" : "false") << ",\n"
         << "  max_vram: \"" << max_vram << "\",\n"
         << "  stream_layers: " << (stream_layers ? "true" : "false") << ",\n"
+        << "  n_gpu_layers: " << n_gpu_layers << ",\n"
         << "  eager_load: " << (eager_load ? "true" : "false") << ",\n"
         << "  backend: \"" << backend << "\",\n"
         << "  params_backend: \"" << params_backend << "\",\n"
@@ -904,6 +916,7 @@ sd_ctx_params_t SDContextParams::to_sd_ctx_params_t(bool taesd_preview) {
     sd_ctx_params.vae_format                      = str_to_vae_format(vae_format);
     sd_ctx_params.max_vram                        = max_vram.c_str();
     sd_ctx_params.stream_layers                   = stream_layers;
+    sd_ctx_params.n_gpu_layers                    = n_gpu_layers;
     sd_ctx_params.eager_load                      = eager_load;
     sd_ctx_params.backend                         = effective_backend.c_str();
     sd_ctx_params.params_backend                  = effective_params_backend.c_str();

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -151,6 +151,7 @@ struct SDContextParams {
     bool offload_params_to_cpu  = false;
     std::string max_vram        = "0";
     bool stream_layers          = false;
+    int n_gpu_layers            = -1;
     bool eager_load             = false;
     std::string backend;
     std::string params_backend;

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -223,6 +223,7 @@ typedef struct {
     enum sd_vae_format_t vae_format;
     const char* max_vram;  // GiB budget or backend assignment spec for graph-cut segmented param offload (0 = disabled, -1 = auto)
     bool stream_layers;  // Enable residency+prefetch streaming on top of --max-vram (no effect without --max-vram)
+    int n_gpu_layers;    // Diffusion layers kept resident in VRAM; the rest stream from RAM. <0 keeps all
     bool eager_load;  // Load all params into the params backend at model-load time instead of lazily on first use
     const char* backend;
     const char* params_backend;

--- a/src/core/ggml_extend.hpp
+++ b/src/core/ggml_extend.hpp
@@ -1746,8 +1746,11 @@ protected:
     ggml_context* compute_ctx    = nullptr;
     ggml_gallocr* compute_allocr = nullptr;
 
-    size_t max_graph_vram_bytes           = 0;
-    bool stream_layers_enabled            = false;
+    size_t max_graph_vram_bytes = 0;
+    bool stream_layers_enabled  = false;
+    // llama.cpp-style layer count: pin this many leading weight-bearing segments
+    // in VRAM and stream the rest. -1 leaves placement to the byte budget.
+    int n_gpu_layers                      = -1;
     size_t observed_max_effective_budget_ = 0;
     bool graph_cut_layer_split_enabled    = false;
     std::vector<size_t> graph_cut_layer_split_backend_vram_limits_;
@@ -2371,14 +2374,14 @@ protected:
     bool should_use_graph_cut_segmented_compute(const GraphCutPlan& plan) {
         return plan.has_cuts &&
                plan.valid &&
-               max_graph_vram_bytes > 0 &&
+               (max_graph_vram_bytes > 0 || n_gpu_layers >= 0) &&
                plan.segments.size() > 1 &&
                !sd_backend_is_cpu(runtime_backend) &&
                !is_multi_device();
     }
 
     bool can_attempt_graph_cut_segmented_compute() const {
-        return max_graph_vram_bytes > 0 &&
+        return (max_graph_vram_bytes > 0 || n_gpu_layers >= 0) &&
                !sd_backend_is_cpu(runtime_backend) &&
                !is_multi_device();
     }
@@ -2390,6 +2393,17 @@ protected:
         GGML_ASSERT(gf != nullptr);
 
         size_t effective_budget = max_graph_vram_bytes;
+        // -ngl without an explicit --max-vram still needs a byte budget, so that
+        // an over-large layer count is capped by what the device actually has.
+        if (n_gpu_layers >= 0 && max_graph_vram_bytes == 0 && runtime_backend != nullptr) {
+            ggml_backend_dev_t dev = ggml_backend_get_device(runtime_backend);
+            if (dev != nullptr && ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_CPU) {
+                size_t free_vram = 0, total_vram = 0;
+                ggml_backend_dev_memory(dev, &free_vram, &total_vram);
+                constexpr size_t safety_margin = 512ull * 1024 * 1024;
+                effective_budget               = (free_vram > safety_margin) ? (free_vram - safety_margin) : 0;
+            }
+        }
         if (stream_layers_enabled && max_graph_vram_bytes > 0 && runtime_backend != nullptr) {
             ggml_backend_dev_t dev = ggml_backend_get_device(runtime_backend);
             if (dev != nullptr && ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_CPU) {
@@ -2425,7 +2439,11 @@ protected:
         // a quarter so it builds smaller merged segments and chunk-K can fit
         // alongside. Without streaming the cap only adds dispatch overhead.
         size_t planner_budget = effective_budget;
-        if (stream_layers_enabled) {
+        if (n_gpu_layers >= 0) {
+            // An explicit layer count needs one segment per layer, so suppress the
+            // budget-driven merging that would otherwise coalesce them.
+            planner_budget = 0;
+        } else if (stream_layers_enabled) {
             size_t total_params_bytes = 0;
             for (const ggml_tensor* t : params_tensor_set_) {
                 if (t != nullptr) {
@@ -2443,8 +2461,8 @@ protected:
                                                      planner_budget,
                                                      params_tensor_set_,
                                                      get_desc().c_str());
-        if (stream_layers_enabled) {
-            sd::ggml_graph_cut::annotate_residency(*plan_out, effective_budget);
+        if (stream_layers_enabled || n_gpu_layers >= 0) {
+            sd::ggml_graph_cut::annotate_residency(*plan_out, effective_budget, n_gpu_layers);
         }
         if (stream_layers_enabled) {
             if (budget_increased) {
@@ -3170,6 +3188,19 @@ public:
             return;
         }
         stream_layers_enabled = enabled;
+    }
+
+    void set_n_gpu_layers(int n_layers) {
+        if (n_layers >= 0 && is_multi_device()) {
+            LOG_WARN("%s: -ngl is not supported with multiple runtime backends; ignoring",
+                     get_desc().c_str());
+            return;
+        }
+        n_gpu_layers = n_layers;
+        if (n_layers >= 0) {
+            // Residency is only honoured on the streaming path.
+            stream_layers_enabled = true;
+        }
     }
 
     void set_graph_cut_layer_split_enabled(bool enabled) {

--- a/src/core/ggml_graph_cut.cpp
+++ b/src/core/ggml_graph_cut.cpp
@@ -960,12 +960,15 @@ namespace sd::ggml_graph_cut {
         return resolved_plan;
     }
 
-    void annotate_residency(Plan& plan, size_t max_graph_vram_bytes) {
+    void annotate_residency(Plan& plan, size_t max_graph_vram_bytes, int n_gpu_layers) {
         // Cached plans may be reused with a smaller live budget.
         for (auto& seg : plan.segments) {
             seg.residency = SegmentResidency::STREAMED;
         }
-        if (max_graph_vram_bytes == 0 || plan.segments.size() < 2) {
+        if (plan.segments.size() < 2) {
+            return;
+        }
+        if (n_gpu_layers < 0 && max_graph_vram_bytes == 0) {
             return;
         }
 
@@ -995,18 +998,35 @@ namespace sd::ggml_graph_cut {
         constexpr size_t safety = 512ull * 1024 * 1024;
         const size_t reserved   = safety + worst_streamed_footprint;
 
-        if (max_graph_vram_bytes <= reserved) {
+        const bool has_budget = max_graph_vram_bytes > reserved;
+        if (!has_budget && n_gpu_layers < 0) {
             return;
         }
-        const size_t available = max_graph_vram_bytes - reserved;
+        const size_t available = has_budget ? max_graph_vram_bytes - reserved : 0;
 
+        // An explicit layer count caps how many segments may stay pinned; the
+        // budget independently caps how many actually fit. Whichever runs out
+        // first wins, so an over-large -ngl degrades into "as much as fits"
+        // rather than an allocation failure part-way through a denoise pass.
+        int remaining     = n_gpu_layers;
         size_t cumulative = 0;
         for (auto& seg : plan.segments) {
-            if (cumulative + seg.input_param_bytes > available) {
+            if (n_gpu_layers >= 0 && seg.input_param_bytes == 0) {
+                // Weightless segments cost no VRAM, so they never spend a slot.
+                seg.residency = SegmentResidency::RESIDENT;
+                continue;
+            }
+            if (remaining == 0) {
+                break;
+            }
+            if (has_budget && cumulative + seg.input_param_bytes > available) {
                 break;
             }
             seg.residency = SegmentResidency::RESIDENT;
             cumulative += seg.input_param_bytes;
+            if (remaining > 0) {
+                remaining--;
+            }
         }
     }
 

--- a/src/core/ggml_graph_cut.h
+++ b/src/core/ggml_graph_cut.h
@@ -122,7 +122,10 @@ namespace sd::ggml_graph_cut {
                       const char* log_desc);
 
     // Mark leading segments resident when they fit after streamed-segment headroom.
-    void annotate_residency(Plan& plan, size_t max_graph_vram_bytes);
+    // `n_gpu_layers >= 0` pins that many leading weight-bearing segments and
+    // streams the remainder, ignoring `max_graph_vram_bytes`. `-1` keeps the
+    // byte-budget behaviour.
+    void annotate_residency(Plan& plan, size_t max_graph_vram_bytes, int n_gpu_layers = -1);
 }  // namespace sd::ggml_graph_cut
 
 #endif  // __SD_CORE_GGML_GRAPH_CUT_H__

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -239,6 +239,7 @@ public:
     bool enable_mmap                     = false;
     sd::ggml_graph_cut::MaxVramAssignment max_vram_assignment;
     bool stream_layers = false;
+    int n_gpu_layers   = -1;
     bool eager_load    = false;
     std::string backend_spec;
     std::string params_backend_spec;
@@ -678,6 +679,7 @@ public:
         n_threads           = sd_ctx_params->n_threads;
         enable_mmap         = sd_ctx_params->enable_mmap;
         stream_layers       = sd_ctx_params->stream_layers;
+        n_gpu_layers        = sd_ctx_params->n_gpu_layers;
         eager_load          = sd_ctx_params->eager_load;
         backend_spec        = SAFE_STR(sd_ctx_params->backend);
         params_backend_spec = SAFE_STR(sd_ctx_params->params_backend);
@@ -1290,6 +1292,7 @@ public:
 
             diffusion_model->set_max_graph_vram_bytes(max_graph_vram_bytes_for_module(SDBackendModule::DIFFUSION));
             diffusion_model->set_stream_layers_enabled(stream_layers);
+            diffusion_model->set_n_gpu_layers(n_gpu_layers);
             if (!register_runner_params("Diffusion model",
                                         diffusion_model,
                                         SDBackendModule::DIFFUSION,
@@ -1300,6 +1303,7 @@ public:
             if (high_noise_diffusion_model) {
                 high_noise_diffusion_model->set_max_graph_vram_bytes(max_graph_vram_bytes_for_module(SDBackendModule::DIFFUSION));
                 high_noise_diffusion_model->set_stream_layers_enabled(stream_layers);
+                high_noise_diffusion_model->set_n_gpu_layers(n_gpu_layers);
                 if (!register_runner_params("High noise diffusion model",
                                             high_noise_diffusion_model,
                                             SDBackendModule::DIFFUSION,
@@ -3432,6 +3436,7 @@ void sd_ctx_params_init(sd_ctx_params_t* sd_ctx_params) {
     sd_ctx_params->lora_apply_mode      = LORA_APPLY_AUTO;
     sd_ctx_params->max_vram             = nullptr;
     sd_ctx_params->stream_layers        = false;
+    sd_ctx_params->n_gpu_layers         = -1;
     sd_ctx_params->eager_load           = false;
     sd_ctx_params->enable_mmap          = false;
     sd_ctx_params->diffusion_flash_attn = false;
@@ -3477,6 +3482,7 @@ char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {
              "prediction: %s\n"
              "max_vram: %s\n"
              "stream_layers: %s\n"
+             "n_gpu_layers: %d\n"
              "eager_load: %s\n"
              "backend: %s\n"
              "params_backend: %s\n"
@@ -3511,6 +3517,7 @@ char* sd_ctx_params_to_str(const sd_ctx_params_t* sd_ctx_params) {
              sd_prediction_name(sd_ctx_params->prediction),
              SAFE_STR(sd_ctx_params->max_vram),
              BOOL_STR(sd_ctx_params->stream_layers),
+             sd_ctx_params->n_gpu_layers,
              BOOL_STR(sd_ctx_params->eager_load),
              SAFE_STR(sd_ctx_params->backend),
              SAFE_STR(sd_ctx_params->params_backend),


### PR DESCRIPTION
## Problem

Residency is currently expressed only as a byte budget (`--max-vram`). That works, but it is awkward when the question is simply "how much of this model fits on my card", and there is no equivalent to the layer count users of similar projects already reach for.

## Solution

`-ngl` / `--gpu-layers` caps how many diffusion layers stay resident in VRAM; the remainder stream from RAM per step.

```shell
sd-cli -m model.safetensors -p "a cat" -ngl 20
```

This reuses the existing graph-cut segmentation and streaming machinery. The substantive change is that `annotate_residency` can now be driven by a count as well as by bytes; segment merging is disabled when a count is given, so one segment corresponds to one layer.

**The count is an upper bound, not a demand.** Residency is also capped by free VRAM, reusing the same safety margin and worst-streamed-segment reserve the byte path already applies. Asking for more layers than fit fills the device and streams the rest, rather than failing part-way through a denoise pass — so `-ngl 999` is a reasonable way to say "use as much VRAM as there is". This differs deliberately from llama.cpp, where the number is absolute and over-asking OOMs.

Since streaming reads weights out of host memory, `-ngl` implies `--offload-to-cpu` and `--stream-layers`. With no count given (`-1`, the default), byte-budget behaviour is unchanged — `remaining` stays negative and never gates the loop.

## Verification

Vulkan (RX 6600 XT, 8 GB, RADV), Krea 2 Turbo, 29 segments:

`-ngl 8` — honoured exactly:
```
RESIDENT=8  STREAMED=21
```

`-ngl 999` — clamped to fit instead of OOMing:
```
krea2 streaming budget = 4204.47 MB     (free VRAM - 512MB margin)
RESIDENT=7  STREAMED=22
```

(The budget is 4.2 GB rather than the full 8 GB because the text encoder is resident at plan time; moving it to CPU frees more.)

Both produce correct images. Without `-ngl` the byte-budget path is untouched and behaves as before.

## Caveats

- Only the Vulkan backend was built and tested here.
- Inherits the existing `--stream-layers` limitations: single-device only, and the streamed tail re-reads per segment, so it trades speed for headroom.

## Note

This was written with AI assistance. Errors are mine; happy to rework or drop any part of it.
