### PR TITLE
feat(server): report generation progress on async jobs

### DIFF
--- a/examples/server/async_jobs.cpp
+++ b/examples/server/async_jobs.cpp
@@ -105,6 +105,73 @@ bool cancel_queued_job(AsyncJobManager& manager, AsyncGenerationJob& job) {
     return true;
 }
 
+// sd_set_progress_callback takes a plain function pointer and the worker runs
+// one job at a time, so the job being sampled is tracked in file scope rather
+// than captured.
+struct SamplingProgressState {
+    AsyncGenerationJob* job = nullptr;
+    int finished_passes     = 0;
+    int last_step           = 0;
+    int last_steps          = 0;
+};
+
+static SamplingProgressState sampling_progress_state;
+
+// A generation samples once per batch image, plus once more per image when
+// hires is on, and each pass counts from zero. Folding a finished pass into a
+// running total turns those passes into one counter for the whole job.
+static void on_sampling_progress(int step, int steps, float time, void* data) {
+    (void)time;
+    (void)data;
+    SamplingProgressState& state = sampling_progress_state;
+    if (state.job == nullptr) {
+        return;
+    }
+    if (step <= state.last_step) {
+        state.finished_passes += state.last_steps;
+    }
+    state.last_step  = step;
+    state.last_steps = steps;
+    state.job->progress_step.store(state.finished_passes + step, std::memory_order_relaxed);
+}
+
+// A custom sigma schedule overrides the requested step count: sampling runs
+// custom_sigmas_count - 1 steps and reports that as its own total, so deriving
+// the expectation from sample_steps would under-count it.
+static int expected_sampling_steps(const sd_img_gen_params_t& params) {
+    const int batch_count            = params.batch_count > 0 ? params.batch_count : 1;
+    const sd_sample_params_t& sample = params.sample_params;
+    const int steps                  = sample.custom_sigmas != nullptr && sample.custom_sigmas_count > 1
+                                           ? sample.custom_sigmas_count - 1
+                                           : (sample.sample_steps > 0 ? sample.sample_steps : 0);
+    int total                        = batch_count * steps;
+    if (params.hires.enabled) {
+        const sd_hires_params_t& hires = params.hires;
+        const int hires_steps          = hires.custom_sigmas != nullptr && hires.custom_sigmas_count > 1
+                                             ? hires.custom_sigmas_count - 1
+                                             : (hires.steps > 0 ? hires.steps : steps);
+        total += batch_count * hires_steps;
+    }
+    return total;
+}
+
+// Installs the callback for one generation and always clears it, so a later
+// job is never credited with steps from this one.
+struct SamplingProgressScope {
+    explicit SamplingProgressScope(AsyncGenerationJob& job) {
+        sampling_progress_state = SamplingProgressState{&job, 0, 0, 0};
+        sd_set_progress_callback(on_sampling_progress, nullptr);
+    }
+
+    ~SamplingProgressScope() {
+        sd_set_progress_callback(nullptr, nullptr);
+        sampling_progress_state = SamplingProgressState{};
+    }
+
+    SamplingProgressScope(const SamplingProgressScope&)            = delete;
+    SamplingProgressScope& operator=(const SamplingProgressScope&) = delete;
+};
+
 json make_async_job_json(const AsyncJobManager& manager, const AsyncGenerationJob& job) {
     json result;
     result["id"]             = job.id;
@@ -114,6 +181,8 @@ json make_async_job_json(const AsyncJobManager& manager, const AsyncGenerationJo
     result["started"]        = job.started_at == 0 ? json(nullptr) : json(job.started_at);
     result["completed"]      = job.completed_at == 0 ? json(nullptr) : json(job.completed_at);
     result["queue_position"] = 0;
+    result["progress_step"]  = job.progress_step.load(std::memory_order_relaxed);
+    result["progress_steps"] = job.progress_steps.load(std::memory_order_relaxed);
 
     if (job.status == AsyncJobStatus::Queued) {
         size_t position = 1;
@@ -170,10 +239,14 @@ bool execute_img_gen_job(ServerRuntime& runtime,
                          std::string& error_message) {
     sd_img_gen_params_t params = job.img_gen.to_sd_img_gen_params_t();
 
+    job.progress_steps.store(expected_sampling_steps(params), std::memory_order_relaxed);
+    job.progress_step.store(0, std::memory_order_relaxed);
+
     SDImageVec results;
 
     {
         std::lock_guard<std::mutex> lock(*runtime.sd_ctx_mutex);
+        SamplingProgressScope progress_scope(job);
         sd_image_t* raw_results = nullptr;
         int num_results         = 0;
         if (!generate_image(runtime.sd_ctx, &params, &raw_results, &num_results)) {

--- a/examples/server/async_jobs.h
+++ b/examples/server/async_jobs.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <cstdint>
 #include <deque>
@@ -35,6 +36,12 @@ struct AsyncGenerationJob {
     int64_t created_at    = unix_timestamp_now();
     int64_t started_at    = 0;
     int64_t completed_at  = 0;
+    // Sampling steps finished across the whole job, and the total expected.
+    // Atomic because the progress callback runs on the worker thread outside
+    // the manager mutex, while HTTP handlers read these under it. A total of
+    // zero means the job has not reached sampling, or the total is unknown.
+    std::atomic<int> progress_step{0};
+    std::atomic<int> progress_steps{0};
     ImgGenJobRequest img_gen;
     VidGenJobRequest vid_gen;
     std::vector<std::string> result_images_b64;

--- a/src/core/ggml_extend.hpp
+++ b/src/core/ggml_extend.hpp
@@ -884,7 +884,7 @@ __STATIC_INLINE__ sd::Tensor<float> process_tiles_2d(const sd::Tensor<float>& in
         LOG_DEBUG("num tiles : %d, %d ", num_tiles_x, num_tiles_y);
         LOG_DEBUG("optimal overlap : %f, %f (targeting %f)", tile_overlap_factor_x, tile_overlap_factor_y, tile_overlap_factor);
         LOG_DEBUG("processing %i tiles", num_tiles);
-        pretty_progress(0, num_tiles, 0.0f);
+        pretty_tile_progress(0, num_tiles, 0.0f);
     }
     for (int y = 0; y < small_height && !last_y; y += non_tile_overlap_y) {
         int dy = 0;
@@ -935,14 +935,14 @@ __STATIC_INLINE__ sd::Tensor<float> process_tiles_2d(const sd::Tensor<float>& in
             if (!silent) {
                 int64_t t2 = ggml_time_ms();
                 last_time  = (t2 - t1) / 1000.0f;
-                pretty_progress(tile_count, num_tiles, last_time);
+                pretty_tile_progress(tile_count, num_tiles, last_time);
             }
             tile_count++;
         }
         last_x = false;
     }
     if (!silent && tile_count < num_tiles) {
-        pretty_progress(num_tiles, num_tiles, last_time);
+        pretty_tile_progress(num_tiles, num_tiles, last_time);
     }
     if (output.empty()) {
         return {};

--- a/src/core/util.cpp
+++ b/src/core/util.cpp
@@ -533,11 +533,7 @@ static void print_progress_line(int step, int steps, const std::string& speed_te
     fflush(stdout);  // for linux
 }
 
-void pretty_progress(int step, int steps, float time) {
-    if (sd_progress_cb) {
-        sd_progress_cb(step, steps, time, sd_progress_cb_data);
-        return;
-    }
+static void render_step_progress(int step, int steps, float time) {
     if (step == 0) {
         return;
     }
@@ -550,13 +546,30 @@ void pretty_progress(int step, int steps, float time) {
     print_progress_line(step, steps, sd_format("%.2f%s", speed, unit));
 }
 
-void pretty_bytes_progress(int step, int steps, uint64_t bytes_processed, float elapsed_seconds) {
+void pretty_progress(int step, int steps, float time) {
     if (sd_progress_cb) {
-        float time = elapsed_seconds / (step + 1e-6f);
         sd_progress_cb(step, steps, time, sd_progress_cb_data);
         return;
     }
-    if (step == 0) {
+    render_step_progress(step, steps, time);
+}
+
+// Tiled decoding runs inside a single sampling step, so its tile counter is on
+// a different scale than the step counter sd_progress_cb reports. Keep it out
+// of the callback, and stay silent when one is installed: a consumer that
+// reports progress itself did not ask for a progress bar in its output.
+void pretty_tile_progress(int step, int steps, float time) {
+    if (sd_progress_cb) {
+        return;
+    }
+    render_step_progress(step, steps, time);
+}
+
+void pretty_bytes_progress(int step, int steps, uint64_t bytes_processed, float elapsed_seconds) {
+    // Loading weights is not sampling them: reporting tensor counts through
+    // sd_progress_cb would restart the step counter on every model load. Stay
+    // silent when a callback is installed, as this function already did.
+    if (sd_progress_cb || step == 0) {
         return;
     }
 

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -76,6 +76,7 @@ bool parse_strict_int(const std::string& text, int& value);
 bool parse_strict_bool(const std::string& text, bool& value);
 
 void pretty_progress(int step, int steps, float time);
+void pretty_tile_progress(int step, int steps, float time);
 void pretty_bytes_progress(int step, int steps, uint64_t bytes_processed, float elapsed_seconds);
 
 void log_printf(sd_log_level_t level, const char* file, int line, const char* format, ...);


### PR DESCRIPTION
## Summary

An async generation reports nothing between accepting the request and returning a result - on a CPU backend, several minutes of silence during which a client polling `GET /sdcpp/v1/jobs/{id}` cannot tell a slow job from a stuck one.

`sd_set_progress_callback` exists for this, but `sd_progress_cb_t` is fed by three producers on three scales - sampling (`src/stable-diffusion.cpp`), model loading (`src/model_loader.cpp`) and tiled VAE decoding (`src/core/ggml_extend.hpp`) - with no discriminator in the signature. A consumer gets one counter that silently changes unit and restarts.

Two commits:

1. **`fix:`** reserve the callback for sampling. The shared console rendering moves into `render_step_progress`, and tiled decoding gets its own entry point, `pretty_tile_progress`. Console output is unchanged when no callback is installed; no public API change.
2. **`feat(server):`** install the callback for the duration of one generation and publish `progress_step` / `progress_steps`. A job samples once per batch image plus once per hires pass, each from zero, so finished passes are folded into a running total covering the whole job. Both fields are additive, and `std::atomic` because the callback runs on the worker thread outside the manager mutex.

The first commit stands on its own: it affects any consumer of `sd_progress_cb`, not just `sd-server`.

## Related Issue / Discussion

N/A

## Additional Information

Built at `de298c2`, CPU backend, SD 1.5, `--vae-tiling`, `batch_count=2` and `sample_steps=6` (12 expected steps):

```text
generating 0/12 → 6/12 → 7/12 → ... → 12/12 → completed
```

The `6/12 → 7/12` step is the batch boundary - the second image continues the count instead of restarting it. The counter holds at `12/12` while the VAE decodes.

An intermediate build without the first commit let tiles count as steps, and the counter ran past its own total: `13/12 ... 27/12`, still climbing.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).