### PR TITLE
fix: silence clang warnings in stb_image_resize.h

### DIFF
--- a/thirdparty/stb_image_resize.h
+++ b/thirdparty/stb_image_resize.h
@@ -385,7 +385,7 @@ STBIRDEF int stbir_resize_region(  const void *input_pixels , int input_w , int 
 #ifdef STBIR_DEBUG
 #define STBIR__DEBUG_ASSERT STBIR_ASSERT
 #else
-#define STBIR__DEBUG_ASSERT
+#define STBIR__DEBUG_ASSERT(x)
 #endif
 
 // If you hit this it means I haven't done it yet.


### PR DESCRIPTION
## Summary

Clang complains about unused expressions:
```
stb_image_resize.h:2390:90: warning: expression result unused [-Wunused-value]
 2390 |         STBIR__DEBUG_ASSERT((size_t)STBIR__NEXT_MEMPTR(info->ring_buffer, unsigned char) == (size_t)tempmem + tempmem_size_in_bytes);
      |                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
35 warnings generated.
```

## Related Issue / Discussion

https://github.com/leejet/stable-diffusion.cpp/pull/614

## Additional Information

When `STBIR_DEBUG` is not defined, `STBIR__DEBUG_ASSERT` is set to "", which causes `STBIR__DEBUG_ASSERT(...)` to be expanded as `(...)` – to unused expression.

Adding `STBIR__DEBUG_ASSERT(x)` blanks the whole assertion.

Or please update https://github.com/nothings/stb/blob/master/deprecated/stb_image_resize.h to version 0.97.
It seems to be stable enough and author replaced debug assertions with regular ones.
(But he changed the license in 0.97).

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
