### PR TITLE
fix: preserve "token_refiner" token for MiniMax H3 LoRAs

### DIFF
--- a/src/name_conversion.cpp
+++ b/src/name_conversion.cpp
@@ -1181,6 +1181,7 @@ std::string convert_sep_to_dot(std::string name) {
         "x_embedder",
         "cross_attn",
         "output_proj",
+        "token_refiner",
     };
 
     // record the positions of underscores that should NOT be replaced


### PR DESCRIPTION
## Summary

Improves support for some H3 LoRAs

## Related Issue / Discussion

<!-- Link related issues, discussions, or previous PRs if applicable. -->

## Additional Information

<!-- Add verification notes, screenshots, sample output, or other context when applicable. -->

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
