### PR TITLE
Optimize Krea2 Vulkan (target: Strix Halo)

### DIFF
--- a/examples/common/media_io.cpp
+++ b/examples/common/media_io.cpp
@@ -38,6 +38,10 @@
 
 namespace fs = std::filesystem;
 
+void set_png_compression_level(int level) {
+    stbi_write_png_compression_level = std::clamp(level, 0, 9);
+}
+
 #ifdef SD_USE_WEBP
 struct WebPFreeDeleter {
     void operator()(void* ptr) const {

--- a/examples/common/media_io.h
+++ b/examples/common/media_io.h
@@ -16,6 +16,9 @@ enum class EncodedImageFormat {
 
 EncodedImageFormat encoded_image_format_from_path(const std::string& path);
 
+// stb stores this process-wide; configure it before starting encoding threads.
+void set_png_compression_level(int level);
+
 std::vector<uint8_t> encode_image_to_vector(EncodedImageFormat format,
                                             const uint8_t* image,
                                             int width,

--- a/examples/server/main.cpp
+++ b/examples/server/main.cpp
@@ -9,6 +9,7 @@
 
 #include "async_jobs.h"
 #include "common/common.h"
+#include "common/media_io.h"
 #include "common/resource_owners.hpp"
 #include "routes.h"
 #include "runtime.h"
@@ -74,6 +75,8 @@ int main(int argc, const char** argv) {
     SDContextParams ctx_params;
     SDGenerationParams default_gen_params;
     parse_args(argc, argv, svr_params, ctx_params, default_gen_params);
+
+    set_png_compression_level(svr_params.png_compression_level);
 
     sd_set_log_callback(sd_log_cb, (void*)&svr_params);
     log_verbose = svr_params.verbose;

--- a/examples/server/runtime.cpp
+++ b/examples/server/runtime.cpp
@@ -33,6 +33,7 @@ static const std::string k_base64_chars =
 
 std::string base64_encode(const std::vector<uint8_t>& bytes) {
     std::string ret;
+    ret.reserve(((bytes.size() + 2) / 3) * 4);
     int val  = 0;
     int valb = -6;
     for (uint8_t c : bytes) {
@@ -196,6 +197,7 @@ ArgOptions SDSvrParams::get_options() {
 
     options.int_options = {
         {"", "--listen-port", "server listen port (default: 1234)", &listen_port},
+        {"", "--png-compression-level", "PNG compression level, 0-9 (default: 4)", &png_compression_level},
     };
 
     options.bool_options = {
@@ -226,6 +228,11 @@ bool SDSvrParams::validate() {
         return false;
     }
 
+    if (png_compression_level < 0 || png_compression_level > 9) {
+        LOG_ERROR("error: png_compression_level should be in the range [0, 9]");
+        return false;
+    }
+
     if (!serve_html_path.empty() && !fs::exists(serve_html_path)) {
         LOG_ERROR("error: serve_html_path file does not exist: %s", serve_html_path.c_str());
         return false;
@@ -245,6 +252,7 @@ std::string SDSvrParams::to_string() const {
     oss << "SDSvrParams {\n"
         << "  listen_ip: " << listen_ip << ",\n"
         << "  listen_port: \"" << listen_port << "\",\n"
+        << "  png_compression_level: " << png_compression_level << ",\n"
         << "  serve_html_path: \"" << serve_html_path << "\",\n"
         << "}";
     return oss.str();

--- a/examples/server/runtime.h
+++ b/examples/server/runtime.h
@@ -21,6 +21,7 @@ struct SDSvrParams {
     std::string listen_ip = "127.0.0.1";
     int listen_port       = 1234;
     std::string serve_html_path;
+    int png_compression_level = 4;
     bool normal_exit = false;
     bool verbose     = false;
     bool color       = false;

--- a/src/core/ggml_extend.hpp
+++ b/src/core/ggml_extend.hpp
@@ -1398,8 +1398,13 @@ __STATIC_INLINE__ ggml_tensor* ggml_ext_attention_ext(ggml_context* ctx,
         }
         k_in = ggml_cast(ctx, k_in, GGML_TYPE_F16);
 
-        v_in = ggml_ext_cont(ctx, ggml_permute(ctx, v_in, 0, 2, 1, 3));
-        v_in = ggml_reshape_3d(ctx, v_in, d_head, L_k, n_kv_head * N);
+        const bool strided_v_cast = N == 1 && v_in->type == GGML_TYPE_F32 &&
+                                    sd_backend_is(backend, "Vulkan");
+        v_in = ggml_permute(ctx, v_in, 0, 2, 1, 3);
+        if (!strided_v_cast) {
+            v_in = ggml_ext_cont(ctx, v_in);
+            v_in = ggml_reshape_3d(ctx, v_in, d_head, L_k, n_kv_head * N);
+        }
         if (kv_scale != 1.0f) {
             v_in = ggml_ext_scale(ctx, v_in, kv_scale);
         }
@@ -1724,6 +1729,15 @@ struct WeightAdapter {
 struct GGMLRunnerContext {
     ggml_backend_t backend                                           = nullptr;
     ggml_context* ggml_ctx                                           = nullptr;
+    // The graph currently being built, for runners that choose to expose it.
+    // cgraph order is post-order DFS from the output, so a subexpression reached only
+    // through a second operand is emitted BETWEEN its consumer and the consumer's first
+    // operand. ggml-vulkan's fusion checks are positional, so that silently defeats them.
+    // A block holding this handle can force such a subexpression into the graph early.
+    ggml_cgraph* gf = nullptr;
+    // True when the runner registered a load-time parameter transform. The model manager
+    // applies it before any loaded parameter can be used by the graph.
+    bool param_transform_registered                                  = false;
     bool flash_attn_enabled                                          = false;
     bool conv2d_direct_enabled                                       = false;
     bool circular_x_enabled                                          = false;
@@ -1820,6 +1834,7 @@ protected:
     bool conv2d_direct_enabled = false;
     bool circular_x_enabled    = false;
     bool circular_y_enabled    = false;
+    bool retain_compute_buffer_between_runs_ = false;
 
     sd::ggml_graph_cut::PlanCache graph_cut_plan_cache_;
     std::unordered_set<const ggml_tensor*> params_tensor_set_;
@@ -2820,7 +2835,7 @@ protected:
             ComputeBufferGuard(const ComputeBufferGuard&)            = delete;
             ComputeBufferGuard& operator=(const ComputeBufferGuard&) = delete;
         };
-        ComputeBufferGuard compute_buffer_guard(this, free_compute_buffer);
+        ComputeBufferGuard compute_buffer_guard(this, free_compute_buffer && !retain_compute_buffer_between_runs_);
 
         if (sched != nullptr) {
             ggml_backend_sched_reset(sched);
@@ -2830,10 +2845,19 @@ protected:
                 return std::nullopt;
             }
         } else if (!ggml_gallocr_alloc_graph(compute_allocr, gf)) {
-            LOG_ERROR("%s alloc compute graph failed", get_desc().c_str());
-            return std::nullopt;
-        }
+            if (!retain_compute_buffer_between_runs_) {
+                LOG_ERROR("%s alloc compute graph failed", get_desc().c_str());
+                return std::nullopt;
+            }
 
+            // A retained allocator may have been reserved for a smaller request. Re-reserve
+            // it on demand; same-shape hot requests continue to reuse the existing buffers.
+            this->free_compute_buffer();
+            if (!alloc_compute_buffer(gf) || !ggml_gallocr_alloc_graph(compute_allocr, gf)) {
+                LOG_ERROR("%s realloc compute graph failed", get_desc().c_str());
+                return std::nullopt;
+            }
+        }
         copy_data_to_backend_tensor(gf, !preserve_backend_tensor_data_map);
         if (sd_backend_is_cpu(runtime_backend)) {
             sd_backend_cpu_set_n_threads(runtime_backend, n_threads);
@@ -3009,8 +3033,14 @@ protected:
     }
 
 public:
+    void release_compute_buffer_after_run() {
+        if (!retain_compute_buffer_between_runs_) {
+            free_compute_buffer();
+        }
+    }
+
     void runner_done() {
-        free_compute_buffer();
+        release_compute_buffer_after_run();
         std::vector<ggml_tensor*> tensors_to_release = std::move(this->runner_param_tensors);
         this->runner_param_tensors.clear();
         runner_param_tensor_set.clear();
@@ -3215,6 +3245,10 @@ public:
 
     void set_conv2d_direct_enabled(bool enabled) {
         conv2d_direct_enabled = enabled;
+    }
+
+    void set_retain_compute_buffer_between_runs(bool enabled) {
+        retain_compute_buffer_between_runs_ = enabled;
     }
 
     void set_circular_axes(bool circular_x, bool circular_y) {

--- a/src/model/diffusion/flux.hpp
+++ b/src/model/diffusion/flux.hpp
@@ -422,7 +422,10 @@ namespace Flux {
             scale = ggml_reshape_3d(ctx, scale, scale->ne[0], 1, scale->ne[1]);  // [N, 1, C]
             shift = ggml_reshape_3d(ctx, shift, shift->ne[0], 1, shift->ne[1]);  // [N, 1, C]
         }
-        x = ggml_add(ctx, x, ggml_mul(ctx, x, scale));
+        // (1 + scale) * x + shift. Folding the 1 into the (tiny) scale tensor keeps
+        // this to two passes over x instead of three; x + x*scale would materialize
+        // an extra full-size intermediate.
+        x = ggml_mul(ctx, x, ggml_scale_bias(ctx, scale, 1.f, 1.f));
         x = ggml_add(ctx, x, shift);
         return x;
     }

--- a/src/model/diffusion/krea2.hpp
+++ b/src/model/diffusion/krea2.hpp
@@ -161,6 +161,54 @@ namespace Krea2 {
         return ((value + multiple - 1) / multiple) * multiple;
     }
 
+    // Graph inputs for the native MROPE path, replacing the precomputed `pe` matrix.
+    struct Krea2Rope {
+        ggml_tensor* pos                  = nullptr;  // I32, 4 streams x n_token
+        ggml_tensor* freq                 = nullptr;  // F32, head_dim/2
+        float theta                       = 1000.f;
+        int sections[GGML_MROPE_SECTIONS] = {0, 0, 0, 0};
+
+        bool enabled() const { return pos != nullptr && freq != nullptr; }
+    };
+
+    // x: [d_head, n_head, L, N] -> [d_head, L, n_head*N], rotated, ready for attention.
+    //
+    // Two conventions have to be reconciled against ggml's MROPE, and neither is visible
+    // in the op's signature:
+    //
+    // 1. MROPE is NEOX-ordered - it rotates the pair (m, d_head/2 + m) - while Krea2 is
+    //    NORMAL-ordered and rotates (2m, 2m+1). The head dim is therefore de-interleaved
+    //    first. q and k receive the SAME permutation and q.k is invariant under a shared
+    //    permutation of the head dim, so nothing is ever permuted back; v, the gate and
+    //    wo never see it.
+    // 2. MROPE runs ONE geometric frequency sweep across the whole head dim, while Krea2
+    //    restarts the sweep for each axis. `freq` (freq_factors) divides theta_base, which
+    //    is the hook that reinstates the per-axis sweep - see gen_krea2_rope_data.
+    //
+    // MROPE indexes positions by ne[2], so the op must run on the [d_head, n_head, L, N]
+    // layout the projections already produce; attention wants tokens in ne[1], so the
+    // transpose happens afterwards. The old hand-rolled path paid the same transpose up
+    // front, so this is not extra work.
+    __STATIC_INLINE__ ggml_tensor* apply_krea2_rope(ggml_context* ctx,
+                                                    ggml_tensor* x,
+                                                    const Krea2Rope& rope) {
+        const int64_t d_head = x->ne[0];
+        const int64_t n_head = x->ne[1];
+        const int64_t L      = x->ne[2];
+        const int64_t N      = x->ne[3];
+
+        x = ggml_reshape_4d(ctx, x, 2, d_head / 2, n_head, L * N);
+        x = ggml_cont(ctx, ggml_permute(ctx, x, 1, 0, 2, 3));
+        x = ggml_reshape_4d(ctx, x, d_head, n_head, L, N);
+
+        x = ggml_rope_multi(ctx, x, rope.pos, rope.freq, static_cast<int>(d_head),
+                            const_cast<int*>(rope.sections), GGML_ROPE_TYPE_MROPE, 0,
+                            rope.theta, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f);
+
+        x = ggml_cont(ctx, ggml_permute(ctx, x, 0, 2, 1, 3));
+        return ggml_reshape_3d(ctx, x, d_head, L, n_head * N);
+    }
+
     class KreaRMSNorm : public UnaryBlock {
     protected:
         int64_t hidden_size;
@@ -183,7 +231,18 @@ namespace Krea2 {
             if (ctx->weight_adapter) {
                 scale = ctx->weight_adapter->patch_weight(ctx->ggml_ctx, ctx->backend, scale, prefix + "scale.weight");
             }
-            scale = ggml_add(ctx->ggml_ctx, scale, ggml_ext_ones(ctx->ggml_ctx, scale->ne[0], 1, 1, 1));
+            // The stored weight is an offset from identity, so the effective scale is w+1.
+            // When the loader has already folded the 1 in, the mul's operand is a plain leaf
+            // and rms_norm/mul come out adjacent, which is what lets ggml-vulkan fuse them.
+            // Otherwise build w+1 here and force it into the graph immediately: left to the
+            // final DFS it lands BETWEEN the rms_norm and the mul, and the fusion check is
+            // positional, so the fusion would silently never fire.
+            if (!ctx->param_transform_registered) {
+                scale = ggml_add(ctx->ggml_ctx, scale, ggml_ext_ones(ctx->ggml_ctx, scale->ne[0], 1, 1, 1));
+                if (ctx->gf != nullptr) {
+                    ggml_build_forward_expand(ctx->gf, scale);
+                }
+            }
             x     = ggml_rms_norm(ctx->ggml_ctx, x, eps);
             x     = ggml_mul_inplace(ctx->ggml_ctx, x, scale);
             return x;
@@ -204,9 +263,9 @@ namespace Krea2 {
             auto up   = std::dynamic_pointer_cast<Linear>(blocks["up"]);
             auto down = std::dynamic_pointer_cast<Linear>(blocks["down"]);
 
-            auto gated = ggml_silu(ctx->ggml_ctx, gate->forward(ctx, x));
-            auto up_x  = up->forward(ctx, x);
-            x          = ggml_mul(ctx->ggml_ctx, gated, up_x);
+            auto gate_x = gate->forward(ctx, x);
+            auto up_x   = up->forward(ctx, x);
+            x           = ggml_swiglu_split(ctx->ggml_ctx, gate_x, up_x);
             return down->forward(ctx, x);
         }
     };
@@ -260,8 +319,8 @@ namespace Krea2 {
 
         ggml_tensor* forward(GGMLRunnerContext* ctx,
                              ggml_tensor* x,
-                             ggml_tensor* pe   = nullptr,
-                             ggml_tensor* mask = nullptr) {
+                             const Krea2Rope& rope = {},
+                             ggml_tensor* mask     = nullptr) {
             auto wq    = std::dynamic_pointer_cast<Linear>(blocks["wq"]);
             auto wk    = std::dynamic_pointer_cast<Linear>(blocks["wk"]);
             auto wv    = std::dynamic_pointer_cast<Linear>(blocks["wv"]);
@@ -284,11 +343,24 @@ namespace Krea2 {
             auto v = wv->forward(ctx, x);
             v      = ggml_reshape_4d(ctx->ggml_ctx, v, head_dim_, kv_heads, L, N);
 
+            if (rope.enabled() && sd_backend_is(ctx->backend, "Vulkan")) {
+                // The fused MROPE path writes head/token-transposed output, so its source
+                // cannot share the destination allocation as a row-wise fusion normally can.
+                ggml_set_output(q);
+                ggml_set_output(k);
+            }
+
             q = qnorm->forward(ctx, q);
             k = knorm->forward(ctx, k);
 
-            auto out = pe != nullptr ? Rope::attention(ctx, q, k, v, pe, mask)
-                                     : attention_no_rope(ctx, q, k, v, mask);
+            ggml_tensor* out;
+            if (rope.enabled()) {
+                q   = apply_krea2_rope(ctx->ggml_ctx, q, rope);  // [d_head, L, heads*N]
+                k   = apply_krea2_rope(ctx->ggml_ctx, k, rope);  // [d_head, L, kv_heads*N]
+                out = ggml_ext_attention_ext(ctx->ggml_ctx, ctx->backend, q, k, v, heads, mask, true, ctx->flash_attn_enabled);
+            } else {
+                out = attention_no_rope(ctx, q, k, v, mask);
+            }
             out      = ggml_mul(ctx->ggml_ctx, out, ggml_sigmoid(ctx->ggml_ctx, gate->forward(ctx, x)));
             out      = wo->forward(ctx, out);
             return out;
@@ -317,6 +389,9 @@ namespace Krea2 {
             }
             lin      = ggml_repeat(ctx->ggml_ctx, lin, vec);
             auto out = ggml_add(ctx->ggml_ctx, vec, lin);
+            if (ctx->gf != nullptr) {
+                ggml_build_forward_expand(ctx->gf, out);
+            }
             return ggml_ext_chunk(ctx->ggml_ctx, out, 6, 0);
         }
     };
@@ -434,7 +509,7 @@ namespace Krea2 {
         ggml_tensor* forward(GGMLRunnerContext* ctx,
                              ggml_tensor* x,
                              ggml_tensor* vec,
-                             ggml_tensor* pe,
+                             const Krea2Rope& rope,
                              ggml_tensor* vec_refs = nullptr,
                              int64_t ref_start     = -1) {
             auto mod      = std::dynamic_pointer_cast<KreaDoubleSharedModulation>(blocks["mod"]);
@@ -467,7 +542,7 @@ namespace Krea2 {
 
                 auto attn_input = ggml_concat(ctx->ggml_ctx, attn_in_main, attn_in_refs, 1);
 
-                auto attn_out = attn->forward(ctx, attn_input, pe);
+                auto attn_out = attn->forward(ctx, attn_input, rope);
 
                 auto attn_out_main = ggml_view_3d(ctx->ggml_ctx, attn_out, D, len_main, B, attn_out->nb[1], attn_out->nb[2], 0);
                 auto attn_out_refs = ggml_view_3d(ctx->ggml_ctx, attn_out, D, len_refs, B, attn_out->nb[1], attn_out->nb[2], len_main * attn_out->nb[1]);
@@ -505,7 +580,7 @@ namespace Krea2 {
                                                  mods[1],
                                                  mods[0],
                                                  true);
-                auto attn_out   = attn->forward(ctx, attn_input, pe);
+                auto attn_out   = attn->forward(ctx, attn_input, rope);
                 x               = ggml_add(ctx->ggml_ctx, x, ggml_mul(ctx->ggml_ctx, attn_out, mods[2]));
 
                 auto mlp_input = Flux::modulate(ctx->ggml_ctx,
@@ -627,7 +702,7 @@ namespace Krea2 {
                              ggml_tensor* x,
                              ggml_tensor* timestep,
                              ggml_tensor* context,
-                             ggml_tensor* pe,
+                             const Krea2Rope& rope,
                              std::vector<ggml_tensor*> ref_latents = {},
                              bool zero_timestep_refs               = false) {
             int64_t W = x->ne[0];
@@ -676,7 +751,7 @@ namespace Krea2 {
             int64_t ref_start  = hidden_states->ne[1] - ref_len;
             for (int i = 0; i < config.layers; ++i) {
                 auto block    = std::dynamic_pointer_cast<KreaSingleStreamBlock>(blocks["blocks." + std::to_string(i)]);
-                hidden_states = block->forward(ctx, hidden_states, tvec, pe, tvec_0, ref_start);
+                hidden_states = block->forward(ctx, hidden_states, tvec, rope, tvec_0, ref_start);
                 sd::ggml_graph_cut::mark_graph_cut(hidden_states, "krea2.blocks." + std::to_string(i), "hidden_states");
             }
 
@@ -687,15 +762,24 @@ namespace Krea2 {
         }
     };
 
-    __STATIC_INLINE__ std::vector<float> gen_krea2_pe(int h,
-                                                      int w,
-                                                      int patch_size,
-                                                      int bs,
-                                                      int context_len,
-                                                      float theta,
-                                                      const std::vector<int>& axes_dim,
-                                                      const std::vector<ggml_tensor*>& ref_latents,
-                                                      Rope::RefIndexMode ref_index_mode) {
+    struct Krea2RopeData {
+        std::vector<int32_t> pos;  // 4 streams x n_token, stream k at pos[i2 + n_token*k]
+        std::vector<float> freq;   // head_dim/2 freq_factors
+        int sections[GGML_MROPE_SECTIONS] = {0, 0, 0, 0};
+    };
+
+    // Position ids and freq_factors for the MROPE path, in place of the `pe` cos/sin matrix.
+    // The ids are built exactly as the previous gen_krea2_pe built them.
+    __STATIC_INLINE__ Krea2RopeData gen_krea2_rope_data(int h,
+                                                        int w,
+                                                        int patch_size,
+                                                        int bs,
+                                                        int context_len,
+                                                        float theta,
+                                                        const std::vector<int>& axes_dim,
+                                                        int64_t head_dim,
+                                                        const std::vector<ggml_tensor*>& ref_latents,
+                                                        Rope::RefIndexMode ref_index_mode) {
         auto txt_ids = Rope::gen_flux_txt_ids(bs, context_len, 3, {});
         auto img_ids = Rope::gen_flux_img_ids(h, w, patch_size, bs, 3, 0, 0, 0, false);
         auto ids     = Rope::concat_ids(txt_ids, img_ids, bs);
@@ -703,13 +787,45 @@ namespace Krea2 {
             auto refs_ids = Rope::gen_refs_ids(patch_size, bs, 3, 1, ref_latents, ref_index_mode, 1.0f, false, 0);
             ids           = Rope::concat_ids(ids, refs_ids, bs);
         }
-        return Rope::embed_nd(ids, bs, theta, axes_dim);
+
+        Krea2RopeData data;
+        const size_t n_token = ids.size();
+        const int n_axes     = std::min<int>(static_cast<int>(axes_dim.size()), GGML_MROPE_SECTIONS);
+
+        // MROPE `sections` are counted in PAIRS, not channels.
+        for (int axis = 0; axis < n_axes; ++axis) {
+            data.sections[axis] = axes_dim[axis] / 2;
+        }
+
+        data.pos.assign(n_token * 4, 0);
+        for (int axis = 0; axis < n_axes; ++axis) {
+            for (size_t token = 0; token < n_token; ++token) {
+                data.pos[axis * n_token + token] = static_cast<int32_t>(std::lround(ids[token][axis]));
+            }
+        }
+
+        // MROPE computes theta_base = pos * theta^(-2p/head_dim) with p the GLOBAL pair
+        // index, then divides by freq_factors. Krea2 wants pos * theta^(-2j/axes_dim[a])
+        // with j restarting at every axis, so the correction is the ratio of the two.
+        data.freq.resize(head_dim / 2);
+        int axis = 0, base = 0;
+        for (int p = 0; p < head_dim / 2; ++p) {
+            while (axis + 1 < n_axes && p >= base + data.sections[axis]) {
+                base += data.sections[axis];
+                ++axis;
+            }
+            const double j = p - base;
+            data.freq[p]   = static_cast<float>(
+                std::pow(static_cast<double>(theta), 2.0 * j / axes_dim[axis] - 2.0 * p / head_dim));
+        }
+        return data;
     }
 
     struct Krea2Runner : public DiffusionModelRunner {
         Krea2Config config;
         Krea2Model model;
-        std::vector<float> pe_vec;
+        Krea2RopeData rope_data;
+        bool param_transform_registered_ = false;
 
         Krea2Runner(ggml_backend_t backend,
                     const String2TensorStorage& tensor_storage_map      = {},
@@ -723,6 +839,33 @@ namespace Krea2 {
 
         std::string get_desc() override {
             return "krea2";
+        }
+
+        // Fold KreaRMSNorm's +1 into the stored scales once at load. Every norm otherwise
+        // rebuilds w+1 in every graph, which costs three dispatches per norm per step and
+        // blocks the RMS_NORM+MUL fusion. Addition commutes with a LoRA delta, so
+        // this stays correct with adapters active.
+        //
+        // The flag is set HERE, at registration, not when the folds are observed to happen.
+        // build_graph runs BEFORE the loader populates the params - the manager needs the
+        // graph to know which tensors to fetch - so a flag driven by observed progress reads
+        // false for the first graph, which then adds +1 to weights the loader folds a moment
+        // later, applying it twice. The invariant that actually holds is per tensor: the
+        // loader folds each scale before anything can use it.
+        std::function<void(const std::string&, ggml_tensor*, bool)> get_param_transform() override {
+            param_transform_registered_ = true;
+            return [](const std::string& name, ggml_tensor* t, bool) {
+                if (t == nullptr || t->type != GGML_TYPE_F32 || !ends_with(name, ".scale")) {
+                    return;
+                }
+                const int64_t n = ggml_nelements(t);
+                std::vector<float> v(static_cast<size_t>(n));
+                ggml_backend_tensor_get(t, v.data(), 0, v.size() * sizeof(float));
+                for (float& x : v) {
+                    x += 1.0f;
+                }
+                ggml_backend_tensor_set(t, v.data(), 0, v.size() * sizeof(float));
+            };
         }
 
         void get_param_tensors(std::map<std::string, ggml_tensor*>& tensors, const std::string& prefix) override {
@@ -747,21 +890,29 @@ namespace Krea2 {
                 ref_latents.push_back(make_input(ref_latent_tensor));
             }
 
-            pe_vec      = gen_krea2_pe(static_cast<int>(x->ne[1]),
-                                       static_cast<int>(x->ne[0]),
-                                       config.patch_size,
-                                       static_cast<int>(x->ne[3]),
-                                       static_cast<int>(context->ne[1]),
-                                       config.theta,
-                                       config.axes_dim,
-                                       ref_latents,
-                                       ref_image_params.ref_index_mode);
-            int pos_len = static_cast<int>(pe_vec.size() / config.axes_dim_sum / 2);
-            auto pe     = ggml_new_tensor_4d(compute_ctx, GGML_TYPE_F32, 2, 2, config.axes_dim_sum / 2, pos_len);
-            set_backend_tensor_data(pe, pe_vec.data());
+            rope_data = gen_krea2_rope_data(static_cast<int>(x->ne[1]),
+                                            static_cast<int>(x->ne[0]),
+                                            config.patch_size,
+                                            static_cast<int>(x->ne[3]),
+                                            static_cast<int>(context->ne[1]),
+                                            config.theta,
+                                            config.axes_dim,
+                                            config.head_dim(),
+                                            ref_latents,
+                                            ref_image_params.ref_index_mode);
 
-            auto runner_ctx  = get_context();
-            ggml_tensor* out = model.forward(&runner_ctx, x, timesteps, context, pe, ref_latents, ref_image_params.force_ref_timestep_zero);
+            Krea2Rope rope;
+            rope.theta = config.theta;
+            std::copy(std::begin(rope_data.sections), std::end(rope_data.sections), std::begin(rope.sections));
+            rope.pos  = ggml_new_tensor_1d(compute_ctx, GGML_TYPE_I32, static_cast<int64_t>(rope_data.pos.size()));
+            rope.freq = ggml_new_tensor_1d(compute_ctx, GGML_TYPE_F32, static_cast<int64_t>(rope_data.freq.size()));
+            set_backend_tensor_data(rope.pos, rope_data.pos.data());
+            set_backend_tensor_data(rope.freq, rope_data.freq.data());
+
+            auto runner_ctx                       = get_context();
+            runner_ctx.gf                         = gf;
+            runner_ctx.param_transform_registered = param_transform_registered_;
+            ggml_tensor* out                      = model.forward(&runner_ctx, x, timesteps, context, rope, ref_latents, ref_image_params.force_ref_timestep_zero);
             ggml_build_forward_expand(gf, out);
             return gf;
         }

--- a/src/model/diffusion/model.hpp
+++ b/src/model/diffusion/model.hpp
@@ -1,6 +1,7 @@
 #ifndef __SD_MODEL_DIFFUSION_MODEL_HPP__
 #define __SD_MODEL_DIFFUSION_MODEL_HPP__
 
+#include <functional>
 #include <string>
 #include <utility>
 #include <variant>
@@ -177,6 +178,11 @@ public:
 
     virtual void get_param_tensors(std::map<std::string, ggml_tensor*>& tensors,
                                    const std::string& prefix) = 0;
+
+    // Optional in-place transform applied to each parameter once, right after it is loaded.
+    // `loras_active` means a LoRA delta will be added to this weight afterwards, so a
+    // transform the delta cannot commute with must decline. Empty means no transform.
+    virtual std::function<void(const std::string&, ggml_tensor*, bool)> get_param_transform() { return {}; }
 };
 
 #endif  // __SD_MODEL_DIFFUSION_MODEL_HPP__

--- a/src/model/vae/wan_vae.hpp
+++ b/src/model/vae/wan_vae.hpp
@@ -67,6 +67,69 @@ namespace WAN {
             int lp2 = 2 * std::get<0>(padding);
             int rp2 = 0;
 
+            // With causal padding, a single uncached frame only observes the final
+            // temporal kernel slice; the earlier slices multiply zeros.
+            const bool single_frame_2d = cache_x == nullptr && x->ne[2] == 1 &&
+                                         ggml_is_contiguous(x) && ggml_is_contiguous(w) &&
+                                         std::get<0>(stride) == 1 &&
+                                         2 * std::get<0>(padding) ==
+                                             std::get<0>(dilation) * (std::get<0>(kernel_size) - 1);
+            if (single_frame_2d) {
+                const int64_t n = x->ne[3] / in_channels;
+                GGML_ASSERT(n * in_channels == x->ne[3]);
+                GGML_ASSERT(w->ne[2] == std::get<0>(kernel_size));
+
+                const size_t temporal_offset = (w->ne[2] - 1) * w->nb[2];
+                ggml_tensor* w_2d            = ggml_view_4d(ctx->ggml_ctx,
+                                                            w,
+                                                            w->ne[0],
+                                                            w->ne[1],
+                                                            in_channels,
+                                                            out_channels,
+                                                            w->nb[1],
+                                                            w->nb[3],
+                                                            in_channels * w->nb[3],
+                                                            temporal_offset);
+                w_2d                         = ggml_cont(ctx->ggml_ctx, w_2d);
+
+                ggml_tensor* x_2d = ggml_reshape_4d(ctx->ggml_ctx,
+                                                    x,
+                                                    x->ne[0],
+                                                    x->ne[1],
+                                                    in_channels,
+                                                    n);
+                x_2d              = ggml_ext_pad_ext(ctx->ggml_ctx,
+                                                     ctx->backend,
+                                                     x_2d,
+                                                     lp0,
+                                                     rp0,
+                                                     lp1,
+                                                     rp1,
+                                                     0,
+                                                     0,
+                                                     0,
+                                                     0,
+                                                     ctx->circular_x_enabled,
+                                                     ctx->circular_y_enabled);
+                x_2d              = ggml_ext_conv_2d(ctx->ggml_ctx,
+                                                     x_2d,
+                                                     w_2d,
+                                                     b,
+                                                     std::get<2>(stride),
+                                                     std::get<1>(stride),
+                                                     0,
+                                                     0,
+                                                     std::get<2>(dilation),
+                                                     std::get<1>(dilation),
+                                                     ctx->conv2d_direct_enabled);
+                return ggml_reshape_4d(ctx->ggml_ctx,
+                                       x_2d,
+                                       x_2d->ne[0],
+                                       x_2d->ne[1],
+                                       1,
+                                       x_2d->ne[2] * x_2d->ne[3]);
+            }
+
             if (cache_x != nullptr && lp2 > 0) {
                 x = ggml_concat(ctx->ggml_ctx, cache_x, x, 2);
                 lp2 -= (int)cache_x->ne[2];

--- a/src/model_loader.cpp
+++ b/src/model_loader.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 #include <chrono>
 #include <cinttypes>
+#include <condition_variable>
 #include <cstdarg>
 #include <cstdlib>
 #include <fstream>
@@ -1056,11 +1057,25 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb,
 
         std::atomic<size_t> tensor_idx(0);
         std::atomic<bool> failed(false);
+        std::atomic<int> active_workers(n_threads);
         std::vector<std::thread> workers;
-        std::mutex backend_tensor_set_mutex;
+        std::mutex worker_wait_mutex;
+        std::condition_variable worker_wait_cv;
+        std::mutex backend_buffer_mutexes_mutex;
+        std::unordered_map<ggml_backend_buffer_t, std::unique_ptr<std::mutex>> backend_buffer_mutexes;
 
         for (int i = 0; i < n_threads; ++i) {
             workers.emplace_back([&, file_path, is_zip]() {
+                struct WorkerDoneGuard {
+                    std::atomic<int>& active_workers;
+                    std::condition_variable& worker_wait_cv;
+
+                    ~WorkerDoneGuard() {
+                        active_workers.fetch_sub(1);
+                        worker_wait_cv.notify_all();
+                    }
+                } worker_done_guard{active_workers, worker_wait_cv};
+
                 std::ifstream file;
                 zip_t* zip = nullptr;
                 if (is_zip) {
@@ -1248,7 +1263,22 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb,
                     if (dst_tensor->buffer != nullptr && !ggml_backend_buffer_is_host(dst_tensor->buffer)) {
                         t0 = ggml_time_ms();
 
-                        std::lock_guard<std::mutex> lock(backend_tensor_set_mutex);
+                        ggml_backend_buffer_t dst_buffer = dst_tensor->view_src != nullptr
+                                                               ? dst_tensor->view_src->buffer
+                                                               : dst_tensor->buffer;
+                        const char* buft_name            = ggml_backend_buft_name(ggml_backend_buffer_get_type(dst_buffer));
+                        const bool is_rpc                = buft_name != nullptr && std::string(buft_name).find("RPC") != std::string::npos;
+                        std::mutex* dst_buffer_mutex     = nullptr;
+                        {
+                            std::lock_guard<std::mutex> lock(backend_buffer_mutexes_mutex);
+                            // RPC buffers share a connection and retain their historical global serialization.
+                            auto& buffer_mutex = backend_buffer_mutexes[is_rpc ? nullptr : dst_buffer];
+                            if (buffer_mutex == nullptr) {
+                                buffer_mutex = std::make_unique<std::mutex>();
+                            }
+                            dst_buffer_mutex = buffer_mutex.get();
+                        }
+                        std::lock_guard<std::mutex> lock(*dst_buffer_mutex);
                         ggml_backend_tensor_set(dst_tensor, convert_buf, 0, ggml_nbytes(dst_tensor));
 
                         t1 = ggml_time_ms();
@@ -1263,9 +1293,9 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb,
             });
         }
 
-        while (true) {
+        while (active_workers.load() > 0 && !failed) {
             size_t current_idx = tensor_idx.load();
-            if (current_idx >= tensors_to_process.size() || failed) {
+            if (current_idx >= tensors_to_process.size()) {
                 break;
             }
             size_t curr_num       = total_tensors_processed + current_idx;
@@ -1276,7 +1306,10 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb,
                                       bytes_processed.load(),
                                       elapsed_seconds);
             }
-            std::this_thread::sleep_for(std::chrono::milliseconds(total_tensors_to_process <= 4 ? 10 : 200));
+            std::unique_lock<std::mutex> wait_lock(worker_wait_mutex);
+            worker_wait_cv.wait_for(wait_lock,
+                                    std::chrono::milliseconds(total_tensors_to_process <= 4 ? 10 : 200),
+                                    [&]() { return active_workers.load() == 0 || failed.load(); });
         }
 
         for (auto& w : workers) {

--- a/src/model_manager.cpp
+++ b/src/model_manager.cpp
@@ -401,6 +401,8 @@ bool ModelManager::load_tensors_to_params_backend(const std::vector<TensorState*
         }
         return false;
     }
+    apply_param_transforms(need_load);
+
     for (ParamsStorageBlock* block : created_storage_blocks) {
         if (block != nullptr && block->buffer != nullptr) {
             LOG_DEBUG("model manager prepared params backend buffer (%6.2f MB, %zu tensors, %s)",
@@ -605,6 +607,34 @@ bool ModelManager::apply_loras_to_params(const std::vector<TensorState*>& states
         }
     }
     return true;
+}
+
+void ModelManager::set_param_transform(const std::string& desc, ParamTransformFn fn) {
+    if (fn) {
+        param_transforms_[desc] = std::move(fn);
+    } else {
+        param_transforms_.erase(desc);
+    }
+}
+
+void ModelManager::apply_param_transforms(const std::vector<TensorState*>& states) {
+    if (param_transforms_.empty()) {
+        return;
+    }
+    const bool loras_active = !loras_.empty();
+    for (TensorState* state : states) {
+        if (state == nullptr || state->tensor == nullptr || state->tensor->data == nullptr) {
+            continue;
+        }
+        if (should_ignore(*state) || is_optional_missing_tensor(state->name)) {
+            continue;
+        }
+        auto it = param_transforms_.find(state->desc);
+        if (it == param_transforms_.end() || !it->second) {
+            continue;
+        }
+        it->second(state->name, state->tensor, loras_active);
+    }
 }
 
 void ModelManager::reset_lora_applied_params() {

--- a/src/model_manager.h
+++ b/src/model_manager.h
@@ -2,6 +2,7 @@
 #define __MODEL_MANAGER_H__
 
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <set>
@@ -26,6 +27,15 @@ public:
         std::string tensor_name_prefix_filter;
         bool required = false;
     };
+
+    // Applied in place to each parameter right after it is loaded into the params backend.
+    // Lets a model bake a layout change into its weights once instead of paying for it in
+    // every graph. Scoped by the `desc` used at registration, and re-run on reload: a LoRA
+    // change releases all params storage, so the reload path transforms the fresh copy.
+    // `loras_active` warns the callee that a LoRA delta will be added to this weight, so a
+    // transform that a delta cannot commute with (e.g. a permutation) must decline.
+    using ParamTransformFn = std::function<void(const std::string& name, ggml_tensor* tensor, bool loras_active)>;
+    void set_param_transform(const std::string& desc, ParamTransformFn fn);
 
 private:
     struct TensorState {
@@ -75,6 +85,7 @@ private:
     int n_threads_               = 0;
     bool enable_mmap_            = false;
     bool writable_mmap_          = false;
+    std::map<std::string, ParamTransformFn> param_transforms_;
 
     void finish_compute_backend_usage(const std::vector<TensorState*>& states);
     void release_all();
@@ -105,6 +116,7 @@ private:
     void free_params_storage_block(ParamsStorageBlock& block);
     void erase_params_storage_block(ParamsStorageBlock* block);
     void reset_lora_applied_params();
+    void apply_param_transforms(const std::vector<TensorState*>& states);
 
 public:
     ~ModelManager() override;

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -1005,7 +1005,7 @@ public:
             apply_lora_immediately = false;
         }
 
-        bool needs_writable_mmap = enable_mmap && apply_lora_immediately;
+        bool needs_writable_mmap = enable_mmap && (apply_lora_immediately || sd_version_is_krea2(version));
         model_manager->set_writable_mmap(needs_writable_mmap);
         if (enable_mmap && apply_lora_immediately) {
             LOG_WARN("in mode 'immediately', LoRAs will cause extra memory usage with mmap");
@@ -1355,11 +1355,17 @@ public:
 
             diffusion_model->set_max_graph_vram_bytes(max_graph_vram_bytes_for_module(SDBackendModule::DIFFUSION));
             diffusion_model->set_stream_layers_enabled(stream_layers);
+            if (version == VERSION_KREA2 && sd_backend_is(backend_for(SDBackendModule::DIFFUSION), "Vulkan")) {
+                diffusion_model->set_retain_compute_buffer_between_runs(true);
+            }
             if (!register_runner_params("Diffusion model",
                                         diffusion_model,
                                         SDBackendModule::DIFFUSION,
                                         &unet_params_mem_size)) {
                 return false;
+            }
+            if (model_manager) {
+                model_manager->set_param_transform("Diffusion model", diffusion_model->get_param_transform());
             }
 
             if (high_noise_diffusion_model) {
@@ -1557,6 +1563,16 @@ public:
                 if (preview_vae) {
                     preview_vae->set_conv2d_direct_enabled(true);
                 }
+            } else {
+                const bool krea2_vulkan = version == VERSION_KREA2 &&
+                                          sd_backend_is(backend_for(SDBackendModule::VAE), "Vulkan");
+                if (krea2_vulkan) {
+                    LOG_INFO("Using Conv2d direct in the Krea2 Vulkan VAE");
+                    first_stage_model->set_conv2d_direct_enabled(true);
+                }
+            }
+            if (version == VERSION_KREA2 && sd_backend_is(backend_for(SDBackendModule::VAE), "Vulkan")) {
+                first_stage_model->set_retain_compute_buffer_between_runs(true);
             }
 
             if (use_control_net) {
@@ -2917,10 +2933,10 @@ public:
 
         if (control_net) {
             control_net->free_control_ctx();
-            control_net->free_compute_buffer();
+            control_net->release_compute_buffer_after_run();
         }
         if (work_diffusion_model) {
-            work_diffusion_model->free_compute_buffer();
+            work_diffusion_model->release_compute_buffer_after_run();
         }
         return x0;
     }


### PR DESCRIPTION
## Summary

People in the Lemonade community have been complaining that sd.cpp is very slow compared to native PyTorch inference and a new backend (TheNoise) has been created to obtain fast generation, so I decided to try to match parity.

## Related Issue / Discussion

Lots of kernel (see linked GGML fork/PR) and Krea changes that in total bring the generation time for a 1024x768 image in 8 steps on Krea2 Turbo Q8_0 on a Strix Halo from 77 seconds to 29 seconds.

## Additional Information

Images are not bit-identical, but coherence/detail has been preserved at a similar level.

Note: this is probably NOT a one-time effort, I chose Krea2 first because that was chosen for TheNoise as one of the first supported models, but I want to do a sweep across a couple of the new supported image models to bring performance up to par and hopefully people with different hardware can use this to tune optimizations for their own hardware as well.

## Checklist

- [X] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
