### PR TITLE
feat: allow customizing the alpha and beta parameters of the beta scheduler

### DIFF
--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -1008,7 +1008,7 @@ ArgOptions SDGenerationParams::get_options() {
          &hires_upscaler},
         {"",
          "--extra-sample-args",
-         "extra sampler/scheduler/guidance args, key=value list. CFG supports guidance_schedule; APG supports apg_eta, apg_momentum, apg_norm_threshold, apg_norm_threshold_smoothing; SLG supports slg_uncond; lcm supports noise_clip_std, noise_scale_start, noise_scale_end; flux supports base_shift, max_shift; ltx2 supports max_shift, base_shift, stretch, terminal; euler_ge supports gamma;; logit_normal supports mu, std, logsnr_min, logsnr_max, resolution_aware",
+         "extra sampler/scheduler/guidance args, key=value list. CFG supports guidance_schedule; APG supports apg_eta, apg_momentum, apg_norm_threshold, apg_norm_threshold_smoothing; SLG supports slg_uncond; lcm supports noise_clip_std, noise_scale_start, noise_scale_end; flux supports base_shift, max_shift; ltx2 supports max_shift, base_shift, stretch, terminal; euler_ge supports gamma; beta scheduler supports alpha, beta; logit_normal supports mu, std, logsnr_min, logsnr_max, resolution_aware",
          (int)',',
          &extra_sample_args},
         {"",

--- a/src/runtime/denoiser.hpp
+++ b/src/runtime/denoiser.hpp
@@ -306,8 +306,33 @@ struct KarrasScheduler : SigmaScheduler {
 };
 
 struct BetaScheduler : SigmaScheduler {
-    static constexpr double alpha = 0.6;
-    static constexpr double beta  = 0.6;
+    double alpha = 0.6;
+    double beta  = 0.6;
+
+    explicit BetaScheduler(const char* extra_sample_args = nullptr) {
+        parse_extra_sample_args(extra_sample_args);
+        LOG_DEBUG("Beta scheduler: alpha=%.4f, beta=%.4f", alpha, beta);
+    }
+
+    void parse_extra_sample_args(const char* extra_sample_args) {
+        for (const auto& [key, value] : parse_key_value_args(extra_sample_args, "beta scheduler arg")) {
+            if (key == "alpha") {
+                float parsed;
+                if (!parse_strict_float(value, parsed) || parsed <= 0.0) {
+                    LOG_WARN("ignoring invalid beta scheduler arg '%s=%s'", key.c_str(), value.c_str());
+                } else {
+                    alpha = static_cast<double>(parsed);
+                }
+            } else if (key == "beta") {
+                float parsed;
+                if (!parse_strict_float(value, parsed) || parsed <= 0.0) {
+                    LOG_WARN("ignoring invalid beta scheduler arg '%s=%s'", key.c_str(), value.c_str());
+                } else {
+                    beta = static_cast<double>(parsed);
+                }
+            }
+        }
+    }
 
     static double log_beta(double a, double b) {
         return std::lgamma(a) + std::lgamma(b) - std::lgamma(a + b);
@@ -1032,7 +1057,7 @@ struct Denoiser {
                 break;
             case BETA_SCHEDULER:
                 LOG_INFO("get_sigmas with Beta scheduler");
-                scheduler = std::make_shared<BetaScheduler>();
+                scheduler = std::make_shared<BetaScheduler>(extra_sample_args);
                 break;
             case EXPONENTIAL_SCHEDULER:
                 LOG_INFO("get_sigmas exponential scheduler");


### PR DESCRIPTION
## Summary

Include `alpha`and `beta` as `extra-sample-args` parameters to customize the Beta scheduler. This allows replicating the `beta57` scheduler from https://github.com/ClownsharkBatwing/RES4LYF , as well as approximating several other schedulers.

I'm not so sure about the parameter names, since `alpha` and `beta` could potentially collide with sampler parameters (`euler_ge` has a `gamma` already...).

## Additional Information

A random example:

> sd-cli --diffusion-model anima-base-v1.0.safetensors --llm Josiefied-Qwen3-0.6B-abliterated-v2.Q8_0.gguf -W 768 -H 1024 --vae Qwen2D_VAE.safetensors --lora-model-dir . --steps 10 --cfg-scale 1 -p '3d anime style, selfie, Jenny Everywhere, round aviation goggles, scarf, Native American, making a V gesture, in a Japanese garden <lora:anima-turbo-lora-v0.1:1>' --diffusion-fa --sampling-method  euler --scheduler beta --extra-sample-args alpha=$ALPHA,beta=$BETA

| alpha=0.6,beta=0.6 | alpha=0.5,beta=0.7 | alpha=2.0,beta=2.0 |
|---|---|---|
|<img width="192" height="256" alt="test_1785363218" src="https://github.com/user-attachments/assets/8bb51961-fef5-415c-888d-04f64543af2c" />|<img width="192" height="256" alt="test_1785363266" src="https://github.com/user-attachments/assets/c3b8a617-319a-4657-8eb2-3a57d8aaed1e" />|<img width="192" height="256" alt="test_1785363787" src="https://github.com/user-attachments/assets/5611da37-4e56-4d70-bbf0-017f09e1bb32" />|


## Checklist

- [X] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
