### PR TITLE
fix: guard against missing sampler/scheduler names

### DIFF
--- a/examples/common/common.cpp
+++ b/examples/common/common.cpp
@@ -1555,6 +1555,18 @@ ArgOptions SDGenerationParams::get_options() {
         return 1;
     };
 
+    std::string sample_methods = sample_method_to_str[0];
+    for (int i = 1; i < SAMPLE_METHOD_COUNT; i++)
+    {
+        sample_methods += ", " + std::string(sample_method_to_str[i]);
+    }
+
+    std::string schedulers = scheduler_to_str[0];
+    for (int i = 1; i < SCHEDULER_COUNT; i++)
+    {
+        schedulers += ", " + std::string(scheduler_to_str[i]);
+    }
+
     options.manual_options = {
         {"-s",
          "--seed",
@@ -1562,17 +1574,18 @@ ArgOptions SDGenerationParams::get_options() {
          on_seed_arg},
         {"",
          "--sampling-method",
-         "sampling method, one of [euler, euler_a, heun, dpm2, dpm++2s_a, dpm++2m, dpm++2mv2, dpm++2m_sde, dpm++2m_sde_bt, ipndm, ipndm_v, lcm, ddim_trailing, tcd, res_multistep, res_2s, er_sde, euler_cfg_pp, euler_a_cfg_pp, lms]"
-         "(default: euler for Flux/SD3/Wan, euler_a otherwise)",
+         "sampling method, one of [" + sample_methods + "], "
+         "default: euler for Flux/SD3/Wan, euler_a otherwise",
          on_sample_method_arg},
         {"",
          "--high-noise-sampling-method",
-         "(high noise) sampling method, one of [euler, euler_a, heun, dpm2, dpm++2s_a, dpm++2m, dpm++2mv2, dpm++2m_sde, dpm++2m_sde_bt, ipndm, ipndm_v, lcm, ddim_trailing, tcd, res_multistep, res_2s, er_sde, euler_cfg_pp, euler_a_cfg_pp, lms]"
-         " default: euler for Flux/SD3/Wan, euler_a otherwise",
+         "(high noise) sampling method, one of [" + sample_methods + "], "
+         "default: euler for Flux/SD3/Wan, euler_a otherwise",
          on_high_noise_sample_method_arg},
         {"",
          "--scheduler",
-         "denoiser sigma scheduler, one of [discrete, karras, exponential, ays, gits, smoothstep, sgm_uniform, simple, kl_optimal, lcm, bong_tangent, ltx2, logit_normal, flux2, flux, beta], alias: normal=discrete, default: model-specific",
+         "denoiser sigma scheduler, one of [" + schedulers + "], "
+         "alias: normal=discrete, default: model-specific",
          on_scheduler_arg},
         {"",
          "--sigmas",

--- a/include/stable-diffusion.h
+++ b/include/stable-diffusion.h
@@ -60,6 +60,8 @@ enum sample_method_t {
     SAMPLE_METHOD_COUNT
 };
 
+extern SD_API const char* sample_method_to_str[];
+
 enum scheduler_t {
     DISCRETE_SCHEDULER,
     KARRAS_SCHEDULER,
@@ -79,6 +81,8 @@ enum scheduler_t {
     BETA_SCHEDULER,
     SCHEDULER_COUNT
 };
+
+extern SD_API const char* scheduler_to_str[];
 
 enum prediction_t {
     EPS_PRED,

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -150,6 +150,9 @@ const char* sampling_methods_str[] = {
     "LMS",
 };
 
+static_assert(SAMPLE_METHOD_COUNT == sizeof(sampling_methods_str) / sizeof(sampling_methods_str[0]),
+              "\nnumber of elements in sampling_methods_str[] != SAMPLE_METHOD_COUNT");
+
 /*================================================== Helper Functions ================================================*/
 
 static bool sd_version_supports_ref_latent_img_cfg(SDVersion version) {
@@ -3306,6 +3309,9 @@ const char* sample_method_to_str[] = {
     "lms",
 };
 
+static_assert(SAMPLE_METHOD_COUNT == sizeof(sample_method_to_str) / sizeof(sample_method_to_str[0]),
+              "\nnumber of elements in sample_method_to_str[] != SAMPLE_METHOD_COUNT");
+
 const char* sd_sample_method_name(enum sample_method_t sample_method) {
     if (sample_method < SAMPLE_METHOD_COUNT) {
         return sample_method_to_str[sample_method];
@@ -3340,6 +3346,9 @@ const char* scheduler_to_str[] = {
     "flux",
     "beta",
 };
+
+static_assert(SCHEDULER_COUNT == sizeof(scheduler_to_str) / sizeof(scheduler_to_str[0]),
+              "\nnumber of elements in scheduler_to_str[] != SCHEDULER_COUNT");
 
 const char* sd_scheduler_name(enum scheduler_t scheduler) {
     if (scheduler < SCHEDULER_COUNT) {


### PR DESCRIPTION
## Summary

Add static size checks for name arrays of schedulers and samplers; form help message dynamically.

And thank you.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
