### PR TITLE
fix: prevent gallocr hash overflow in tiny graph-cut segments

### DIFF
--- a/src/core/ggml_graph_cut.cpp
+++ b/src/core/ggml_graph_cut.cpp
@@ -603,7 +603,43 @@ namespace sd::ggml_graph_cut {
         GGML_ASSERT(gf != nullptr);
         GGML_ASSERT(graph_ctx_out != nullptr);
 
-        const size_t graph_size = segment.internal_node_indices.size() + segment.input_refs.size() + 8;
+        // Collect leaf inputs and internal nodes, then any tensor they
+        // reference that is not already represented, notably the view_src of a
+        // view-typed input leaf. ggml_gallocr sizes its hash set from
+        // n_nodes + n_leafs (plus a 25% margin that rounds down to zero for a
+        // one-node segment), so every distinct tensor it will hash must be
+        // counted here or a tiny segment overflows the hash set and aborts.
+        std::vector<ggml_tensor*> leaves;
+        std::unordered_set<ggml_tensor*> represented;
+        for (const auto& input : segment.input_refs) {
+            ggml_tensor* current_input = input_tensor(gf, input);
+            if (current_input == nullptr) {
+                continue;
+            }
+            if (represented.insert(current_input).second) {
+                leaves.push_back(current_input);
+            }
+        }
+        for (int node_idx : segment.internal_node_indices) {
+            represented.insert(ggml_graph_node(gf, node_idx));
+        }
+        auto add_reference = [&](ggml_tensor* tensor) {
+            if (tensor != nullptr && represented.insert(tensor).second) {
+                leaves.push_back(tensor);
+            }
+        };
+        for (int node_idx : segment.internal_node_indices) {
+            ggml_tensor* node = ggml_graph_node(gf, node_idx);
+            for (int src_idx = 0; src_idx < GGML_MAX_SRC; ++src_idx) {
+                add_reference(node->src[src_idx]);
+            }
+            add_reference(node->view_src);
+        }
+        for (size_t i = 0; i < leaves.size(); ++i) {
+            add_reference(leaves[i]->view_src);
+        }
+
+        const size_t graph_size = segment.internal_node_indices.size() + leaves.size() + 8;
         ggml_init_params params = {
             /*.mem_size   =*/ggml_graph_overhead_custom(graph_size, false) + 1024,
             /*.mem_buffer =*/nullptr,
@@ -614,13 +650,9 @@ namespace sd::ggml_graph_cut {
         ggml_cgraph* segment_graph = ggml_new_graph_custom(graph_ctx, graph_size, false);
         GGML_ASSERT(segment_graph != nullptr);
 
-        for (const auto& input : segment.input_refs) {
-            ggml_tensor* current_input = input_tensor(gf, input);
-            if (current_input == nullptr) {
-                continue;
-            }
+        for (ggml_tensor* leaf : leaves) {
             GGML_ASSERT(segment_graph->n_leafs < segment_graph->size);
-            segment_graph->leafs[segment_graph->n_leafs++] = current_input;
+            segment_graph->leafs[segment_graph->n_leafs++] = leaf;
         }
 
         for (int output_node_index : segment.output_node_indices) {


### PR DESCRIPTION
## Summary

`build_segment_graph()` sized each segment graph from `internal_node_indices + input_refs`, but `ggml_gallocr` hashes more tensors than that: a view-typed input leaf's `view_src` is a distinct tensor it must hash, even though it is marked external and never allocated.

gallocr sizes its hash set to `(n_nodes + n_leafs) + (n_nodes + n_leafs)/4`. The 25% margin normally absorbs the extra tensor, but on a one-node segment the integer division yields zero margin, so 4 distinct tensors overflow a 3-slot hash and `ggml_hash_find` aborts.

The segment graph now registers every tensor gallocr will hash - leaf `view_src`s, plus any node `src`/`view_src` not already present - so the count covers them. External tensors are hashed but never allocated, so measurement is unchanged.

## Related Issue / Discussion

Fixes the crash reported in #1788.

#1788 also reports mosaic/blank output on the CPU path. That is a separate bug and is **not** addressed here, so the issue should stay open after this lands.

## Additional Information

Reproduced on CUDA (RTX 3060) with an edit model that uses the Qwen2.5-VL vision encoder (Qwen-Image-Edit-2509, LongCat-Image-Edit) and `--offload-to-cpu --max-vram -1 --stream-layers`. It aborts at `ggml/src/ggml-impl.h:318` immediately after `resize conditioner ref image`, and the process then hangs.

Instrumented segment at the point of failure:

```
seg#34  n_nodes=1  n_leafs=2  distinct=4  min_hash=3  -> OVERFLOW
```

A patched vs unpatched A/B on regular (non-edit) Qwen streaming produced byte-identical output, so the change is numerically inert. With the patch the abort and hang are gone and the edit pipeline runs to completion.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
