### PR TITLE
fix: re-clamp streaming VRAM budget to currently free memory

### DIFF
--- a/src/core/ggml_extend.hpp
+++ b/src/core/ggml_extend.hpp
@@ -2456,13 +2456,14 @@ protected:
         GGML_ASSERT(gf != nullptr);
 
         size_t effective_budget = max_graph_vram_bytes;
+        size_t free_clamp       = SIZE_MAX;
         if (stream_layers_enabled && max_graph_vram_bytes > 0 && runtime_backend != nullptr) {
             ggml_backend_dev_t dev = ggml_backend_get_device(runtime_backend);
             if (dev != nullptr && ggml_backend_dev_type(dev) != GGML_BACKEND_DEVICE_TYPE_CPU) {
                 size_t free_vram = 0, total_vram = 0;
                 ggml_backend_dev_memory(dev, &free_vram, &total_vram);
                 constexpr size_t safety_margin = 512ull * 1024 * 1024;
-                size_t free_clamp              = (free_vram > safety_margin) ? (free_vram - safety_margin) : 0;
+                free_clamp                     = (free_vram > safety_margin) ? (free_vram - safety_margin) : 0;
                 if (free_clamp < effective_budget) {
                     LOG_DEBUG("%s clamping streaming budget: actual free VRAM %.2f MB < user cap %.2f MB",
                               get_desc().c_str(),
@@ -2479,7 +2480,9 @@ protected:
                 observed_max_effective_budget_ = effective_budget;
                 budget_increased               = true;
             } else {
-                effective_budget = observed_max_effective_budget_;
+                // Keep the plan cache stable, but never plan above what is free now:
+                // another model or process can take VRAM after the first measurement.
+                effective_budget = std::min(observed_max_effective_budget_, free_clamp);
             }
         }
 


### PR DESCRIPTION
## Summary

With `--stream-layers`, `resolve_graph_cut_plan()` re-measures free VRAM on every call and clamps the budget to it, then discards that value: the ratchet restores `observed_max_effective_budget_` whenever the fresh measurement is lower. The first measurement wins for the lifetime of the runner, so once another model or another process takes VRAM, the planner plans against memory that is gone and the allocation fails.

Now the remembered budget is capped by what is free at that moment. `free_clamp` stays `SIZE_MAX` when the device is not measurable, so the unmeasured path is unchanged. Clamping at use rather than lowering the stored maximum lets the budget recover when the other consumer releases memory.

## Related Issue / Discussion

None.

## Additional Information

Seen on a 12GB card with two models loaded and a second CUDA process running:

```
qwen3    graph cut max_vram=9959.75 MB merged 36 segments -> 1 segments
z_image  graph cut max_vram=2489.94 MB merged 36 segments -> 9 segments
z_image  streaming budget = 9959.75 MB
...
qwen3    graph cut max_vram=9959.75 MB merged 36 segments -> 1 segments
ggml_backend_cuda_buffer_type_alloc_buffer: allocating 7480.09 MiB on device 0: cudaMalloc failed: out of memory
```

The second `qwen3` plan reuses 9959.75 MB, measured when the GPU was still empty.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
