### PR TITLE
fix: correct MiniMax H3 audio Euler steps

### DIFF
--- a/src/model/diffusion/minimax_h3.hpp
+++ b/src/model/diffusion/minimax_h3.hpp
@@ -130,6 +130,18 @@ namespace MiniMaxH3 {
         return to_shift * a * a / (from_shift * b * b);
     }
 
+    static float time_shift_step_scale(float sigma,
+                                       float next_sigma,
+                                       float from_shift,
+                                       float to_shift) {
+        if (!std::isfinite(next_sigma) || next_sigma < 0.f || next_sigma == sigma) {
+            return time_shift_slope(sigma, from_shift, to_shift);
+        }
+        float shifted_sigma      = time_shift_sigma(sigma, from_shift, to_shift);
+        float shifted_next_sigma = time_shift_sigma(next_sigma, from_shift, to_shift);
+        return (shifted_sigma - shifted_next_sigma) / (sigma - next_sigma);
+    }
+
     struct TimeEmbedder : public GGMLBlock {
         TimeEmbedder(int64_t input_dim, int64_t hidden_dim, int64_t output_dim) {
             blocks["proj_in"]  = std::make_shared<Linear>(input_dim, hidden_dim, true, true);
@@ -1033,7 +1045,8 @@ namespace MiniMaxH3 {
                                  const std::vector<MiniMaxH3ReferenceBlock>& reference_blocks,
                                  int audio_length,
                                  float video_shift,
-                                 float audio_shift) {
+                                 float audio_shift,
+                                 float next_video_sigma) {
             auto split        = split_av_latents(packed, audio_length);
             video_input_cache = std::move(split.first);
             audio_input_cache = std::move(split.second);
@@ -1130,7 +1143,16 @@ namespace MiniMaxH3 {
                                             layout.sequence_segments,
                                             layout.video_segment,
                                             layout.audio_segment,
-                                            time_shift_slope(sigma_v, video_shift, audio_shift));
+                                            // The generic Euler sampler advances the packed tensor by
+                                            // `next_video_sigma - sigma_v`. For that sampler, scale H3's
+                                            // audio velocity by the exact ratio of the independent audio
+                                            // step. The derivative approximation substantially oversteps
+                                            // at low step counts (the Turbo use case). Retain the local
+                                            // slope for samplers that make extra/intermediate evaluations.
+                                            time_shift_step_scale(sigma_v,
+                                                                  next_video_sigma,
+                                                                  video_shift,
+                                                                  audio_shift));
             auto merged     = merge_av_latents(compute_ctx, output.first, output.second);
             auto graph      = new_graph_custom(H3_GRAPH_SIZE);
             ggml_build_forward_expand(graph, merged);
@@ -1162,7 +1184,8 @@ namespace MiniMaxH3 {
                                    reference_blocks,
                                    extra->audio_length,
                                    extra->video_sigma_shift,
-                                   extra->audio_sigma_shift);
+                                   extra->audio_sigma_shift,
+                                   extra->next_video_sigma);
             };
             return restore_trailing_singleton_dims(GGMLRunner::compute<float>(get_graph,
                                                                               n_threads,

--- a/src/model/diffusion/model.hpp
+++ b/src/model/diffusion/model.hpp
@@ -108,6 +108,8 @@ struct MiniMaxH3DiffusionExtra {
     int audio_length                                              = 0;
     float video_sigma_shift                                       = 12.f;
     float audio_sigma_shift                                       = 3.f;
+    // Negative when the outer sampler is not a single-evaluation Euler step.
+    float next_video_sigma                                        = -1.f;
 };
 
 struct MiniT2IDiffusionExtra {

--- a/src/model/diffusion/model.hpp
+++ b/src/model/diffusion/model.hpp
@@ -109,7 +109,7 @@ struct MiniMaxH3DiffusionExtra {
     float video_sigma_shift                                       = 12.f;
     float audio_sigma_shift                                       = 3.f;
     // Negative when the outer sampler is not a single-evaluation Euler step.
-    float next_video_sigma                                        = -1.f;
+    float next_video_sigma = -1.f;
 };
 
 struct MiniT2IDiffusionExtra {

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -2761,7 +2761,11 @@ public:
                         condition.c_reference_blocks.empty() ? nullptr : &condition.c_reference_blocks,
                         audio_length,
                         std::isfinite(active_flow_shift) ? active_flow_shift : 12.f,
-                        3.f};
+                        3.f,
+                        method == EULER_SAMPLE_METHOD && step > 0 &&
+                                static_cast<size_t>(step) < sigmas.size()
+                            ? sigmas[step]
+                            : -1.f};
                 } else if (sd_version_is_ltxav(version)) {
                     diffusion_params.extra = LTXAVDiffusionExtra{
                         nullptr,


### PR DESCRIPTION
## Summary

Fix MiniMax H3 generated audio degradation with Euler sampling, especially at the low step counts used by the Turbo LoRA.

H3 conditions video and audio on different shifted flow schedules (video shift 12, audio shift 3). The existing implementation converts the audio velocity to the video clock with the local derivative `d sigma_audio / d sigma_video`. That is an infinitesimal conversion, but the Euler sampler advances over finite sigma intervals. Because the mapping between schedules is nonlinear, the derivative approximation over-advances audio at low step counts.

For ordinary Euler evaluations, this PR instead scales audio velocity by the exact finite-step ratio:

```text
(sigma_audio_current - sigma_audio_next)
-----------------------------------------
(sigma_video_current - sigma_video_next)
```

This makes the packed-latent Euler update algebraically equivalent to advancing audio with its own shift-3 sigma interval. Other samplers retain the existing local-slope behavior because they may make intermediate or repeated model evaluations and need a more general dual-clock integration design.

## Impact

The derivative approximation's cumulative audio advance is about:

- 2.17x at 4 intervals
- 1.45x at 8 intervals
- 1.14x at 20 intervals
- 1.09x at 30 intervals

This explains why H3 Turbo audio is affected most strongly while higher-step full-model output can still be degraded.

The issue applies to generated audio in T2VA, FL2VA, and Ref2VA. It is separate from the reference-audio encoder correction in #1886.

## Validation

- Verified numerically at 4, 8, 20, and 30 intervals that every scaled packed-Euler audio delta equals the corresponding independent audio-schedule delta, and that the complete audio schedule integrates from 1 to 0 exactly.
- Clean configure and `sd-cli` build on macOS/Metal against current `master`.
- `sd-cli --help` smoke test.
- Runtime-tested MiniMax H3 Ref2VA with the Turbo LoRA, Euler/simple, 4 steps, and fixed seed. The previous output had severely malformed audio; with exact finite-step scaling, the generated speech/audio was clear and subjectively correct.

## Scope

Only the standard Euler path supplies a next sigma. Unsupported sampler paths continue using the previous derivative conversion, avoiding behavior changes until they can carry independent audio schedule state correctly.
