### PR TITLE
fix(cmake): only apply /MP to the MSVC compiler, not icx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,11 @@ endif()
 if (MSVC)
     add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
     add_compile_definitions(_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
+    # /MP is MSVC-only: icx rejects it outright once offloading is enabled.
     add_compile_options(
-        $<$<COMPILE_LANGUAGE:C>:/MP>
+        $<$<AND:$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:MSVC>>:/MP>
         $<$<COMPILE_LANGUAGE:C>:/utf-8>
-        $<$<COMPILE_LANGUAGE:CXX>:/MP>
+        $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:/MP>
         $<$<COMPILE_LANGUAGE:CXX>:/utf-8>
     )
 endif()


### PR DESCRIPTION
## Summary

- `/MP` is currently gated only on the top-level `MSVC` variable, which stays true for a mixed `cl`/`icx` SYCL toolchain (`-DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=icx`). That leaks `/MP` onto the `icx` CXX compile line.
- `icx` rejects `/MP` once offloading is enabled, so every Windows SYCL build (`-DSD_SYCL=ON`) currently fails to configure/build.
- This was introduced by #1438, which added `/MP` unconditionally inside `if (MSVC)` without checking the per-language compiler ID.
- Fix: gate `/MP` on `$<C_COMPILER_ID:MSVC>` / `$<CXX_COMPILER_ID:MSVC>` in addition to the existing `COMPILE_LANGUAGE` generator expressions, so it only applies when the actual per-language compiler is MSVC's `cl`.

## Related Issue / Discussion

No existing issue found for this; searched for `/MP`, `icx`, and SYCL build-error reports before opening this PR.

## Additional Information

Verified with a clean Windows SYCL build (`-DSD_SYCL=ON -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=icx`, oneAPI 2025.x, MSVC 2022):
- Before the fix: build fails during the SYCL backend compile once offloading is enabled, with `icx` rejecting `/MP`.
- After the fix: full build succeeds; `compile_commands.json` shows 0 of the `ggml-sycl` entries carrying `/MP`, while MSVC-compiled (`cl`) translation units still get it.
- Non-SYCL MSVC builds are unaffected — `/MP` is still applied there since `C_COMPILER_ID`/`CXX_COMPILER_ID` is `MSVC` in that configuration.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).