### PR TITLE
feat: additional `--preview-interval` values

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -36,6 +36,7 @@ struct SDCliParams {
     SDMode mode             = IMG_GEN;
     std::string output_path = "output.png";
     int output_begin_idx    = -1;
+    int compression_quality = 90;
     std::string image_path;
     std::string metadata_format = "text";
 
@@ -99,6 +100,10 @@ struct SDCliParams {
              "--output-begin-idx",
              "starting index for output image sequence, must be non-negative (default 0 if specified %d in output path, 1 otherwise)",
              &output_begin_idx},
+            {"",
+             "--compression-quality",
+             "compression quality of video and JPEG / WebP images (90 by default)",
+             &compression_quality},
         };
 
         options.bool_options = {
@@ -383,11 +388,13 @@ void step_callback(int step, int frame_count, sd_image_t* image, bool is_noisy, 
                                  image->data,
                                  image->width,
                                  image->height,
-                                 image->channel)) {
+                                 image->channel,
+                                 "",
+                                 cli_params->compression_quality)) {
             LOG_ERROR("save preview image to '%s' failed", cli_params->preview_path.c_str());
         }
     } else {
-        if (create_video_from_sd_images(cli_params->preview_path.c_str(), image, frame_count, cli_params->preview_fps) != 0) {
+        if (create_video_from_sd_images(cli_params->preview_path.c_str(), image, frame_count, cli_params->preview_fps, cli_params->compression_quality) != 0) {
             LOG_ERROR("save preview video to '%s' failed", cli_params->preview_path.c_str());
         }
     }
@@ -486,7 +493,7 @@ bool save_results(const SDCliParams& cli_params,
         std::string params          = gen_params.embed_image_metadata
                                           ? get_image_params(ctx_params, gen_params, metadata_seed, cli_params.mode)
                                           : "";
-        const bool ok               = write_image_to_file(path.string(), img.data, img.width, img.height, img.channel, params, 90);
+        const bool ok               = write_image_to_file(path.string(), img.data, img.width, img.height, img.channel, params, cli_params.compression_quality);
         LOG_INFO("save result image %d to '%s' (%s)", idx, path.string().c_str(), ok ? "success" : "failure");
         return ok;
     };
@@ -532,7 +539,7 @@ bool save_results(const SDCliParams& cli_params,
         std::string final_ext_lower = ext.string();
         std::transform(final_ext_lower.begin(), final_ext_lower.end(), final_ext_lower.begin(), ::tolower);
         const bool mux_audio = generated_audio != nullptr && (final_ext_lower == ".avi" || final_ext_lower == ".webm");
-        if (create_video_from_sd_images(video_path.string().c_str(), results, num_results, gen_params.fps, 90, mux_audio ? generated_audio : nullptr) == 0) {
+        if (create_video_from_sd_images(video_path.string().c_str(), results, num_results, gen_params.fps, cli_params.compression_quality, mux_audio ? generated_audio : nullptr) == 0) {
             LOG_INFO("save result video to '%s'", video_path.string().c_str());
             if (generated_audio != nullptr && !mux_audio) {
                 fs::path wav_path = video_path;

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -94,7 +94,7 @@ struct SDCliParams {
         options.int_options = {
             {"",
              "--preview-interval",
-             "interval in denoising steps between consecutive updates of the image preview file (default is 1, meaning updating at every step)",
+             "interval in denoising steps between consecutive updates of the image preview file (default is 1, meaning updating at every step). Set to -N to preview only the Nth single step. Set to 0 to preview the last step of 1st pass (base resolution / high noise) sampling",
              &preview_interval},
             {"",
              "--output-begin-idx",

--- a/examples/common/media_io.cpp
+++ b/examples/common/media_io.cpp
@@ -835,6 +835,9 @@ std::vector<uint8_t> create_mjpg_avi_from_sd_images_to_vector(sd_image_t* images
     const uint32_t audio_byte_rate       = has_audio ? static_cast<uint32_t>(audio->sample_rate * audio_block_align) : 0;
     const uint32_t audio_data_size       = has_audio ? static_cast<uint32_t>(audio_pcm.size()) : 0;
 
+    if (mjpg_quality != quality)
+        LOG_DEBUG("create_mjpg_avi...(): compression quality was limited from %i to %i", quality, mjpg_quality);
+
     std::vector<uint8_t> avi_data;
     avi_data.reserve(static_cast<size_t>(num_images) * 1024);
 

--- a/src/model/te/llm.hpp
+++ b/src/model/te/llm.hpp
@@ -269,9 +269,13 @@ namespace LLM {
             if ((arch == LLMArch::QWEN3 || arch == LLMArch::QWEN3_VL) && config.num_layers == 28) {
                 config.num_heads = 16;
             }
-            if (arch == LLMArch::QWEN3_VL && config.num_layers == 50 && config.hidden_size == 5120) {
-                config.num_heads  = 64;
-                config.final_norm = false;
+            if (arch == LLMArch::QWEN3_VL &&
+                (config.num_layers == 50 || config.num_layers == 64) &&
+                config.hidden_size == 5120) {
+                config.num_heads = 64;
+                if (config.num_layers == 50) {
+                    config.final_norm = false;
+                }
             }
             if (detected_vision_layers > 0) {
                 config.vision.num_layers = detected_vision_layers;

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -2670,7 +2670,9 @@ public:
                     denoised = denoised * denoise_mask + init_latent * (1.0f - denoise_mask);
                 }
                 if (sd_should_preview_denoised() && preview.callback != nullptr) {
-                    preview_image(step, denoised, version, preview.mode, preview.callback, preview.data, false);
+                    if (step % sd_get_preview_interval() == 0) {
+                        preview_image(step, denoised, version, preview.mode, preview.callback, preview.data, false);
+                    }
                 }
                 report_sample_progress(step, steps, &last_progress_us);
                 sd::guidance::GuiderOutput output;
@@ -2679,7 +2681,9 @@ public:
             }
 
             if (sd_should_preview_noisy() && preview.callback != nullptr) {
-                preview_image(step, noised_input, version, preview.mode, preview.callback, preview.data, true);
+                if (step % sd_get_preview_interval() == 0) {
+                    preview_image(step, noised_input, version, preview.mode, preview.callback, preview.data, true);
+                }
             }
 
             sd::Tensor<float> cond_out;
@@ -2889,7 +2893,9 @@ public:
                 denoised = denoised * denoise_mask + init_latent * (1.0f - denoise_mask);
             }
             if (sd_should_preview_denoised() && preview.callback != nullptr) {
-                preview_image(step, denoised, version, preview.mode, preview.callback, preview.data, false);
+                if (step % sd_get_preview_interval() == 0) {
+                    preview_image(step, denoised, version, preview.mode, preview.callback, preview.data, false);
+                }
             }
             report_sample_progress(step, steps, &last_progress_us);
             output.pred = denoised;

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -259,6 +259,8 @@ public:
     bool is_using_v_parameterization     = false;
     bool is_using_edm_v_parameterization = false;
 
+    bool preview_last_step = false;
+
     size_t control_net_params_mem_size = 0;
 
     std::shared_ptr<ModelManager> model_manager;
@@ -2639,6 +2641,18 @@ public:
             float c_out  = scaling[1];
             float c_in   = scaling[2];
 
+            bool preview_needed = preview.callback != nullptr;
+            if (preview_needed) {
+                int preview_interval = sd_get_preview_interval();
+                if (preview_interval > 0) {         // every Nth step
+                    preview_needed = step % preview_interval == 0;
+                } else if (preview_interval < 0) {  // only (-N)th step
+                    preview_needed = step == -preview_interval;
+                } else {                            // last step of base resolution / high noise pass
+                    preview_needed = preview_last_step && step == steps;
+                }
+            }
+
             std::vector<float> base_timesteps_vec = prepare_sample_timesteps(sigma, shifted_timestep);
             std::vector<float> timesteps_vec      = base_timesteps_vec;
             sd::Tensor<float> audio_timesteps_tensor;
@@ -2669,10 +2683,8 @@ public:
                 if (!denoise_mask.empty()) {
                     denoised = denoised * denoise_mask + init_latent * (1.0f - denoise_mask);
                 }
-                if (sd_should_preview_denoised() && preview.callback != nullptr) {
-                    if (step % sd_get_preview_interval() == 0) {
-                        preview_image(step, denoised, version, preview.mode, preview.callback, preview.data, false);
-                    }
+                if (preview_needed && sd_should_preview_denoised()) {
+                    preview_image(step, denoised, version, preview.mode, preview.callback, preview.data, false);
                 }
                 report_sample_progress(step, steps, &last_progress_us);
                 sd::guidance::GuiderOutput output;
@@ -2680,10 +2692,8 @@ public:
                 return output;
             }
 
-            if (sd_should_preview_noisy() && preview.callback != nullptr) {
-                if (step % sd_get_preview_interval() == 0) {
-                    preview_image(step, noised_input, version, preview.mode, preview.callback, preview.data, true);
-                }
+            if (preview_needed && sd_should_preview_noisy()) {
+                preview_image(step, noised_input, version, preview.mode, preview.callback, preview.data, true);
             }
 
             sd::Tensor<float> cond_out;
@@ -2892,10 +2902,8 @@ public:
             if (!denoise_mask.empty()) {
                 denoised = denoised * denoise_mask + init_latent * (1.0f - denoise_mask);
             }
-            if (sd_should_preview_denoised() && preview.callback != nullptr) {
-                if (step % sd_get_preview_interval() == 0) {
-                    preview_image(step, denoised, version, preview.mode, preview.callback, preview.data, false);
-                }
+            if (preview_needed && sd_should_preview_denoised()) {
+                preview_image(step, denoised, version, preview.mode, preview.callback, preview.data, false);
             }
             report_sample_progress(step, steps, &last_progress_us);
             output.pred = denoised;
@@ -5666,6 +5674,7 @@ SD_API bool generate_image(sd_ctx_t* sd_ctx,
     ImageGenerationEmbeds embeds = std::move(*embeds_opt);
 
     std::vector<sd::Tensor<float>> final_latents;
+    sd_ctx->sd->preview_last_step = true;
     int64_t denoise_start = ggml_time_ms();
     for (int b = 0; b < request.batch_count; b++) {
         sd_cancel_mode_t cancel = sd_ctx->sd->get_cancel_flag();
@@ -5726,6 +5735,7 @@ SD_API bool generate_image(sd_ctx_t* sd_ctx,
         return false;
     }
     int64_t denoise_end = ggml_time_ms();
+    sd_ctx->sd->preview_last_step = false;
     LOG_INFO("generating %zu latent images completed, taking %.2fs",
              final_latents.size(),
              (denoise_end - denoise_start) * 1.0f / 1000);
@@ -6938,6 +6948,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
         }
         LOG_DEBUG("sample(high noise) %dx%dx%d", W, H, T);
 
+        sd_ctx->sd->preview_last_step = true;
         int64_t sampling_start = ggml_time_ms();
         std::vector<float> high_noise_sigmas(plan.sigmas.begin(), plan.sigmas.begin() + plan.high_noise_sample_steps + 1);
         plan.sigmas = std::vector<float>(plan.sigmas.begin() + plan.high_noise_sample_steps, plan.sigmas.end());
@@ -6968,6 +6979,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
                                                            request.cache_params,
                                                            latents.video_positions);
         int64_t sampling_end          = ggml_time_ms();
+        sd_ctx->sd->preview_last_step = false;
         if (x_t_sampled.empty()) {
             LOG_ERROR("sampling(high noise) failed after %.2fs", (sampling_end - sampling_start) * 1.0f / 1000);
             return false;

--- a/src/stable-diffusion.cpp
+++ b/src/stable-diffusion.cpp
@@ -2644,11 +2644,11 @@ public:
             bool preview_needed = preview.callback != nullptr;
             if (preview_needed) {
                 int preview_interval = sd_get_preview_interval();
-                if (preview_interval > 0) {         // every Nth step
+                if (preview_interval > 0) {  // every Nth step
                     preview_needed = step % preview_interval == 0;
                 } else if (preview_interval < 0) {  // only (-N)th step
                     preview_needed = step == -preview_interval;
-                } else {                            // last step of base resolution / high noise pass
+                } else {  // last step of base resolution / high noise pass
                     preview_needed = preview_last_step && step == steps;
                 }
             }
@@ -5675,7 +5675,7 @@ SD_API bool generate_image(sd_ctx_t* sd_ctx,
 
     std::vector<sd::Tensor<float>> final_latents;
     sd_ctx->sd->preview_last_step = true;
-    int64_t denoise_start = ggml_time_ms();
+    int64_t denoise_start         = ggml_time_ms();
     for (int b = 0; b < request.batch_count; b++) {
         sd_cancel_mode_t cancel = sd_ctx->sd->get_cancel_flag();
         if (cancel == SD_CANCEL_ALL) {
@@ -5734,7 +5734,7 @@ SD_API bool generate_image(sd_ctx_t* sd_ctx,
                   (sampling_end - sampling_start) * 1.0f / 1000);
         return false;
     }
-    int64_t denoise_end = ggml_time_ms();
+    int64_t denoise_end           = ggml_time_ms();
     sd_ctx->sd->preview_last_step = false;
     LOG_INFO("generating %zu latent images completed, taking %.2fs",
              final_latents.size(),
@@ -6949,7 +6949,7 @@ SD_API bool generate_video(sd_ctx_t* sd_ctx,
         LOG_DEBUG("sample(high noise) %dx%dx%d", W, H, T);
 
         sd_ctx->sd->preview_last_step = true;
-        int64_t sampling_start = ggml_time_ms();
+        int64_t sampling_start        = ggml_time_ms();
         std::vector<float> high_noise_sigmas(plan.sigmas.begin(), plan.sigmas.begin() + plan.high_noise_sample_steps + 1);
         plan.sigmas = std::vector<float>(plan.sigmas.begin() + plan.high_noise_sample_steps, plan.sigmas.end());
 


### PR DESCRIPTION
## Summary

Additional values for `--preview-interval` option of `sd-cli`:
- value `0` should preview only the last step of base-resolution sampling.
Can be used in `--hires` generations to save (in `--preview-path`) the base-resolution result together with the high-resolution final image, skipping simultaneous high-resolution sampling + decoding.
With https://github.com/leejet/stable-diffusion.cpp/pull/1895, can save all base-resolution results of batch generations.
- values `less than 0` should decode only the `-N`th single image (to preview a sample and not to slow the generation down).

## Additional Information

For example, `--steps 20 --hires --preview-interval 20` and `--steps 20 --hires --preview-interval 0` make identical "base + high" images, but with less memory.
Peak memory usage (SD 1.5, 256×512 -> 448×896, CPU):
<table>
<tr><td>--preview</td><td>--preview-interval 0</td><td>--preview-interval 20</td></tr>
<tr><td>tae</td><td>3.03 Gb</td><td>3.72 Gb</td></tr>
<tr><td>vae</td><td>3.12 Gb</td><td>4.33 Gb</td></tr>
</table>


Also, I have enabled "last step" preview for "high noise" video pass, but I didn't test any video generations and not sure if this is much useful.

The `sd-server` should be unaffected because it doesn't set the preview interval and uses default "every step" value.

## Checklist

- [x] I have read and confirmed this PR follows the [contribution guidelines](https://github.com/leejet/stable-diffusion.cpp/blob/master/CONTRIBUTING.md).
