### PR TITLE
vae.hpp: Replace free_compute_buffer with runner_done to fix memory not released

### DIFF
--- a/src/model/vae/vae.hpp
+++ b/src/model/vae/vae.hpp
@@ -156,7 +156,7 @@ public:
             output = _compute(n_threads, input, false);
         }
 
-        free_compute_buffer();
+        runner_done();
 
         if (output.empty()) {
             LOG_ERROR("vae encode compute failed");
@@ -207,7 +207,7 @@ public:
             output = _compute(n_threads, input, true);
         }
 
-        free_compute_buffer();
+        runner_done();
 
         if (output.empty()) {
             LOG_ERROR("vae decode compute failed");


### PR DESCRIPTION
## Summary

In vae.hpp, free_compute_buffer() does not seem to release all resources after the gen. On some tight setups, this causes subsequent generations to fail due to insufficient memory that was not freed.

Replaced free_compute_buffer() calls with runner_done() to ensure all resources freed after a generation is done.

## Additional Information

@wbruna recommended I PR this

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
