### PR TITLE
fix: correct MiniMax H3 reference audio encoding

### DIFF
--- a/src/model/vae/minimax_h3_audio_vae.hpp
+++ b/src/model/vae/minimax_h3_audio_vae.hpp
@@ -154,8 +154,9 @@ namespace MiniMaxH3 {
                          const String2TensorStorage& tensor_storage_map = {},
                          const std::string prefix                       = "") override {
             GGMLBlock::init_params(ctx, tensor_storage_map, prefix);
-            params["q_bias"] = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, in_channels);
-            params["v_bias"] = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, in_channels);
+            params["q_bias"]      = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, in_channels);
+            params["zero_k_bias"] = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, in_channels);
+            params["v_bias"]      = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, in_channels);
         }
 
         ggml_tensor* forward(GGMLRunnerContext* ctx, ggml_tensor* x) {
@@ -166,7 +167,7 @@ namespace MiniMaxH3 {
                 return ggml_reshape_4d(ctx->ggml_ctx, bias, bias->ne[0], 1, 1, 1);
             };
             auto q = ggml_add(ctx->ggml_ctx, qkv[0], bias_shape(params["q_bias"]));
-            auto k = qkv[1];
+            auto k = ggml_add(ctx->ggml_ctx, qkv[1], bias_shape(params["zero_k_bias"]));
             auto v = ggml_add(ctx->ggml_ctx, qkv[2], bias_shape(params["v_bias"]));
 
             int64_t sequence = x->ne[1];
@@ -358,22 +359,38 @@ namespace MiniMaxH3 {
         }
 
         ggml_tensor* encode(GGMLRunnerContext* ctx, ggml_tensor* waveform) {
-            GGML_ASSERT(waveform->ne[1] == 2);
+            GGML_ASSERT(waveform->ne[1] * waveform->ne[2] * waveform->ne[3] == 2);
             auto encoder   = std::dynamic_pointer_cast<AudioEncoder>(blocks["encoder"]);
             auto pre       = std::dynamic_pointer_cast<AudioAttentionProjection>(blocks["pre_block"]);
             auto mean_proj = std::dynamic_pointer_cast<LTXV::Conv1D>(blocks["mean_proj"]);
 
-            waveform = ggml_reshape_3d(ctx->ggml_ctx, waveform, waveform->ne[0], 1, waveform->ne[1]);
-            auto x   = encoder->forward(ctx, waveform);  // [B*S, 2048, T]
-            x        = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 1, 0, 2, 3));
-            x        = pre->forward(ctx, x);
-            x        = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 1, 0, 2, 3));
-            auto z   = mean_proj->forward(ctx, x);
+            // GGML's batched conv1d storage interleaves the stream dimension
+            // with output channels. Subsequent layers then read stereo samples
+            // as adjacent feature channels. Run each mono stream independently,
+            // matching PyTorch's reshape(B*S, 1, samples), and concatenate only
+            // the completed normalized latents.
+            const int64_t streams = waveform->ne[2] * waveform->ne[3];
+            waveform = ggml_reshape_3d(ctx->ggml_ctx,
+                                       waveform,
+                                       waveform->ne[0],
+                                       1,
+                                       streams);
+            ggml_tensor* stereo_z = nullptr;
+            for (int64_t stream = 0; stream < streams; ++stream) {
+                auto mono = ggml_ext_slice(ctx->ggml_ctx, waveform, 2, stream, stream + 1);
+                auto x    = encoder->forward(ctx, mono);
+                x         = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 1, 0, 2, 3));
+                x         = pre->forward(ctx, x);
+                x         = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, x, 1, 0, 2, 3));
+                auto z    = mean_proj->forward(ctx, x);
 
-            auto mean = ggml_reshape_4d(ctx->ggml_ctx, params["latents_mean"], 1, kLatentChannels, 1, 1);
-            auto std  = ggml_reshape_4d(ctx->ggml_ctx, params["latents_std"], 1, kLatentChannels, 1, 1);
-            z         = ggml_div(ctx->ggml_ctx, ggml_sub(ctx->ggml_ctx, z, mean), std);
-            return ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, z, 0, 2, 1, 3));
+                auto mean = ggml_reshape_4d(ctx->ggml_ctx, params["latents_mean"], 1, kLatentChannels, 1, 1);
+                auto std  = ggml_reshape_4d(ctx->ggml_ctx, params["latents_std"], 1, kLatentChannels, 1, 1);
+                z         = ggml_div(ctx->ggml_ctx, ggml_sub(ctx->ggml_ctx, z, mean), std);
+                z         = ggml_cont(ctx->ggml_ctx, ggml_permute(ctx->ggml_ctx, z, 0, 2, 1, 3));
+                stereo_z  = stereo_z == nullptr ? z : ggml_concat(ctx->ggml_ctx, stereo_z, z, 1);
+            }
+            return stereo_z;
         }
 
         ggml_tensor* decode(GGMLRunnerContext* ctx, ggml_tensor* latent) {

--- a/src/model/vae/minimax_h3_audio_vae.hpp
+++ b/src/model/vae/minimax_h3_audio_vae.hpp
@@ -370,11 +370,11 @@ namespace MiniMaxH3 {
             // matching PyTorch's reshape(B*S, 1, samples), and concatenate only
             // the completed normalized latents.
             const int64_t streams = waveform->ne[2] * waveform->ne[3];
-            waveform = ggml_reshape_3d(ctx->ggml_ctx,
-                                       waveform,
-                                       waveform->ne[0],
-                                       1,
-                                       streams);
+            waveform              = ggml_reshape_3d(ctx->ggml_ctx,
+                                                    waveform,
+                                                    waveform->ne[0],
+                                                    1,
+                                                    streams);
             ggml_tensor* stereo_z = nullptr;
             for (int64_t stream = 0; stream < streams; ++stream) {
                 auto mono = ggml_ext_slice(ctx->ggml_ctx, waveform, 2, stream, stream + 1);

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -4728,7 +4728,11 @@ static sd::Tensor<float> prepare_minimax_h3_reference_waveform(const sd_audio_t&
         static_cast<long double>(audio.sample_count) * target_sample_rate / audio.sample_rate));
     output_samples          = std::max<uint64_t>(1, output_samples);
     uint64_t padded_samples = (output_samples + 799) / 800 * 800;
-    sd::Tensor<float> waveform({static_cast<int64_t>(padded_samples), 2, 1, 1});
+    // Keep stereo streams planar for the mono-per-stream audio encoder:
+    // [samples, 1, stereo, batch]. This avoids flattening interleaved L/R
+    // storage into alternating samples when the encoder folds streams into
+    // its batch dimension.
+    sd::Tensor<float> waveform({static_cast<int64_t>(padded_samples), 1, 2, 1});
 
     for (uint64_t i = 0; i < output_samples; ++i) {
         long double source_pos = static_cast<long double>(i) * audio.sample_rate / target_sample_rate;
@@ -4739,7 +4743,7 @@ static sd::Tensor<float> prepare_minimax_h3_reference_waveform(const sd_audio_t&
             uint32_t source_channel = audio.channels == 1 ? 0 : std::min<uint32_t>(channel, audio.channels - 1);
             float a                 = audio.data[source0 * audio.channels + source_channel];
             float b                 = audio.data[source1 * audio.channels + source_channel];
-            waveform.index(static_cast<int64_t>(i), channel, 0, 0) =
+            waveform.index(static_cast<int64_t>(i), 0, channel, 0) =
                 std::clamp(a + (b - a) * fraction, -1.f, 1.f);
         }
     }


### PR DESCRIPTION
## Summary

Fix MiniMax-H3 stereo reference-audio encoding so the C++ audio VAE matches the official PyTorch implementation.

The current encoder reshapes stereo into a batched `conv1d` input. On the tested GGML Metal backend, convolution output storage interleaves the stream dimension with feature channels, while later layers read each stream's feature channels as contiguous. This corrupts the reference latent before Ref2VA conditioning.

This change:

- keeps the prepared stereo waveform planar;
- runs the mono audio encoder independently for each stereo stream;
- concatenates the completed normalized stream latents;
- registers and applies the checkpoint's `zero_k_bias` in causal attention.

Fixes #1882.

## Verification

Tested on Apple M4 Max with the Metal backend and `minimax_h3_audio_vae_fp32.safetensors`.

Cross-decoding isolated the failure to C++ encoding:

- PyTorch encode -> C++ decode: intelligible speech
- original C++ encode -> PyTorch decode: buzzing
- original C++ encode -> C++ decode: buzzing
- fixed C++ encode -> C++ decode: intelligible speech

For the same 3.04-second stereo WAV, fixed C++ versus PyTorch normalized latents:

- shape: `122 x 2 x 32 x 1`
- correlation: `0.9999837`
- mean absolute error: `0.0004343`
- C++ standard deviation: `0.4534302`
- PyTorch standard deviation: `0.4534051`

The original latent correlation was approximately `-0.066`.

A clean checkout at `de298c2` builds successfully with:

```bash
cmake -B build -DSD_METAL=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --config Release -j 8 --target sd-cli
```

A clean-checkout 4-step Ref2VA smoke test also completed successfully, although its generated output was music and is not used as speech-quality evidence. The latent parity and cross-decoding results above came from an instrumented build of the same encoder implementation. Separate longer repaired-input tests produced intelligible, input-dependent generated speech. H3 still generates a new target soundtrack; this patch does not claim waveform copying or exact transcript preservation.

## Scope

This is focused on MiniMax-H3 reference-audio encoding. T2AV primarily exercises the audio decoder and therefore does not expose this encoder defect.

## AI assistance

AI tools assisted with investigation and patch preparation. I reviewed the changed lines and validated the implementation against the official PyTorch encoder, cross-decoding, a clean build, and end-to-end runs.
