### PR TITLE
feat: support sequential execution for taehv

### DIFF
--- a/src/model/vae/tae.hpp
+++ b/src/model/vae/tae.hpp
@@ -183,9 +183,8 @@ public:
 };
 
 class TPool : public UnaryBlock {
-    int stride;
-
 public:
+    int stride;
     TPool(int channels, int stride)
         : stride(stride) {
         blocks["conv"] = std::shared_ptr<GGMLBlock>(new Conv2d(channels * stride, channels, {1, 1}, {1, 1}, {0, 0}, {1, 1}, false));
@@ -356,6 +355,20 @@ ggml_tensor* unpatchify(ggml_context* ctx,
     return x;
 }
 
+struct WorkItem {
+    ggml_tensor* xt;
+    int block_idx;
+};
+
+struct SequentialDecoderState {
+    std::map<int, ggml_tensor*> mem_single;
+};
+
+struct SequentialEncoderState {
+    std::map<int, ggml_tensor*> mem_single;
+    std::map<int, std::vector<ggml_tensor*>> mem_pool;
+};
+
 class TinyVideoEncoder : public UnaryBlock {
     int in_channels = 3;
     int hidden      = 64;
@@ -363,6 +376,9 @@ class TinyVideoEncoder : public UnaryBlock {
     int num_blocks  = 3;
     int num_layers  = 3;
     int patch_size  = 1;
+
+    int total_blocks = 0;
+    int relu_idx     = 0;
 
 public:
     int t_downscale = 1;
@@ -376,7 +392,7 @@ public:
         }
         int index                       = 0;
         blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new Conv2d(in_channels * patch_size * patch_size, hidden, {3, 3}, {1, 1}, {1, 1}));
-        index++;  // nn.ReLU()
+        relu_idx                        = index++;  // nn.ReLU()
         for (int i = 0; i < num_layers; i++) {
             int stride                      = time_downscale[i] ? 2 : 1;
             blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new TPool(hidden, stride));
@@ -385,7 +401,8 @@ public:
                 blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new MemBlock(hidden, hidden));
             }
         }
-        blocks[std::to_string(index)] = std::shared_ptr<GGMLBlock>(new Conv2d(hidden, z_channels, {3, 3}, {1, 1}, {1, 1}));
+        blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new Conv2d(hidden, z_channels, {3, 3}, {1, 1}, {1, 1}));
+        total_blocks                    = index;
     }
 
     ggml_tensor* forward(GGMLRunnerContext* ctx, ggml_tensor* z) override {
@@ -414,20 +431,95 @@ public:
         }
         auto last_conv = std::dynamic_pointer_cast<Conv2d>(blocks[std::to_string(index)]);
         h              = last_conv->forward(ctx, h);
+
+        return h;
+    }
+
+    ggml_tensor* forward_seq_single_step(GGMLRunnerContext* ctx,
+                                         SequentialEncoderState& state,
+                                         std::vector<WorkItem>& work_stack) {
+        while (!work_stack.empty()) {
+            WorkItem item = work_stack.back();
+            work_stack.pop_back();
+
+            ggml_tensor* xt = item.xt;
+            int i           = item.block_idx;
+
+            if (i >= total_blocks) {
+                if (patch_size > 1) {
+                    xt = unpatchify(ctx->ggml_ctx, xt, patch_size, 1);
+                }
+                return xt;
+            }
+
+            if (i == relu_idx) {
+                xt = ggml_relu_inplace(ctx->ggml_ctx, xt);
+                work_stack.push_back({xt, i + 1});
+                continue;
+            }
+
+            std::string key = std::to_string(i);
+            auto block      = blocks[key];
+
+            if (auto mem_block = std::dynamic_pointer_cast<MemBlock>(block)) {
+                ggml_tensor* prev_mem = state.mem_single[i];
+                if (prev_mem == nullptr) {
+                    prev_mem = ggml_dup_tensor(ctx->ggml_ctx, xt);
+                    prev_mem = ggml_scale(ctx->ggml_ctx, prev_mem, 0.);
+                }
+                ggml_tensor* xt_next = mem_block->forward(ctx, xt, prev_mem);
+                state.mem_single[i]  = xt;
+
+                work_stack.push_back({xt_next, i + 1});
+            } else if (auto pool = std::dynamic_pointer_cast<TPool>(block)) {
+                state.mem_pool[i].push_back(xt);
+
+                if ((int)state.mem_pool[i].size() == pool->stride) {
+                    ggml_tensor* cat_input = ggml_ext_vec_concat(ctx->ggml_ctx, state.mem_pool[i], 3);
+                    ggml_tensor* xt_next   = pool->forward(ctx, cat_input);
+
+                    state.mem_pool[i].clear();
+                    work_stack.push_back({xt_next, i + 1});
+                }
+            } else if (auto unary_block = std::dynamic_pointer_cast<UnaryBlock>(block)) {
+                ggml_tensor* xt_next = unary_block->forward(ctx, xt);
+                work_stack.push_back({xt_next, i + 1});
+            }
+        }
+
+        return nullptr;  // Work stack exhausted
+    }
+
+    ggml_tensor* forward_seq(GGMLRunnerContext* ctx,
+                             ggml_tensor* z) {
+        SequentialEncoderState state;
+        std::vector<WorkItem> work_stack;
+
+        if (patch_size > 1) {
+            z = patchify(ctx->ggml_ctx, z, patch_size, 1);
+        }
+
+        const std::vector<ggml_tensor*>& latent_frames = ggml_ext_chunk(ctx->ggml_ctx, z, z->ne[3], 3);
+
+        for (auto it = latent_frames.rbegin(); it != latent_frames.rend(); ++it) {
+            work_stack.push_back({*it, 0});
+        }
+
+        std::vector<ggml_tensor*> output_frames;
+
+        while (!work_stack.empty()) {
+            ggml_tensor* out_frame = forward_seq_single_step(ctx, state, work_stack);
+            if (out_frame != nullptr) {
+                output_frames.push_back(out_frame);
+            }
+        }
+
+        auto h = ggml_ext_vec_concat(ctx->ggml_ctx, output_frames, 3);
         return h;
     }
 };
 
 
-struct WorkItem {
-    ggml_tensor* xt;
-    int block_idx;
-};
-
-// Stateful memory cache tracking MemBlock/WideMemBlock frames across steps
-struct TinyVideoDecoderState {
-    std::map<int, ggml_tensor*> mem_single;
-};
 
 class TinyVideoDecoder : public UnaryBlock {
     int z_channels               = 4;
@@ -438,10 +530,9 @@ class TinyVideoDecoder : public UnaryBlock {
     int patch_size               = 1;
     bool is_wide                 = false;
 
-    // Track total block index count and special unmapped activation indices
-    int total_blocks = 0;
-    int clamp_idx = 0;
-    int relu1_idx = 0;
+    int total_blocks   = 0;
+    int clamp_idx      = 0;
+    int relu1_idx      = 0;
     int relu_final_idx = 0;
     std::set<int> upsample_indices;
 
@@ -474,11 +565,11 @@ public:
                     blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new MemBlock(channels[i], channels[i]));
                 }
             }
-            upsample_indices.insert(index++); // Nearest-neighbor spatial upsample slot
+            upsample_indices.insert(index++);  // Nearest-neighbor spatial upsample slot
             blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new TGrow(channels[i], stride));
             blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new Conv2d(channels[i], channels[i + 1], {3, 3}, {1, 1}, {1, 1}, {1, 1}, false));
         }
-        relu_final_idx = index++;  // nn.ReLU()
+        relu_final_idx                  = index++;  // nn.ReLU()
         blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new Conv2d(channels[num_layers], out_channels * patch_size * patch_size, {3, 3}, {1, 1}, {1, 1}));
 
         total_blocks = index;
@@ -530,7 +621,7 @@ public:
     }
 
     ggml_tensor* forward_seq_single_step(GGMLRunnerContext* ctx,
-                                         TinyVideoDecoderState& state,
+                                         SequentialDecoderState& state,
                                          std::vector<WorkItem>& work_stack) {
         while (!work_stack.empty()) {
             WorkItem item = work_stack.back();
@@ -615,12 +706,10 @@ public:
 
         return nullptr;  // Work stack exhausted
     }
-    
-    ggml_tensor* forward_seq(
-        GGMLRunnerContext* ctx,
-        ggml_tensor* x
-    ) {
-        TinyVideoDecoderState state;
+
+    ggml_tensor* forward_seq(GGMLRunnerContext* ctx,
+                             ggml_tensor* x) {
+        SequentialDecoderState state;
         std::vector<WorkItem> work_stack;
 
         const std::vector<ggml_tensor*>& latent_frames = ggml_ext_chunk(ctx->ggml_ctx, x, x->ne[3], 3);
@@ -653,9 +742,9 @@ protected:
     bool decode_only;
     SDVersion version;
     bool is_wide;
-    
-    public:
-    bool parallel = false;
+
+public:
+    bool parallel                    = false;
     int z_channels                   = 16;
     std::vector<bool> time_downscale = {true, true, false};
     std::vector<bool> time_upscale   = {false, true, true};
@@ -813,7 +902,7 @@ public:
                 x = ggml_concat(ctx->ggml_ctx, x, last_frame, 3);
             }
         }
-        x = encoder->forward(ctx, x);
+        x = parallel ? encoder->forward(ctx, x) : encoder->forward_seq(ctx, x);
         if (sd_version_is_wan(version) || sd_version_is_hunyuan_video(version) || sd_version_is_ltxav(version)) {
             // (W, H, C, T) -> (W, H, T, C)
             x = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 0, 1, 3, 2));
@@ -996,12 +1085,16 @@ struct TinyVideoAutoEncoder : public VAE {
 
     ggml_cgraph* build_graph(const sd::Tensor<float>& z_tensor, bool decode_graph) {
         ggml_cgraph* gf = nullptr;
-        ggml_tensor* z   = make_input(z_tensor);
+        ggml_tensor* z  = make_input(z_tensor);
         if (decode_graph) {
             int64_t passes = taehv.parallel ? 1 : z->ne[3];
             gf             = ggml_new_graph_custom(compute_ctx, (is_wide ? 4096 : 2048) * passes, false);
         } else {
-            gf = ggml_new_graph(compute_ctx);
+            int64_t frames = z->ne[2];
+            int64_t factor = sd_version_is_minimax_h3(version) ? 20 : sd_version_is_ltxav(version) ? 8
+                                                                                                   : 4;
+            int64_t passes = taehv.parallel ? 1 : (frames + factor - 1) / factor;
+            gf             = ggml_new_graph_custom(compute_ctx, 2048 * passes, false);
         }
         auto runner_ctx  = get_context();
         ggml_tensor* out = decode_graph ? taehv.decode(&runner_ctx, z) : taehv.encode(&runner_ctx, z);

--- a/src/model/vae/tae.hpp
+++ b/src/model/vae/tae.hpp
@@ -203,9 +203,8 @@ public:
 };
 
 class TGrow : public UnaryBlock {
-    int stride;
-
 public:
+    int stride;
     TGrow(int channels, int stride)
         : stride(stride) {
         blocks["conv"] = std::shared_ptr<GGMLBlock>(new Conv2d(channels, channels * stride, {1, 1}, {1, 1}, {0, 0}, {1, 1}, false));
@@ -419,6 +418,17 @@ public:
     }
 };
 
+
+struct WorkItem {
+    ggml_tensor* xt;
+    int block_idx;
+};
+
+// Stateful memory cache tracking MemBlock/WideMemBlock frames across steps
+struct TinyVideoDecoderState {
+    std::map<int, ggml_tensor*> mem_single;
+};
+
 class TinyVideoDecoder : public UnaryBlock {
     int z_channels               = 4;
     int out_channels             = 3;
@@ -427,6 +437,13 @@ class TinyVideoDecoder : public UnaryBlock {
     int channels[num_layers + 1] = {256, 128, 64, 64};
     int patch_size               = 1;
     bool is_wide                 = false;
+
+    // Track total block index count and special unmapped activation indices
+    int total_blocks = 0;
+    int clamp_idx = 0;
+    int relu1_idx = 0;
+    int relu_final_idx = 0;
+    std::set<int> upsample_indices;
 
 public:
     int t_upscale = 1;
@@ -444,9 +461,10 @@ public:
                 t_upscale *= 2;
             }
         }
+        clamp_idx                       = 0;
         int index                       = 1;  // Clamp()
         blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new Conv2d(z_channels, channels[0], {3, 3}, {1, 1}, {1, 1}));
-        index++;  // nn.ReLU()
+        relu1_idx                       = index++;  // nn.ReLU()
         for (int i = 0; i < num_layers; i++) {
             int stride = time_upscale[i] ? 2 : 1;
             for (int j = 0; j < num_blocks; j++) {
@@ -456,12 +474,14 @@ public:
                     blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new MemBlock(channels[i], channels[i]));
                 }
             }
-            index++;  // nn.Upsample()
+            upsample_indices.insert(index++); // Nearest-neighbor spatial upsample slot
             blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new TGrow(channels[i], stride));
             blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new Conv2d(channels[i], channels[i + 1], {3, 3}, {1, 1}, {1, 1}, {1, 1}, false));
         }
-        index++;  // nn.ReLU()
+        relu_final_idx = index++;  // nn.ReLU()
         blocks[std::to_string(index++)] = std::shared_ptr<GGMLBlock>(new Conv2d(channels[num_layers], out_channels * patch_size * patch_size, {3, 3}, {1, 1}, {1, 1}));
+
+        total_blocks = index;
     }
 
     ggml_tensor* forward(GGMLRunnerContext* ctx, ggml_tensor* z) override {
@@ -508,6 +528,124 @@ public:
         h = ggml_view_4d(ctx->ggml_ctx, h, h->ne[0], h->ne[1], h->ne[2], h->ne[3] - (t_upscale - 1), h->nb[1], h->nb[2], h->nb[3], (t_upscale - 1) * h->nb[3]);
         return h;
     }
+
+    ggml_tensor* forward_seq_single_step(GGMLRunnerContext* ctx,
+                                         TinyVideoDecoderState& state,
+                                         std::vector<WorkItem>& work_stack) {
+        while (!work_stack.empty()) {
+            WorkItem item = work_stack.back();
+            work_stack.pop_back();
+
+            ggml_tensor* xt = item.xt;
+            int i           = item.block_idx;
+
+            if (i >= total_blocks) {
+                if (patch_size > 1) {
+                    xt = unpatchify(ctx->ggml_ctx, xt, patch_size, 1);
+                }
+                return xt;
+            }
+
+            if (i == clamp_idx) {
+                xt = ggml_ext_scale(ctx->ggml_ctx,
+                                    ggml_tanh_inplace(ctx->ggml_ctx,
+                                                      ggml_ext_scale(ctx->ggml_ctx, xt, 1.0f / 3.0f)),
+                                    3.0f, true);
+                work_stack.push_back({xt, i + 1});
+                continue;
+            }
+            if (i == relu1_idx || i == relu_final_idx) {
+                xt = ggml_relu_inplace(ctx->ggml_ctx, xt);
+                work_stack.push_back({xt, i + 1});
+                continue;
+            }
+            if (upsample_indices.count(i)) {
+                xt = ggml_upscale(ctx->ggml_ctx, xt, 2, GGML_SCALE_MODE_NEAREST);
+                work_stack.push_back({xt, i + 1});
+                continue;
+            }
+
+            std::string key = std::to_string(i);
+            auto block      = blocks[key];
+
+            if (auto mem_block = std::dynamic_pointer_cast<MemBlock>(block)) {
+                ggml_tensor* prev_mem = state.mem_single[i];
+                if (prev_mem == nullptr) {
+                    prev_mem = ggml_dup_tensor(ctx->ggml_ctx, xt);
+                    prev_mem = ggml_scale(ctx->ggml_ctx, prev_mem, 0.);
+                }
+                ggml_tensor* xt_next = mem_block->forward(ctx, xt, prev_mem);
+                state.mem_single[i]  = xt;
+
+                work_stack.push_back({xt_next, i + 1});
+            } else if (auto wide_mem_block = std::dynamic_pointer_cast<WideMemBlock>(block)) {
+                ggml_tensor* prev_mem = state.mem_single[i];
+                if (prev_mem == nullptr) {
+                    prev_mem = ggml_dup_tensor(ctx->ggml_ctx, xt);
+                    prev_mem = ggml_scale(ctx->ggml_ctx, prev_mem, 0.);
+                }
+                ggml_tensor* xt_next = wide_mem_block->forward(ctx, xt, prev_mem);
+                state.mem_single[i]  = xt;
+
+                work_stack.push_back({xt_next, i + 1});
+            } else if (auto tgrow = std::dynamic_pointer_cast<TGrow>(block)) {
+                ggml_tensor* xt_grown = tgrow->forward(ctx, xt);
+                int stride            = tgrow->stride;
+
+                // Push chunked sub-frames onto stack in REVERSE order
+                // so that sub-frame 0 is popped and processed first
+                for (int s = stride - 1; s >= 0; --s) {
+                    ggml_tensor* sub_frame = xt_grown;
+                    if (stride > 1) {
+                        int64_t chunk_channels = xt_grown->ne[3] / stride;
+                        size_t offset          = s * chunk_channels * xt_grown->nb[3];
+
+                        sub_frame = ggml_view_4d(ctx->ggml_ctx, xt_grown,
+                                                 xt_grown->ne[0], xt_grown->ne[1], xt_grown->ne[2], chunk_channels,
+                                                 xt_grown->nb[1], xt_grown->nb[2], xt_grown->nb[3],
+                                                 offset);
+                    }
+                    work_stack.push_back({sub_frame, i + 1});
+                }
+            } else if (auto unary_block = std::dynamic_pointer_cast<UnaryBlock>(block)) {
+                ggml_tensor* xt_next = unary_block->forward(ctx, xt);
+                work_stack.push_back({xt_next, i + 1});
+            }
+        }
+
+        return nullptr;  // Work stack exhausted
+    }
+    
+    ggml_tensor* forward_seq(
+        GGMLRunnerContext* ctx,
+        ggml_tensor* x
+    ) {
+        TinyVideoDecoderState state;
+        std::vector<WorkItem> work_stack;
+
+        const std::vector<ggml_tensor*>& latent_frames = ggml_ext_chunk(ctx->ggml_ctx, x, x->ne[3], 3);
+
+        for (auto it = latent_frames.rbegin(); it != latent_frames.rend(); ++it) {
+            work_stack.push_back({*it, 0});
+        }
+
+        std::vector<ggml_tensor*> output_frames;
+
+        while (!work_stack.empty()) {
+            ggml_tensor* out_frame = forward_seq_single_step(ctx, state, work_stack);
+            if (out_frame != nullptr) {
+                output_frames.push_back(out_frame);
+            }
+        }
+
+        auto h = ggml_ext_vec_concat(ctx->ggml_ctx, output_frames, 3);
+        // shape(W, H, 3, (t_upscale - 1) + T) => shape(W, H, 3, T)
+        h = ggml_view_4d(ctx->ggml_ctx, h,
+                         h->ne[0], h->ne[1], h->ne[2], h->ne[3] - (t_upscale - 1),
+                         h->nb[1], h->nb[2], h->nb[3],
+                         (t_upscale - 1) * h->nb[3]);
+        return h;
+    }
 };
 
 class TAEHV : public GGMLBlock {
@@ -515,8 +653,9 @@ protected:
     bool decode_only;
     SDVersion version;
     bool is_wide;
-
-public:
+    
+    public:
+    bool parallel = false;
     int z_channels                   = 16;
     std::vector<bool> time_downscale = {true, true, false};
     std::vector<bool> time_upscale   = {false, true, true};
@@ -553,7 +692,7 @@ public:
             // (W, H, C, T) -> (W, H, T, C)
             z = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, z, 0, 1, 3, 2));
         }
-        auto result = decoder->forward(ctx, z);
+        auto result = parallel ? decoder->forward(ctx, z) : decoder->forward_seq(ctx, z);
 
         if (sd_version_is_minimax_h3(version)) {
             int64_t num_frames   = result->ne[3];
@@ -856,9 +995,14 @@ struct TinyVideoAutoEncoder : public VAE {
     }
 
     ggml_cgraph* build_graph(const sd::Tensor<float>& z_tensor, bool decode_graph) {
-        ggml_cgraph* gf  = decode_graph && is_wide ? ggml_new_graph_custom(compute_ctx, 4096, false)
-                                                   : ggml_new_graph(compute_ctx);
+        ggml_cgraph* gf = nullptr;
         ggml_tensor* z   = make_input(z_tensor);
+        if (decode_graph) {
+            int64_t passes = taehv.parallel ? 1 : z->ne[3];
+            gf             = ggml_new_graph_custom(compute_ctx, (is_wide ? 4096 : 2048) * passes, false);
+        } else {
+            gf = ggml_new_graph(compute_ctx);
+        }
         auto runner_ctx  = get_context();
         ggml_tensor* out = decode_graph ? taehv.decode(&runner_ctx, z) : taehv.encode(&runner_ctx, z);
         ggml_build_forward_expand(gf, out);

--- a/src/model/vae/tae.hpp
+++ b/src/model/vae/tae.hpp
@@ -1087,7 +1087,7 @@ struct TinyVideoAutoEncoder : public VAE {
         ggml_cgraph* gf = nullptr;
         ggml_tensor* z  = make_input(z_tensor);
         if (decode_graph) {
-            int64_t passes = taehv.parallel ? 1 : z->ne[3];
+            int64_t passes = taehv.parallel ? 1 : z->ne[2];
             gf             = ggml_new_graph_custom(compute_ctx, (is_wide ? 4096 : 2048) * passes, false);
         } else {
             int64_t frames = z->ne[2];


### PR DESCRIPTION
## Summary

Keep the VRAM usage of video decoding for TAEHV lower by decoding (or encoding) frame-by-frame.

## Related Issue / Discussion

<!-- Link related issues, discussions, or previous PRs if applicable. -->

## Additional Information

I left in the code for parallel decoding, but it's always disabled, on all my tests it seemed like sequential is always faster and uses lower memory, but on some more powerful hardware it might not be the case.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
