### PR TITLE
Fail with a message when MiniMax-H3 is run in img_gen mode

### DIFF
--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -5584,6 +5584,18 @@ SD_API bool generate_image(sd_ctx_t* sd_ctx,
         return false;
     }
 
+    // MiniMax-H3 is video-only. Its denoiser always splits the packed latent into a video and an
+    // audio half, and only generate_video ever computes the audio length, so reaching this
+    // function with an H3 checkpoint is guaranteed to die on
+    // GGML_ASSERT(!audio_input_cache.empty()) with a core dump, after the several minutes it
+    // takes to load the weights, and with nothing in the output pointing at the missing --mode.
+    // (The AnimateDiff path below routes vid_gen back through here, but that is SD1.5 plus a
+    // motion module, never H3.)
+    if (sd_version_is_minimax_h3(sd_ctx->sd->version)) {
+        LOG_ERROR("MiniMax-H3 is a video model and cannot be run in img_gen mode; use --mode vid_gen");
+        return false;
+    }
+
     sd_ctx->sd->reset_cancel_flag();
 
     int64_t t0                    = ggml_time_ms();


### PR DESCRIPTION
MiniMax-H3 is video-only. Its denoiser always splits the packed latent into a video half and an audio half, and only \`generate_video\` computes the audio length, so an H3 checkpoint that reaches \`generate_image\` is guaranteed to die on \`GGML_ASSERT(!audio_input_cache.empty())\`.

That happens whenever \`--mode vid_gen\` is left off, which is easy to do because it is the one flag not implied by passing \`--audio-vae\`. The failure arrives after the several minutes it takes to load the weights, as a core dump with a raw ggml assert and a stack trace, and nothing in the output points at the missing flag.

Before, on a q4_K H3 denoiser with the Qwen3-VL encoder and both VAEs, no \`--mode\`:

```
src/model/diffusion/minimax_h3.hpp:1040: GGML_ASSERT(!audio_input_cache.empty()) failed
...15 frames of stack trace...
Aborted (core dumped)   rc=134
```

After, same command:

```
[ERROR] stable-diffusion.cpp:5595 - MiniMax-H3 is a video model and cannot be run in img_gen mode; use --mode vid_gen
[ERROR] main.cpp:952  - generate failed
rc=1
```

The AnimateDiff path routes \`vid_gen\` back through \`generate_image\`, but that is SD1.5 plus a motion module and never H3, so the guard cannot fire there.