### PR TITLE
feat: support numbering for preview images

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -400,20 +400,15 @@ void step_callback(int step, int frame_count, sd_image_t* image, bool is_noisy, 
     // is_noisy is set to true if the preview corresponds to noisy latents, false if it's denoised latents
     // unused in this app, it will either be always noisy or always denoised here
     if (frame_count == 1) {
-        std::string name = cli_params->preview_path;
-        size_t name_pos = name.find_last_of('/') + 1;  // skipping %d in path
-#ifdef _WIN32
-        size_t name_pos2 = name.find_last_of('\\') + 1;
-        name_pos = std::max(name_pos, name_pos2);
-#endif
-        name = cli_params->preview_path.substr(0, name_pos) +
-               format_frame_idx(name.substr(name_pos), ++continuous_preview_counter);
-        if (!write_image_to_file(name,
+        fs::path path = cli_params->preview_path;
+        std::string new_pathname = fs::path(path).remove_filename().string() + 
+            format_frame_idx(path.filename().string(), ++continuous_preview_counter);
+        if (!write_image_to_file(new_pathname,
                                  image->data,
                                  image->width,
                                  image->height,
                                  image->channel)) {
-            LOG_ERROR("save preview image to '%s' failed", name.c_str());
+            LOG_ERROR("save preview image to '%s' failed", new_pathname.c_str());
         }
     } else {
         if (create_video_from_sd_images(cli_params->preview_path.c_str(), image, frame_count, cli_params->preview_fps) != 0) {

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -372,6 +372,25 @@ bool load_images_from_dir(const std::string dir,
     return true;
 }
 
+std::string format_frame_idx(std::string pattern, int frame_idx) {
+    std::smatch match;
+    std::string result = pattern;
+    while (std::regex_search(result, match, format_specifier_regex)) {
+        std::string specifier = match.str(1);
+        char buffer[32];
+        snprintf(buffer, sizeof(buffer), specifier.c_str(), frame_idx);
+        result.replace(match.position(1), match.length(1), buffer);
+    }
+
+    // Then replace all '%%' with '%'
+    size_t pos = 0;
+    while ((pos = result.find("%%", pos)) != std::string::npos) {
+        result.replace(pos, 2, "%");
+        pos += 1;
+    }
+    return result;
+}
+
 void step_callback(int step, int frame_count, sd_image_t* image, bool is_noisy, void* data) {
     (void)step;
     (void)is_noisy;
@@ -391,25 +410,6 @@ void step_callback(int step, int frame_count, sd_image_t* image, bool is_noisy, 
             LOG_ERROR("save preview video to '%s' failed", cli_params->preview_path.c_str());
         }
     }
-}
-
-std::string format_frame_idx(std::string pattern, int frame_idx) {
-    std::smatch match;
-    std::string result = pattern;
-    while (std::regex_search(result, match, format_specifier_regex)) {
-        std::string specifier = match.str(1);
-        char buffer[32];
-        snprintf(buffer, sizeof(buffer), specifier.c_str(), frame_idx);
-        result.replace(match.position(1), match.length(1), buffer);
-    }
-
-    // Then replace all '%%' with '%'
-    size_t pos = 0;
-    while ((pos = result.find("%%", pos)) != std::string::npos) {
-        result.replace(pos, 2, "%");
-        pos += 1;
-    }
-    return result;
 }
 
 static fs::path get_video_audio_sidecar_path(const SDCliParams& cli_params) {

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -80,7 +80,7 @@ struct SDCliParams {
              &metadata_format},
             {"",
              "--preview-path",
-             "path to write preview image to (default: ./preview.png). Multi-frame previews support .avi, .webm, and animated .webp",
+             "path to write preview image to (default: ./preview.png). For image generation, the filename can have %03d placeholder for sequential numbering. Multi-frame previews support .avi, .webm, and animated .webp",
              0,
              &preview_path},
             {"",
@@ -391,6 +391,8 @@ std::string format_frame_idx(std::string pattern, int frame_idx) {
     return result;
 }
 
+int continuous_preview_counter = 0;
+
 void step_callback(int step, int frame_count, sd_image_t* image, bool is_noisy, void* data) {
     (void)step;
     (void)is_noisy;
@@ -398,12 +400,20 @@ void step_callback(int step, int frame_count, sd_image_t* image, bool is_noisy, 
     // is_noisy is set to true if the preview corresponds to noisy latents, false if it's denoised latents
     // unused in this app, it will either be always noisy or always denoised here
     if (frame_count == 1) {
-        if (!write_image_to_file(cli_params->preview_path,
+        std::string name = cli_params->preview_path;
+        size_t name_pos = name.find_last_of('/') + 1;  // skipping %d in path
+#ifdef _WIN32
+        size_t name_pos2 = name.find_last_of('\\') + 1;
+        name_pos = std::max(name_pos, name_pos2);
+#endif
+        name = cli_params->preview_path.substr(0, name_pos) +
+               format_frame_idx(name.substr(name_pos), ++continuous_preview_counter);
+        if (!write_image_to_file(name,
                                  image->data,
                                  image->width,
                                  image->height,
                                  image->channel)) {
-            LOG_ERROR("save preview image to '%s' failed", cli_params->preview_path.c_str());
+            LOG_ERROR("save preview image to '%s' failed", name.c_str());
         }
     } else {
         if (create_video_from_sd_images(cli_params->preview_path.c_str(), image, frame_count, cli_params->preview_fps) != 0) {


### PR DESCRIPTION
## Summary

Allow to use %d placeholder in a filename template of preview images.
Hires previews will use numbering, continuous with base resolution.

Video previews are unaffected.

## Additional Information

Tested only on Android.
And thank you.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
